### PR TITLE
MQTT Bucket Notification Target

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ git+https://github.com/ravindk89/sphinx-tabs
 recommonmark == 0.6.0
 sphinx-markdown-tables == 0.0.15
 Sphinx-Substitution-Extensions == 2020.9.30.0
+sphinx-togglebutton === 0.2.3

--- a/source/conf.py
+++ b/source/conf.py
@@ -43,7 +43,8 @@ extensions = [
     'recommonmark',
     'sphinx_markdown_tables',
     'sphinx-prompt',
-    'sphinx_substitution_extensions'
+    'sphinx_substitution_extensions',
+    'sphinx_togglebutton'
 ]
 
 # -- External Links
@@ -57,7 +58,7 @@ extlinks = {
     'github'    : ('https://github.com/%s',''),
     'kube-api'  : ('https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/%s',''),
     'aws-docs'  : ('https://docs.aws.amazon.com/%s',''),
-    's3-docs'   : ('https://docs.aws.amazon.com/AmazonS3/latest/dev/%s',''),
+    's3-docs'   : ('https://docs.aws.amazon.com/AmazonS3/latest/userguide/%s',''),
     's3-api'    : ('https://docs.aws.amazon.com/AmazonS3/latest/API/%s',''),
     'iam-docs'  : ('https://docs.aws.amazon.com/IAM/latest/UserGuide/%s',''),
     'release'   : ('https://github.com/minio/mc/releases/tag/%s',''),

--- a/source/includes/common-admonitions.rst
+++ b/source/includes/common-admonitions.rst
@@ -1,0 +1,18 @@
+.. Used in the following pages:
+   - /monitoring/bucket-notifications/publish-events-to-amqp.rst
+
+.. start-restart-downtime
+
+.. important::
+
+   This procedure *requires* restarting all :mc:`minio server` processes
+   associated to the deployment at the same time. There is typically a brief
+   period of time during which API operations are interrupted or may fail.
+
+   Applications using an S3-compatible SDK with built-in retry logic *or* which
+   implement manual retry logic typically experience no notable interruption in
+   services. For applications which cannot use retry-logic, consider scheduling
+   a maintenance period to minimize interruption of services while performing
+   this procedure.
+
+.. end-restart-downtime

--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -1,0 +1,109 @@
+.. Descriptions for AMQP bucket notification configurations.
+   Used in the following files:
+   - /source/reference/minio-server/minio-server.rst
+   - /source/concepts/bucket-notifications.rst
+
+.. start-minio-notify-amqp-enable
+
+Specify ``on`` to enable publishing bucket notifications to an AMQP endpoint.
+
+Defaults to ``off``.
+
+.. end-minio-notify-amqp-enable
+
+
+.. start-minio-notify-amqp-url
+
+Specify the AMQP server endpoint to which MinIO publishes bucket events.
+For example, ``amqp://myuser:mypassword@localhost:5672``.
+
+.. end-minio-notify-amqp-url
+
+
+.. start-minio-notify-amqp-exchange
+
+Specify the name of the AMQP exchange to use.
+
+.. end-minio-notify-amqp-exchange
+
+
+.. start-minio-notify-amqp-exchange-type
+
+Specify the type of the AMQP exchange.
+
+.. end-minio-notify-amqp-exchange-type
+
+
+.. start-minio-notify-amqp-routing-key
+
+Specify the routing key for publishing events.
+
+.. end-minio-notify-amqp-routing-key
+
+
+.. start-minio-notify-amqp-mandatory
+
+Specify ``off`` to ignore undelivered messages errors. Defaults to ``on``.
+
+.. end-minio-notify-amqp-mandatory
+
+
+.. start-minio-notify-amqp-durable
+
+Specify ``on`` to persist the message queue across broker restarts. Defaults to
+'off'.
+
+.. end-minio-notify-amqp-durable
+
+
+.. start-minio-notify-amqp-no-wait
+
+Specify ``on`` to enable non-blocking message delivery. Defaults to 'off'.
+
+.. end-minio-notify-amqp-no-wait
+
+
+.. start-minio-notify-amqp-internal
+
+Specify ``on`` to use the exchange only if it is bound to other exchanges.
+
+.. end-minio-notify-amqp-internal
+
+
+.. start-minio-notify-amqp-auto-deleted
+
+Specify ``on`` to automatically delete the message queue if there are no
+consumers. Defaults to ``off``.
+
+.. end-minio-notify-amqp-auto-deleted
+
+
+.. start-minio-notify-amqp-delivery-mode
+
+Specify ``1`` for set the delivery mode to non-persistent queue.
+
+Specify ``2`` to set the delivery mode to persistent queue.
+
+.. end-minio-notify-amqp-delivery-mode
+
+
+.. start-minio-notify-amqp-queue-dir
+
+Specify the directory path to use for undelivered messages, 
+such as ``/home/events``.
+
+.. end-minio-notify-amqp-queue-dir
+
+
+.. start-minio-notify-amqp-queue-limit
+
+Specify the maximum limit for undelivered messages. Defaults to ``10000``.
+
+.. end-minio-notify-amqp-queue-limit
+
+
+.. start-minio-notify-amqp-comment
+
+Specify a comment for the AMQP setting.
+
+.. end-minio-notify-amqp-comment

--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -89,8 +89,11 @@ Specify ``2`` to set the delivery mode to persistent queue.
 
 .. start-minio-notify-amqp-queue-dir
 
-Specify the directory path to use for undelivered messages, 
-such as ``/home/events``.
+Specify the directory path to enable MinIO's persistent event store for
+undelivered messages, such as ``/home/events``.
+
+MinIO stores undelivered events in the specified store while the AMQP
+service is offline and replays the directory when connectivity resumes.
 
 .. end-minio-notify-amqp-queue-dir
 
@@ -104,6 +107,116 @@ Specify the maximum limit for undelivered messages. Defaults to ``10000``.
 
 .. start-minio-notify-amqp-comment
 
-Specify a comment for the AMQP setting.
+Specify a comment for the AMQP configuration.
 
 .. end-minio-notify-amqp-comment
+
+.. Descriptions for MQTT bucket notification configurations.
+   Used in the following files:
+   - /source/reference/minio-server/minio-server.rst
+   - /source/concepts/bucket-notifications.rst
+
+.. start-minio-notify-mqtt-enable
+
+Specify ``on`` to enable publishing bucket notifications to an MQTT endpoint.
+
+Defaults to ``off``.
+
+.. end-minio-notify-mqtt-enable
+
+
+.. start-minio-notify-mqtt-broker
+
+Specify the MQTT server/broker endpoint. MinIO supports TCP, TLS, or Websocket
+connections to the server/broker URL. For example:
+
+- ``tcp://mqtt.example.net:1883``
+- ``tls://mqtt.example.net:1883``
+- ``ws://mqtt.example.net:1883``
+
+.. end-minio-notify-mqtt-broker
+
+
+.. start-minio-notify-mqtt-topic
+
+Specify the name of the MQTT topic to associate with events published by 
+MinIO to the MQTT endpoint.
+
+.. end-minio-notify-mqtt-topic
+
+
+.. start-minio-notify-mqtt-username
+
+Specify the MQTT username with which MinIO authenticates to the MQTT
+server/broker.
+
+.. end-minio-notify-mqtt-username
+
+
+.. start-minio-notify-mqtt-password
+
+Specify the password for the MQTT username with which MinIO authenticates to the
+MQTT server/broker.
+
+.. end-minio-notify-mqtt-password
+
+
+.. start-minio-notify-mqtt-qos
+
+Specify the Quality of Service priority for the published events. 
+
+Defaults to ``0``.
+
+.. end-minio-notify-mqtt-qos
+
+
+.. start-minio-notify-mqtt-keep-alive-interval
+
+Specify the keep-alive interval for the MQTT connections. MinIO 
+supports the following units of time measurement:
+
+- ``s`` - seconds, "60s"
+- ``m`` - minutes, "60m"
+- ``h`` - hours, "24h"
+- ``d`` - days, "7d"
+
+.. end-minio-notify-mqtt-keep-alive-interval
+
+
+.. start-minio-notify-mqtt-reconnect-interval
+
+Specify the reconnect interval for the MQTT connections. MinIO 
+supports the following units of time measurement:
+
+- ``s`` - seconds, "60s"
+- ``m`` - minutes, "60m"
+- ``h`` - hours, "24h"
+- ``d`` - days, "7d"
+
+.. end-minio-notify-mqtt-reconnect-interval
+
+
+.. start-minio-notify-mqtt-queue-dir
+
+Specify the directory path to enable MinIO's persistent event store for
+undelivered messages, such as ``/home/events``.
+
+MinIO stores undelivered events in the specified store while the MQTT 
+server/broker is offline and replays the directory when connectivity resumes.
+
+.. end-minio-notify-mqtt-queue-dir
+
+
+.. start-minio-notify-mqtt-queue-limit
+
+Specify the maximum limit for undelivered messages. Defaults to ``10000``.
+
+.. end-minio-notify-mqtt-queue-limit
+
+
+.. start-minio-notify-mqtt-comment
+
+Specify a comment to associate to the MQTT configuration.
+
+.. end-minio-notify-mqtt-comment
+

--- a/source/index.rst
+++ b/source/index.rst
@@ -22,6 +22,8 @@ Users deploying onto a Kubernetes cluster should start with our
    /concepts/feature-overview
    /tutorials/minio-installation
    /security/security-overview
+   /monitoring/monitoring-overview
    /reference/minio-cli/minio-mc
    /reference/minio-cli/minio-mc-admin
    /reference/minio-server/minio-server
+   /reference/minio-server/minio-gateway

--- a/source/monitoring/bucket-notifications/bucket-notifications.rst
+++ b/source/monitoring/bucket-notifications/bucket-notifications.rst
@@ -1,0 +1,104 @@
+.. _minio-bucket-notifications:
+
+====================
+Bucket Notifications
+====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+MinIO bucket notifications allow administrators to send notifications to 
+supported external services on certain object or bucket events. MinIO 
+supports bucket and object-level S3 events similar to the 
+:s3-docs:`Amazon S3 Event Notifications <NotificationHowTo.html>`.
+
+MinIO bucket notifications are available *only* with 
+:mc:`minio server` deployments. MinIO :ref:`Gateway <minio-gateway>`
+does *not* support bucket notifications.
+
+Supported Notification Targets
+------------------------------
+
+MinIO supports publishing event notifications to the following targets:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Target
+     - Description
+
+   * - :guilabel:`AMQP`
+     - Publish notifications to an AMQP service such as 
+       `RabbitMQ <https://www.rabbitmq.com>`__.
+
+       See :ref:`minio-bucket-notifications-publish-amqp` for a tutorial.
+
+Supported S3 Event Types
+------------------------
+
+MinIO bucket notifications are compatible with 
+:s3-docs:`Amazon S3 Event Notifications <NotificationHowTo.html>`. This 
+section lists all supported events.
+
+Object Events
+~~~~~~~~~~~~~
+
+MinIO supports triggering notifications on the following S3 object events:
+
+.. data:: s3:ObjectRemoved:DeleteMarkerCreated
+.. data:: s3:ObjectRemoved:Delete
+.. data:: s3:ObjectCreated:PutRetention
+.. data:: s3:ObjectCreated:PutLegalHold
+.. data:: s3:ObjectCreated:Put
+.. data:: s3:ObjectCreated:Post
+.. data:: s3:ObjectCreated:Copy
+.. data:: s3:ObjectCreated:CompleteMultipartUpload
+.. data:: s3:ObjectAccessed:Head
+.. data:: s3:ObjectAccessed:GetRetention
+.. data:: s3:ObjectAccessed:GetLegalHold
+.. data:: s3:ObjectAccessed:Get
+
+Replication Events
+~~~~~~~~~~~~~~~~~~
+
+MinIO supports triggering notifications on the following S3 replication 
+events:
+
+.. data:: s3:Replication:OperationCompletedReplication
+.. data:: s3:Replication:OperationFailedReplication
+.. data:: s3:Replication:OperationMissedThreshold
+.. data:: s3:Replication:OperationNotTracked
+.. data:: s3:Replication:OperationReplicatedAfterThreshold
+
+ILM Transition Events
+~~~~~~~~~~~~~~~~~~~~~
+
+MinIO supports triggering notifications on the following S3 ILM transition
+events:
+
+.. data:: s3:ObjectRestore:Post
+.. data:: s3:ObjectRestore:Completed
+
+Global Events
+~~~~~~~~~~~~~
+
+MinIO supports triggering notifications on the following global events. 
+You can only listen to these events through the :legacy:`ListenNotification 
+<golang-client-api-reference.html#ListenNotification>` API:
+
+.. data:: s3:BucketCreated
+.. data:: s3:BucketRemoved
+
+
+.. todo
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   /monitoring/bucket-notifications/publish-events-to-amqp

--- a/source/monitoring/bucket-notifications/bucket-notifications.rst
+++ b/source/monitoring/bucket-notifications/bucket-notifications.rst
@@ -38,6 +38,12 @@ MinIO supports publishing event notifications to the following targets:
 
        See :ref:`minio-bucket-notifications-publish-amqp` for a tutorial.
 
+   * - :guilabel:`MQTT`
+     - Publish notifications to an `MQTT <https://www.mqtt.org/>`__  
+       server/broker endpoint.
+
+       See :ref:`minio-bucket-notifications-publish-mqtt` for a tutorial.
+
 Supported S3 Event Types
 ------------------------
 
@@ -102,3 +108,4 @@ You can only listen to these events through the :legacy:`ListenNotification
    :hidden:
 
    /monitoring/bucket-notifications/publish-events-to-amqp
+   /monitoring/bucket-notifications/publish-events-to-mqtt

--- a/source/monitoring/bucket-notifications/publish-events-to-amqp.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-amqp.rst
@@ -1,0 +1,381 @@
+.. _minio-bucket-notifications-publish-amqp:
+
+======================
+Publish Events to AMQP
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+MinIO supports publishing :ref:`bucket notification
+<minio-bucket-notifications>` events to `AMQP 0-9-1 <https://www.amqp.org/>`__ 
+services such as `RabbitMQ <https://www.rabbitmq.com>`__. 
+
+MinIO relies on the :github:`streadway/amqp` project for AMQP connectivity. The
+project is primarily tested against `RabbitMQ <https://www.rabbitmq.com/>`__
+deployments, though other `AMQP 0-9-1-compatible <https://www.amqp.org/>`__
+services *may* also work. The procedures on this page *assumes* a RabbitMQ
+deployment as the service endpoint.
+
+Add an AMQP Endpoint to a MinIO Deployment
+------------------------------------------
+
+The following procedure adds a new AMQP service endpoint for supporting
+:ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
+deployment.
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-restart-downtime
+   :end-before: end-restart-downtime
+
+Prerequisites
+~~~~~~~~~~~~~~
+
+AMQP 0-9-1 Service Endpoint
++++++++++++++++++++++++++++
+
+MinIO relies on the :github:`streadway/amqp` project for AMQP connectivity. The
+project is primarily tested against `RabbitMQ <https://www.rabbitmq.com/>`__
+deployments, though other `AMQP 0-9-1-compatible <https://www.amqp.org/>`__
+services *may* also work. This procedure *assumes* a RabbitMQ deployment 
+as the service endpoint.
+
+If the AMQP service requires authentication, you *must* provide an appropriate
+username and password during the configuration process to grant MinIO access
+to the service.
+
+MinIO ``mc`` Command Line Tool
+++++++++++++++++++++++++++++++
+
+This procedure uses the :mc:`mc` command line tool for certain actions. 
+See the ``mc`` :ref:`Quickstart <mc-install>` for installation instructions.
+
+1) Add the AMQP Endpoint to MinIO
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can configure a new AMQP service endpoint using either environment variables
+*or* by setting runtime configuration settings.
+
+.. tabs::
+
+   .. tab:: Environment Variables
+
+      MinIO supports specifying the AMQP service endpoint and associated
+      configuration settings using 
+      :ref:`environment variables 
+      <minio-server-envvar-bucket-notification-amqp>`. The 
+      :mc:`minio server` process applies the specified settings on its 
+      next startup.
+      
+      The following example code sets *all*  environment variables
+      related to configuring an AMQP service endpoint. The minimum
+      *required* variables are
+      :envvar:`MINIO_NOTIFY_AMQP_ENABLE` and :envvar:`MINIO_NOTIFY_AMQP_URL`:
+
+
+      .. code-block:: shell
+         :class: copyable
+
+         set MINIO_NOTIFY_AMQP_ENABLE_<IDENTIFIER>="on"
+         set MINIO_NOTIFY_AMQP_URL_<IDENTIFIER>="<ENDPOINT>"
+         set MINIO_NOTIFY_AMQP_EXCHANGE_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_EXCHANGE_TYPE_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_ROUTING_KEY_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_MANDATORY_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_DURABLE_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_NO_WAIT_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_INTERNAL_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_AUTO_DELETED_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_DELIVERY_MODE_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_QUEUE_DIR_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_AMQP_COMMENT_<IDENTIFIER>="<string>"
+
+      - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
+        AMQP service endpoint. Use the same ``<IDENTIFIER>`` value for all 
+        environment variables related to the new AMQP service endpoint.
+        The following examples assume an identifier of ``PRIMARY``.
+
+        If the specified ``<IDENTIFIER>`` matches an existing AMQP service
+        endpoint on the MinIO deployment, the new settings *override* 
+        any existing settings for that endpoint. Use 
+        :mc-cmd:`mc admin config get notify_amqp <mc admin config get>` to
+        review the currently configured AMQP endpoints on the MinIO deployment.
+
+      - Replace ``<ENDPOINT>`` with the URL of the AMQP service endpoint.
+        For example:
+
+        ``amqp://user:password@hostname:port``
+
+      See :ref:`AMQP Service for Bucket Notifications
+      <minio-server-envvar-bucket-notification-amqp>` for complete documentation
+      on each environment variable.
+
+   .. tab:: Configuration Settings
+
+      MinIO supports adding or updating AMQP endpoints on a running 
+      :mc:`minio server` process using the :mc-cmd:`mc admin config set` command 
+      and the :mc-conf:`notify_amqp` configuration key. You must restart the 
+      :mc:`minio server` process to apply any new or updated configuration
+      settings.
+
+      The following example code sets *all*  settings related to configuring an
+      AMQP service endpoint. The minimum *required* setting is 
+      :mc-conf:`notify_amqp url <notify_amqp.url>`:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin config set ALIAS/ notify_amqp:IDENTIFIER \
+           url="ENDPOINT" \
+           exchange="<string>" \
+           exchange_type="<string>" \
+           routing_key="<string>" \
+           mandatory="<string>" \
+           durable="<string>" \
+           no_wait="<string>" \
+           internal="<string>" \
+           auto_deleted="<string>" \
+           delivery_mode="<string>" \
+           queue_dir="<string>" \
+           queue_limit="<string>" \
+           comment="<string>"
+
+      - Replace ``IDENTIFIER`` with a unique descriptive string for the
+        AMQP service endpoint. The following examples in this procedure
+        assume an identifier of ``PRIMARY``.
+
+        If the specified ``IDENTIFIER`` matches an existing AMQP service
+        endpoint on the MinIO deployment, the new settings *override* 
+        any existing settings for that endpoint. Use 
+        :mc-cmd:`mc admin config get notify_amqp <mc admin config get>` to
+        review the currently configured AMQP endpoints on the MinIO deployment.
+
+      - Replace ``ENDPOINT`` with the URL of the AMQP service endpoint.
+        For example:
+
+        ``amqp://user:password@hostname:port``
+
+      See :ref:`AMQP Bucket Notification Configuration Settings
+      <minio-server-config-bucket-notification-amqp>` for complete 
+      documentation on each setting.
+
+2) Restart the MinIO Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You must restart the MinIO deployment to apply the configuration changes. 
+Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
+
+.. important::
+
+   MinIO restarts *all* :mc:`minio server` processes associated to the 
+   deployment at the same time. Applications may experience a brief period of 
+   downtime during the restart process. 
+
+   Consider scheduling the restart during a maintenance period to minimize
+   interruption of services.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin service restart ALIAS
+
+Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+restart.
+
+The :mc:`minio server` process prints a line on startup for each configured AMQP
+target similar to the following:
+
+.. code-block:: shell
+
+   SQS ARNs: arn:minio:sqs::primary:amqp
+
+You must specify the ARN resource when configuring bucket notifications with
+the associated AMQP deployment as a target.
+
+3) Configure Bucket Notifications using the AMQP Endpoint as a Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc-cmd:`mc event add` command to add a new bucket notification 
+event with the configured AMQP service as a target:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc event add ALIAS/BUCKET arn:minio:sqs::primary:amqp \
+     --event EVENTS
+
+- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``BUCKET`` with the name of the bucket in which to configure the 
+  event.
+- Replace ``EVENTS`` with a comma-separated list of :ref:`events 
+  <mc-event-supported-events>` for which MinIO triggers notifications.
+
+Use :mc-cmd:`mc event list` to view all configured bucket events for 
+a given notification target:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc event list ALIAS/BUCKET arn:minio:sqs::primary:amqp
+
+4) Validate the Configured Events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Perform an action on the bucket for which you configured the new event and 
+check the AMQP service for the notification data. The action required
+depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+when configuring the bucket notification.
+
+For example, if the bucket notification configuration includes the 
+``s3:ObjectCreated:Put`` event, you can use the 
+:mc-cmd:`mc cp` command to create a new object in the bucket and trigger 
+a notification.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc cp ~/data/new-object.txt ALIAS/BUCKET
+
+Update an AMQP Endpoint in a MinIO Deployment
+---------------------------------------------
+
+The following procedure updates an existing AMQP service endpoint for supporting
+:ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
+deployment.
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-restart-downtime
+   :end-before: end-restart-downtime
+
+Prerequisites
+~~~~~~~~~~~~~~
+
+AMQP 0-9-1 Service Endpoint
++++++++++++++++++++++++++++
+
+MinIO relies on the :github:`streadway/amqp` project for AMQP connectivity. The
+project is primarily tested against `RabbitMQ <https://www.rabbitmq.com/>`__
+deployments, though other `AMQP 0-9-1-compatible <https://www.amqp.org/>`__
+services *may* also work. This procedure *assumes* a RabbitMQ deployment 
+as the service endpoint.
+
+If the AMQP service requires authentication, you *must* provide an appropriate
+username and password during the configuration process to grant MinIO access
+to the service.
+
+MinIO ``mc`` Command Line Tool
+++++++++++++++++++++++++++++++
+
+This procedure uses the :mc:`mc` command line tool for certain actions. 
+See the ``mc`` :ref:`Quickstart <mc-install>` for installation instructions.
+
+
+1) List Configured AMQP Endpoints In The Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc-cmd:`mc admin config get` command to list the currently
+configured AMQP service endpoints in the deployment:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin config get ALIAS/ notify_amqp
+
+Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+
+The command output resembles the following:
+
+.. code-block:: shell
+
+   notify_amqp:primary delivery_mode="0" exchange_type="" no_wait="off" queue_dir="" queue_limit="0"  url="amqp://user:password@hostname:port" auto_deleted="off" durable="off" exchange="" internal="off" mandatory="off" routing_key=""
+   notify_amqp:secondary delivery_mode="0" exchange_type="" no_wait="off" queue_dir="" queue_limit="0"  url="amqp://user:password@hostname:port" auto_deleted="off" durable="off" exchange="" internal="off" mandatory="off" routing_key=""
+
+The :mc-conf:`notify_amqp` key is the top-level configuration key for an
+:ref:`minio-server-config-bucket-notification-amqp`. The 
+:mc-conf:`url <notify_amqp.url>` key specifies the AMQP service endpoint 
+for the given `notify_amqp` key. The ``notify_amqp:<IDENTIFIER>`` suffix 
+describes the unique identifier for that AMQP service endpoint.
+
+Note the identifier for the AMQP service endpoint you want to update for
+the next step. 
+
+2) Update the AMQP Endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc-cmd:`mc admin config set` command to set the new configuration
+for the AMQP service endpoint:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin config set ALIAS/ notify_amqp:<IDENTIFIER> \
+      url="amqp://user:password@hostname:port" \
+      exchange="<string>" \
+      exchange_type="<string>" \
+      routing_key="<string>" \
+      mandatory="<string>" \
+      durable="<string>" \
+      no_wait="<string>" \
+      internal="<string>" \
+      auto_deleted="<string>" \
+      delivery_mode="<string>" \
+      queue_dir="<string>" \
+      queue_limit="<string>" \
+      comment="<string>"
+
+The :mc-conf:`notify_amqp url <notify_amqp.url>` configuration setting is the
+*minimum* required for an AMQP service endpoint. All other configuration
+settings are *optional*. See :ref:`minio-server-config-bucket-notification-amqp`
+for a complete list of AMQP configuration settings.
+
+3) Restart the MinIO Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You must restart the MinIO deployment to apply the configuration changes. 
+Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
+
+.. important::
+
+   MinIO restarts *all* :mc:`minio server` processes associated to the 
+   deployment at the same time. Applications may experience a brief period of 
+   downtime during the restart process. 
+
+   Consider scheduling the restart during a maintenance period to minimize
+   interruption of services.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin service restart ALIAS
+
+Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+restart.
+
+The :mc:`minio server` process prints a line on startup for each configured AMQP
+target similar to the following:
+
+.. code-block:: shell
+
+   SQS ARNs: arn:minio:sqs::primary:amqp
+
+3) Validate the Changes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Perform an action on a bucket which has an event configuration using the updated
+AMQP service endpoint and check the AMQP service for the notification data. The
+action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+specified when configuring the bucket notification.
+
+For example, if the bucket notification configuration includes the 
+``s3:ObjectCreated:Put`` event, you can use the 
+:mc-cmd:`mc cp` command to create a new object in the bucket and trigger 
+a notification.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc cp ~/data/new-object.txt ALIAS/BUCKET

--- a/source/monitoring/bucket-notifications/publish-events-to-mqtt.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-mqtt.rst
@@ -1,0 +1,389 @@
+.. _minio-bucket-notifications-publish-mqtt:
+
+======================
+Publish Events to MQTT
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+MinIO supports publishing :ref:`bucket notification
+<minio-bucket-notifications>` events to `MQTT <https://www.mqtt.org/>`__ 
+server/broker endpoint.
+
+Add an MQTT Endpoint to a MinIO Deployment
+------------------------------------------
+
+The following procedure adds a new MQTT service endpoint for supporting
+:ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
+deployment.
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-restart-downtime
+   :end-before: end-restart-downtime
+
+Prerequisites
+~~~~~~~~~~~~~~
+
+MQTT 3.1 or 3.1.1 Server/Broker
++++++++++++++++++++++++++++++++
+
+This procedure assumes an existing MQTT 3.1 or 3.1.1 server/broker to which the
+MinIO deployment has connectivity. See the 
+`mqtt.org software listing <https://mqtt.org/software/>`__ for a list of
+MQTT-compatible server/brokers.
+
+If the MQTT service requires authentication, you *must* provide an appropriate
+username and password during the configuration process to grant MinIO access
+to the service.
+
+MinIO ``mc`` Command Line Tool
+++++++++++++++++++++++++++++++
+
+This procedure uses the :mc:`mc` command line tool for certain actions. 
+See the ``mc`` :ref:`Quickstart <mc-install>` for installation instructions.
+
+1) Add the MQTT Endpoint to MinIO
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can configure a new MQTT service endpoint using either environment variables
+*or* by setting runtime configuration settings.
+
+.. tabs::
+
+   .. tab:: Environment Variables
+
+      MinIO supports specifying the MQTT service endpoint and associated
+      configuration settings using 
+      :ref:`environment variables 
+      <minio-server-envvar-bucket-notification-mqtt>`. The 
+      :mc:`minio server` process applies the specified settings on its 
+      next startup.
+      
+      The following example code sets *all*  environment variables
+      related to configuring an MQTT service endpoint. The minimum *required*
+      variables are:
+
+      - :envvar:`MINIO_NOTIFY_MQTT_ENABLE`
+      - :envvar:`MINIO_NOTIFY_MQTT_BROKER`
+      - :envvar:`MINIO_NOTIFY_MQTT_TOPIC`
+      - :envvar:`MINIO_NOTIFY_MQTT_USERNAME` *Required if the MQTT server/broker enforces authentication/authorization*
+      - :envvar:`MINIO_NOTIFY_MQTT_PASSWORD` *Required if the MQTT server/broker enforces authentication/authorization*
+
+      .. code-block:: shell
+         :class: copyable
+
+         set MINIO_NOTIFY_MQTT_ENABLE_<IDENTIFIER>="on"
+         set MINIO_NOTIFY_MQTT_BROKER_<IDENTIFIER>="ENDPOINT"
+         set MINIO_NOTIFY_MQTT_TOPIC_<IDENTIFIER>="TOPIC"
+         set MINIO_NOTIFY_MQTT_USERNAME_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_MQTT_PASSWORD_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_MQTT_QOS_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_MQTT_KEEP_ALIVE_INTERVAL_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_MQTT_RECONNECT_INTERVAL_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_MQTT_QUEUE_DIR_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_MQTT_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+         set MINIO_NOTIFY_MQTT_COMMENT_<IDENTIFIER>="<string>"
+
+      - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
+        MQTT service endpoint. Use the same ``<IDENTIFIER>`` value for all 
+        environment variables related to the new MQTT service endpoint.
+        The following examples assume an identifier of ``PRIMARY``.
+
+        If the specified ``<IDENTIFIER>`` matches an existing MQTT service
+        endpoint on the MinIO deployment, the new settings *override* 
+        any existing settings for that endpoint. Use 
+        :mc-cmd:`mc admin config get notify_mqtt <mc admin config get>` to
+        review the currently configured MQTT endpoints on the MinIO deployment.
+
+      - Replace ``<ENDPOINT>`` with the URL of the MQTT service endpoint.
+        For example:
+
+        ``tcp://hostname:port``
+
+      - Replace ``TOPIC`` with the MQTT topic to which MinIO associates 
+        events published to the server/broker.
+
+      See :ref:`MQTT Service for Bucket Notifications
+      <minio-server-envvar-bucket-notification-mqtt>` for complete documentation
+      on each environment variable.
+
+   .. tab:: Configuration Settings
+
+      MinIO supports adding or updating MQTT endpoints on a running 
+      :mc:`minio server` process using the :mc-cmd:`mc admin config set` command 
+      and the :mc-conf:`notify_mqtt` configuration key. You must restart the 
+      :mc:`minio server` process to apply any new or updated configuration
+      settings.
+
+      The following example code sets *all*  settings related to configuring an
+      MQTT service endpoint. The following configuration settings are the
+      *minimum* required for an MQTT server/broker endpoint:
+
+      - :mc-conf:`~notify_mqtt.broker`
+      - :mc-conf:`~notify_mqtt.topic`
+      - :mc-conf:`~notify_mqtt.username` *Required if the MQTT server/broker enforces authentication/authorization*
+      - :mc-conf:`~notify_mqtt.password` *Required if the MQTT server/broker enforces authentication/authorization*
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin config set ALIAS/ notify_mqtt:IDENTIFIER \
+            broker="ENDPOINT" \
+            topic="TOPIC" \
+            username="username" \
+            password="password" \
+            qos="<integer>" \
+            keep_alive_interval="60s|m|h|d"
+            reconnect_interval="60s|m|h|d"
+            queue_dir="<string>" \
+            queue_limit="<string>" \
+            comment="<string>"
+
+      - Replace ``IDENTIFIER`` with a unique descriptive string for the
+        MQTT service endpoint. The following examples in this procedure
+        assume an identifier of ``PRIMARY``.
+
+        If the specified ``IDENTIFIER`` matches an existing MQTT service
+        endpoint on the MinIO deployment, the new settings *override* 
+        any existing settings for that endpoint. Use 
+        :mc-cmd:`mc admin config get notify_mqtt <mc admin config get>` to
+        review the currently configured MQTT endpoints on the MinIO deployment.
+
+      - Replace ``ENDPOINT`` with the URL of the MQTT service endpoint.
+        For example:
+
+        ``tcp://hostname:port``
+
+      - Replace ``TOPIC`` with the MQTT topic to which MinIO associates 
+        events published to the server/broker.
+
+      See :ref:`MQTT Bucket Notification Configuration Settings
+      <minio-server-config-bucket-notification-mqtt>` for complete 
+      documentation on each setting.
+
+2) Restart the MinIO Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You must restart the MinIO deployment to apply the configuration changes. 
+Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
+
+.. important::
+
+   MinIO restarts *all* :mc:`minio server` processes associated to the 
+   deployment at the same time. Applications may experience a brief period of 
+   downtime during the restart process. 
+
+   Consider scheduling the restart during a maintenance period to minimize
+   interruption of services.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin service restart ALIAS
+
+Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+restart.
+
+The :mc:`minio server` process prints a line on startup for each configured MQTT
+target similar to the following:
+
+.. code-block:: shell
+
+   SQS ARNs: arn:minio:sqs::primary:mqtt
+
+You must specify the ARN resource when configuring bucket notifications with
+the associated MQTT deployment as a target.
+
+3) Configure Bucket Notifications using the MQTT Endpoint as a Target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc-cmd:`mc event add` command to add a new bucket notification 
+event with the configured MQTT service as a target:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc event add ALIAS/BUCKET arn:minio:sqs::primary:mqtt \
+     --event EVENTS
+
+- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``BUCKET`` with the name of the bucket in which to configure the 
+  event.
+- Replace ``EVENTS`` with a comma-separated list of :ref:`events 
+  <mc-event-supported-events>` for which MinIO triggers notifications.
+
+Use :mc-cmd:`mc event list` to view all configured bucket events for 
+a given notification target:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc event list ALIAS/BUCKET arn:minio:sqs::primary:MQTT
+
+4) Validate the Configured Events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Perform an action on the bucket for which you configured the new event and 
+check the MQTT service for the notification data. The action required
+depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+when configuring the bucket notification.
+
+For example, if the bucket notification configuration includes the 
+``s3:ObjectCreated:Put`` event, you can use the 
+:mc-cmd:`mc cp` command to create a new object in the bucket and trigger 
+a notification.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc cp ~/data/new-object.txt ALIAS/BUCKET
+
+Update an MQTT Endpoint in a MinIO Deployment
+---------------------------------------------
+
+The following procedure updates an existing MQTT service endpoint for supporting
+:ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
+deployment.
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-restart-downtime
+   :end-before: end-restart-downtime
+
+Prerequisites
+~~~~~~~~~~~~~~
+
+MQTT 3.1 or 3.1.1 Server/Broker Endpoint
+++++++++++++++++++++++++++++++++++++++++
+
+This procedure assumes an existing MQTT 3.1 or 3.1.1 server/broker to which the
+MinIO deployment has connectivity. See the 
+`mqtt.org software listing <https://mqtt.org/software/>`__ for a list of
+MQTT-compatible server/brokers.
+
+If the MQTT service requires authentication, you *must* provide an appropriate
+username and password during the configuration process to grant MinIO access
+to the service.
+
+MinIO ``mc`` Command Line Tool
+++++++++++++++++++++++++++++++
+
+This procedure uses the :mc:`mc` command line tool for certain actions. 
+See the ``mc`` :ref:`Quickstart <mc-install>` for installation instructions.
+
+
+1) List Configured MQTT Endpoints In The Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc-cmd:`mc admin config get` command to list the currently
+configured MQTT service endpoints in the deployment:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin config get ALIAS/ notify_mqtt
+
+Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+
+The command output resembles the following:
+
+.. code-block:: shell
+
+   notify_mqtt:primary  broker="tcp://mqtt-primary.example.net:port" password="" queue_dir="" queue_limit="0" reconnect_interval="0s"  keep_alive_interval="0s" qos="0" topic="" username=""
+   notify_mqtt:secondary  broker="tcp://mqtt-primary.example.net:port" password="" queue_dir="" queue_limit="0" reconnect_interval="0s"  keep_alive_interval="0s" qos="0" topic="" username=""
+
+The :mc-conf:`notify_mqtt` key is the top-level configuration key for an
+:ref:`minio-server-config-bucket-notification-mqtt`. The 
+:mc-conf:`broker <notify_mqtt.broker>` key specifies the MQTT server/broker endpoint 
+for the given `notify_mqtt` key. The ``notify_mqtt:<IDENTIFIER>`` suffix 
+describes the unique identifier for that MQTT service endpoint.
+
+Note the identifier for the MQTT service endpoint you want to update for
+the next step. 
+
+2) Update the MQTT Endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc-cmd:`mc admin config set` command to set the new configuration
+for the MQTT service endpoint:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin config set ALIAS/ notify_mqtt:<IDENTIFIER> \
+      url="MQTT://user:password@hostname:port" \
+      exchange="<string>" \
+      exchange_type="<string>" \
+      routing_key="<string>" \
+      mandatory="<string>" \
+      durable="<string>" \
+      no_wait="<string>" \
+      internal="<string>" \
+      auto_deleted="<string>" \
+      delivery_mode="<string>" \
+      queue_dir="<string>" \
+      queue_limit="<string>" \
+      comment="<string>"
+
+The following configuration settings are the *minimum* required for an 
+MQTT server/broker endpoint:
+
+- :mc-conf:`~notify_mqtt.broker`
+- :mc-conf:`~notify_mqtt.topic`
+- :mc-conf:`~notify_mqtt.username` *Required if the MQTT server/broker enforces authentication/authorization*
+- :mc-conf:`~notify_mqtt.password` *Required if the MQTT server/broker enforces authentication/authorization*
+
+All other configuration settings are *optional*. See
+:ref:`minio-server-config-bucket-notification-mqtt` for a complete list of MQTT
+configuration settings.
+
+3) Restart the MinIO Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You must restart the MinIO deployment to apply the configuration changes. 
+Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
+
+.. important::
+
+   MinIO restarts *all* :mc:`minio server` processes associated to the 
+   deployment at the same time. Applications may experience a brief period of 
+   downtime during the restart process. 
+
+   Consider scheduling the restart during a maintenance period to minimize
+   interruption of services.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin service restart ALIAS
+
+Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+restart.
+
+The :mc:`minio server` process prints a line on startup for each configured MQTT
+target similar to the following:
+
+.. code-block:: shell
+
+   SQS ARNs: arn:minio:sqs::primary:mqtt
+
+3) Validate the Changes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Perform an action on a bucket which has an event configuration using the updated
+MQTT service endpoint and check the MQTT service for the notification data. The
+action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+specified when configuring the bucket notification.
+
+For example, if the bucket notification configuration includes the 
+``s3:ObjectCreated:Put`` event, you can use the 
+:mc-cmd:`mc cp` command to create a new object in the bucket and trigger 
+a notification.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc cp ~/data/new-object.txt ALIAS/BUCKET

--- a/source/monitoring/monitoring-overview.rst
+++ b/source/monitoring/monitoring-overview.rst
@@ -1,0 +1,25 @@
+==========
+Monitoring
+==========
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+Bucket Notifications
+--------------------
+
+MinIO supports publishing bucket or object events to the following supported 
+targets on certain supported events. See :ref:`minio-bucket-notifications`
+for more complete documentation on MinIO Bucket Notifications.
+
+- Publish MinIO Events to AMQP
+
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   /monitoring/bucket-notifications/bucket-notifications

--- a/source/reference/minio-cli/minio-mc-admin/mc-admin.config.rst
+++ b/source/reference/minio-cli/minio-mc-admin/mc-admin.config.rst
@@ -229,3 +229,172 @@ using these environment variables.
 
       This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_COMMENT`
       environment variable.
+
+.. _minio-server-config-bucket-notification-mqtt:
+
+MQTT Service for Bucket Notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following section documents settings for configuring an MQTT
+server/broker as a publishing target for :doc:`MinIO Bucket Notifications
+</concepts/bucket-notifications>`. See
+:ref:`minio-bucket-notifications-publish-mqtt` for a tutorial on 
+using these configuration settings.
+
+.. mc-conf:: notify_mqtt
+
+   The top-level configuration key for defining an MQTT server/broker endpoint
+   for use with :ref:`MinIO bucket notifications <minio-bucket-notifications>`.
+
+   Use :mc-cmd:`mc admin config set` to set or update an MQTT server/broker
+   endpoint. The following arguments are *required* for each endpoint: 
+   
+   - :mc-conf:`~notify_mqtt.broker`
+   - :mc-conf:`~notify_mqtt.topic`
+   - :mc-conf:`~notify_mqtt.username` *Optional if MQTT server/broker does not enforce authentication/authorization*
+   - :mc-conf:`~notify_mqtt.password` *Optional if MQTT server/broker does not enforce authentication/authorization*
+
+   Specify additional optional arguments as a whitespace (``" "``)-delimited
+   list.
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc admin config set notify_mqtt \ 
+         broker="tcp://endpoint:port" \
+         topic="minio/bucket-name/events/" \
+         username="username" \
+         password="password" \
+         [ARGUMENT="VALUE"] ... \
+
+   You can specify multiple MQTT server/broker endpoints by appending
+   ``[:name]`` to the top level key. For example, the following commands set two
+   distinct MQTT service endpoints as ``primary`` and ``secondary``
+   respectively:
+
+   .. code-block:: shell
+
+      mc admin config set notify_mqtt:primary \ 
+         broker="tcp://endpoint:port" \
+         topic="minio/bucket-name/events/" \
+         username="username" \
+         password="password" \
+         [ARGUMENT="VALUE"] ... \
+
+      mc admin config set notify_mqtt:secondary \
+         broker="tcp://endpoint:port" \
+         topic="minio/bucket-name/events/" \
+         username="username" \
+         password="password" \
+         [ARGUMENT="VALUE"] ... \
+
+   The :mc-conf:`notify_mqtt` configuration key supports the following 
+   arguments:
+
+   .. mc-conf:: broker
+      :delimiter: " "
+
+      *Required*
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-broker
+         :end-before:  end-minio-notify-mqtt-broker
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_BROKER`
+      environment variable.
+
+   .. mc-conf:: topic
+      :delimiter: " "
+
+      *Required*
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-topic
+         :end-before:  end-minio-notify-mqtt-topic
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_TOPIC`
+      environment variable.
+
+   .. mc-conf:: username
+      :delimiter: " "
+
+      *Required if the MQTT server/broker enforces authentication/authorization*
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-username
+         :end-before:  end-minio-notify-mqtt-username
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_TOPIC`
+      environment variable.
+
+   .. mc-conf:: password
+      :delimiter: " "
+
+      *Required if the MQTT server/broker enforces authentication/authorization*
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-password
+         :end-before:  end-minio-notify-mqtt-password
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_PASSWORD`
+      environment variable.
+
+   .. mc-conf:: qos
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-qos
+         :end-before:  end-minio-notify-mqtt-qos
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_QOS`
+      environment variable.
+
+   .. mc-conf:: keep_alive_interval
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-keep-alive-interval
+         :end-before:  end-minio-notify-mqtt-keep-alive-interval
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_KEEP_ALIVE_INTERVAL`
+      environment variable.
+
+   .. mc-conf:: reconnect_interval
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-reconnect-interval
+         :end-before:  end-minio-notify-mqtt-reconnect-interval
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_RECONNECT_INTERVAL`
+      environment variable.
+
+   .. mc-conf:: queue_dir 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-queue-dir
+         :end-before:  end-minio-notify-mqtt-queue-dir
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_QUEUE_DIR`
+      environment variable.
+
+   .. mc-conf:: queue_limit 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-queue-limit
+         :end-before:  end-minio-notify-mqtt-queue-limit
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_QUEUE_LIMIT`
+      environment variable.
+
+   .. mc-conf:: comment 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-mqtt-comment
+         :end-before:  end-minio-notify-mqtt-comment
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_MQTT_COMMENT`
+      environment variable.

--- a/source/reference/minio-cli/minio-mc-admin/mc-admin.config.rst
+++ b/source/reference/minio-cli/minio-mc-admin/mc-admin.config.rst
@@ -32,3 +32,200 @@ Examples
 
 Syntax
 ------
+
+.. mc-cmd:: set
+   :fullpath:
+
+   Sets a :ref:`configuration key <minio-server-configuration-settings>` on the 
+   MinIO deployment.
+
+.. mc-cmd:: get
+   :fullpath:
+
+   Gets a :ref:`configuration key <minio-server-configuration-settings>` on the
+   MinIO deployment.
+
+.. _minio-server-configuration-settings:
+
+Configuration Settings
+----------------------
+
+The following configuration settings define runtime behavior of the 
+MinIO :mc:`server <minio server>` process:
+
+.. _minio-server-config-bucket-notification-amqp:
+
+AMQP Service for Bucket Notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following section documents settings for configuring an AMQP
+service as a target for :doc:`MinIO Bucket Notifications
+</concepts/bucket-notifications>`. See
+:ref:`minio-bucket-notifications-publish-amqp` for a tutorial on 
+using these environment variables.
+
+.. mc-conf:: notify_amqp
+
+   The top-level configuration key for defining an AMQP service endpoint for use
+   with :ref:`MinIO bucket notifications <minio-bucket-notifications>`.
+
+   Use :mc-cmd:`mc admin config set` to set or update an AMQP service endpoint. 
+   The :mc-conf:`~notify_amqp.url` argument is *required* for each target.
+   Specify additional optional arguments as a whitespace (``" "``)-delimited 
+   list.
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc admin config set notify_amqp \ 
+        url="amqp://user:password@endpoint:port" \
+        [ARGUMENT="VALUE"] ... \
+
+   You can specify multiple AMQP service endpoints by appending ``[:name]`` to
+   the top level key. For example, the following commands set two distinct AMQP
+   service endpoints as ``primary`` and ``secondary`` respectively:
+
+   .. code-block:: shell
+
+      mc admin config set notify_amqp:primary \ 
+         url="user:password@amqp://endpoint:port" [ARGUMENT=VALUE ...]
+
+      mc admin config set notify_amqp:secondary \
+         url="user:password@amqp://endpoint:port" [ARGUMENT=VALUE ...]
+
+   The :mc-conf:`notify_amqp` configuration key supports the following 
+   arguments:
+
+   .. mc-conf:: url
+      :delimiter: " "
+
+      *Required*
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-url
+         :end-before:  end-minio-notify-amqp-url
+
+      This key corresponds to the :envvar:`MINIO_NOTIFY_AMQP_URL` environment
+      variable. 
+
+   .. mc-conf:: exchange 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-exchange
+         :end-before:  end-minio-notify-amqp-exchange
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_EXCHANGE`
+      environment variable.
+
+   .. mc-conf:: exchange_type 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-exchange-type
+         :end-before:  end-minio-notify-amqp-exchange-type
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_EXCHANGE_TYPE`
+      environment variable.
+
+   .. mc-conf:: routing_key 
+      :delimiter: " "
+   
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-routing-key
+         :end-before:  end-minio-notify-amqp-routing-key
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_ROUTING_KEY`
+      environment variable.
+
+   .. mc-conf:: mandatory 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-mandatory
+         :end-before:  end-minio-notify-amqp-mandatory
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_MANDATORY`
+      environment variable.
+
+   .. mc-conf:: durable 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-durable
+         :end-before:  end-minio-notify-amqp-durable
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_DURABLE`
+      environment variable.
+
+   .. mc-conf:: no_wait 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-no-wait
+         :end-before:  end-minio-notify-amqp-no-wait
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_NO_WAIT`
+      environment variable.
+
+   .. mc-conf:: internal 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-internal
+         :end-before:  end-minio-notify-amqp-internal
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_INTERNAL`
+      environment variable.
+
+   .. explanation is very unclear. Need to revisit this.
+
+   .. mc-conf:: auto_deleted 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-auto-deleted
+         :end-before:  end-minio-notify-amqp-auto-deleted
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_AUTO_DELETED`
+      environment variable.
+
+   .. mc-conf:: delivery_mode 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-delivery-mode
+         :end-before:  end-minio-notify-amqp-delivery-mode
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_DELIVERY_MODE`
+      environment variable.
+
+   .. mc-conf:: queue_dir 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-queue-dir
+         :end-before:  end-minio-notify-amqp-queue-dir
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_QUEUE_DIR`
+      environment variable.
+
+   .. mc-conf:: queue_limit 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-queue-limit
+         :end-before:  end-minio-notify-amqp-queue-limit
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_QUEUE_LIMIT`
+      environment variable.
+
+   .. mc-conf:: comment 
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-amqp-comment
+         :end-before:  end-minio-notify-amqp-comment
+
+      This field corresponds to the :envvar:`MINIO_NOTIFY_AMQP_COMMENT`
+      environment variable.

--- a/source/reference/minio-server/minio-gateway.rst
+++ b/source/reference/minio-server/minio-gateway.rst
@@ -1,0 +1,101 @@
+=============
+MinIO Gateway
+=============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. _minio-gateway:
+
+MinIO Gateway
+-------------
+
+Syntax
+~~~~~~
+
+.. mc:: minio gateway
+
+Starts the MinIO Gateway process. 
+
+The command has the following syntax:
+
+.. code-block:: shell
+   :class: copyable
+
+   minio gateway [FLAGS] SUBCOMMAND [ARGUMENTS]
+
+:mc:`minio gateway` supports the following flags:
+
+.. mc-cmd:: address
+   :option:
+
+   *Optional* Binds the MinIO Gateway to a specific network address and port
+   number. Specify the address and port as ``ADDRESS:PORT``, where ``ADDRESS``
+   is an IP address or hostname and ``PORT`` is a valid and open port on the
+   host system.
+
+   To change the port number for all IP addresses or hostnames configured
+   on the host machine, specify ``:PORT`` where ``PORT`` is a valid
+   and open port on the host.
+
+.. mc-cmd:: certs-dir, -S
+   :option:
+
+   *Optional* Specifies the path to the folder containing certificates the
+   MinIO Gateway process uses for configuring TLS/SSL connectivity.
+
+   Omit to use the default directory paths:
+
+   - Linux/OSX: ``${HOME}/.minio/certs`` 
+   - Windows: ``%%USERPROFILE%%\.minio\certs``.
+
+   See :ref:`minio-TLS` for more information on TLS/SSL connectivity.
+
+.. mc-cmd:: quiet
+   :option:
+
+   *Optional* Disables startup information.
+
+.. mc-cmd:: anonymous
+   :option:
+
+   *Optional* Hides sensitive information from logging.
+
+.. mc-cmd:: json
+   :option:
+
+   *Optional* Outputs server logs and startup information in ``JSON``
+   format.
+
+:mc:`minio gateway` supports the following subcommands:
+
+.. mc-cmd:: nas
+   :fullpath:
+
+   Creates a MinIO Gateway process configured for Network-Attached Storage
+   (NAS).
+
+.. mc-cmd:: azure
+   :fullpath:
+
+   Creates a MinIO Gateway process configured for Microsoft Azure Blob Storage.
+
+.. mc-cmd:: s3
+   :fullpath:
+
+   Creates a MinIO Gateway process configured for Amazon Simple Storage Service
+   (S3).
+
+.. mc-cmd:: hdfs
+   :fullpath:
+
+   Creates a MinIO Gateway process configured for Hadoop Distributed File
+   System (HDFS).
+
+.. mc-cmd:: gcs
+   :fullpath:
+
+   Creates a MinIO Gateway process configured for Google Cloud Storage.

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -1,6 +1,6 @@
-========================
-MinIO Server (``minio``)
-========================
+============
+MinIO Server
+============
 
 .. default-domain:: minio
 
@@ -9,9 +9,6 @@ MinIO Server (``minio``)
    :depth: 2
 
 .. mc:: minio
-
-The :mc:`minio` command line executable starts either the MinIO Object Storage
-process *or* the MinIO Gateway process. 
 
 MinIO Server
 ------------
@@ -28,7 +25,6 @@ see :ref:`minio-installation`.
 
 For examples of deploying :mc:`minio server` on a Kubernetes environment,
 see :docs-k8s:`Kubernetes documentation <>`.
-
 
 Configuration Settings
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -168,101 +164,13 @@ The command accepts the following arguments:
    *Optional* Outputs server logs and startup information in ``JSON``
    format.
 
-MinIO Gateway
--------------
-
-Syntax
-~~~~~~
-
-.. mc:: minio gateway
-
-Starts the MinIO Gateway process. 
-
-The command has the following syntax:
-
-.. code-block:: shell
-   :class: copyable
-
-   minio gateway [FLAGS] SUBCOMMAND [ARGUMENTS]
-
-:mc:`minio gateway` supports the following flags:
-
-.. mc-cmd:: address
-   :option:
-
-   *Optional* Binds the MinIO Gateway to a specific network address and port
-   number. Specify the address and port as ``ADDRESS:PORT``, where ``ADDRESS``
-   is an IP address or hostname and ``PORT`` is a valid and open port on the
-   host system.
-
-   To change the port number for all IP addresses or hostnames configured
-   on the host machine, specify ``:PORT`` where ``PORT`` is a valid
-   and open port on the host.
-
-.. mc-cmd:: certs-dir, -S
-   :option:
-
-   *Optional* Specifies the path to the folder containing certificates the
-   MinIO Gateway process uses for configuring TLS/SSL connectivity.
-
-   Omit to use the default directory paths:
-
-   - Linux/OSX: ``${HOME}/.minio/certs`` 
-   - Windows: ``%%USERPROFILE%%\.minio\certs``.
-
-   See :ref:`minio-TLS` for more information on TLS/SSL connectivity.
-
-.. mc-cmd:: quiet
-   :option:
-
-   *Optional* Disables startup information.
-
-.. mc-cmd:: anonymous
-   :option:
-
-   *Optional* Hides sensitive information from logging.
-
-.. mc-cmd:: json
-   :option:
-
-   *Optional* Outputs server logs and startup information in ``JSON``
-   format.
-
-:mc:`minio gateway` supports the following subcommands:
-
-.. mc-cmd:: nas
-   :fullpath:
-
-   Creates a MinIO Gateway process configured for Network-Attached Storage
-   (NAS).
-
-.. mc-cmd:: azure
-   :fullpath:
-
-   Creates a MinIO Gateway process configured for Microsoft Azure Blob Storage.
-
-.. mc-cmd:: s3
-   :fullpath:
-
-   Creates a MinIO Gateway process configured for Amazon Simple Storage Service
-   (S3).
-
-.. mc-cmd:: hdfs
-   :fullpath:
-
-   Creates a MinIO Gateway process configured for Hadoop Distributed File
-   System (HDFS).
-
-.. mc-cmd:: gcs
-   :fullpath:
-
-   Creates a MinIO Gateway process configured for Google Cloud Storage.
+.. _minio-server-environment-variables:
 
 Environment Variables
 ---------------------
 
-The :mc:`minio server` and :mc:`minio gateway` processes can use the following
-environment variables when creating its configuration settings:
+The :mc:`minio server` processes uses the following
+environment variables during startup to set configuration settings.
 
 Root Credentials
 ~~~~~~~~~~~~~~~~
@@ -361,3 +269,171 @@ refers to the specific storage tier on which to store a given object.
 .. envvar:: MINIO_STORAGE_CLASS_COMMENT
 
    Adds a comment to the storage class settings.
+
+Bucket Notifications
+~~~~~~~~~~~~~~~~~~~~
+
+These environment variables configure notification targets for use with 
+:doc:`MinIO Bucket Notifications </concepts/bucket-notifications>`:
+   
+- :ref:`minio-server-envvar-bucket-notification-amqp`
+
+.. _minio-server-envvar-bucket-notification-amqp:
+
+AMQP Service for Bucket Notifications
++++++++++++++++++++++++++++++++++++++
+
+The following section documents environment variables for configuring an AMQP
+service as a target for :doc:`MinIO Bucket Notifications
+</concepts/bucket-notifications>`. See
+:ref:`minio-bucket-notifications-publish-amqp` for a tutorial on 
+using these environment variables.
+
+You can specify multiple AMQP service endpoints by appending a unique identifier
+``_ID`` for each set of related AMQP environment variables:
+the top level key. For example, the following commands set two distinct AMQP
+service endpoints as ``PRIMARY`` and ``SECONDARY`` respectively:
+
+.. code-block:: shell
+   :class: copyable
+
+   set MINIO_NOTIFY_AMQP_ENABLE_PRIMARY="on"
+   set MINIO_NOTIFY_AMQP_URL_PRIMARY="amqp://user:password@amqp-endpoint.example.net:5672"
+
+   set MINIO_NOTIFY_AMQP_ENABLE_SECONDARY="on"
+   set MINIO_NOTIFY_AMQP_URL_SECONDARY="amqp://user:password@amqp-endpoint.example.net:5672"
+
+For example, :envvar:`MINIO_NOTIFY_AMQP_ENABLE_PRIMARY
+<MINIO_NOTIFY_AMQP_ENABLE>` indicates the environment variable is associated to
+an AMQP service endpoint with ID of ``PRIMARY``.
+
+.. envvar:: MINIO_NOTIFY_AMQP_ENABLE
+   
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-enable
+      :end-before:  end-minio-notify-amqp-enable
+
+   Requires specifying :envvar:`MINIO_NOTIFY_AMQP_URL` if set to ``on``.
+
+.. envvar:: MINIO_NOTIFY_AMQP_URL
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-url
+      :end-before:  end-minio-notify-amqp-url
+
+   This field is *required* if :envvar:`MINIO_NOTIFY_AMQP_ENABLE` is ``on``.
+   All other AMQP-related variables are optional.
+
+   This variable corresponds to the :mc-conf:`notify_amqp url <notify_amqp.url>`
+   configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_EXCHANGE 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-exchange
+      :end-before:  end-minio-notify-amqp-exchange
+
+   This variable corresponds to the :mc-conf:`notify_amqp exchange 
+   <notify_amqp.exchange>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_EXCHANGE_TYPE 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-exchange-type
+      :end-before:  end-minio-notify-amqp-exchange-type
+
+   This variable corresponds to the :mc-conf:`notify_amqp exchange_type
+   <notify_amqp.exchange_type>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_ROUTING_KEY 
+   
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-routing-key
+      :end-before:  end-minio-notify-amqp-routing-key
+
+   This variable corresponds to the :mc-conf:`notify_amqp routing_key
+   <notify_amqp.routing_key>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_MANDATORY 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-mandatory
+      :end-before:  end-minio-notify-amqp-mandatory
+
+   This variable corresponds to the :mc-conf:`notify_amqp mandatory
+   <notify_amqp.mandatory>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_DURABLE 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-durable
+      :end-before:  end-minio-notify-amqp-durable
+
+   This variable corresponds to the :mc-conf:`notify_amqp durable
+   <notify_amqp.durable>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_NO_WAIT 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-no-wait
+      :end-before:  end-minio-notify-amqp-no-wait
+
+   This variable corresponds to the :mc-conf:`notify_amqp no_wait
+   <notify_amqp.no_wait>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_INTERNAL 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-internal
+      :end-before:  end-minio-notify-amqp-internal
+
+   This variable corresponds to the :mc-conf:`notify_amqp internal
+   <notify_amqp.internal>` configuration setting.
+
+   .. explanation is very unclear. Need to revisit this.
+
+.. envvar:: MINIO_NOTIFY_AMQP_AUTO_DELETED 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-auto-deleted
+      :end-before:  end-minio-notify-amqp-auto-deleted
+
+   This variable corresponds to the :mc-conf:`notify_amqp auto_deleted
+   <notify_amqp.auto_deleted>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_DELIVERY_MODE 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-delivery-mode
+      :end-before:  end-minio-notify-amqp-delivery-mode
+
+   This variable corresponds to the :mc-conf:`notify_amqp delivery_mode
+   <notify_amqp.delivery_mode>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_QUEUE_DIR 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-queue-dir
+      :end-before:  end-minio-notify-amqp-queue-dir
+
+   This variable corresponds to the :mc-conf:`notify_amqp queue_dir
+   <notify_amqp.queue_dir>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_QUEUE_LIMIT 
+
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-queue-limit
+      :end-before:  end-minio-notify-amqp-queue-limit
+
+   This variable corresponds to the :mc-conf:`notify_amqp queue_limit
+   <notify_amqp.queue_limit>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_AMQP_COMMENT 
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-amqp-comment
+      :end-before:  end-minio-notify-amqp-comment
+
+   This variable corresponds to the :mc-conf:`notify_amqp comment
+   <notify_amqp.comment>` configuration setting.

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -277,6 +277,7 @@ These environment variables configure notification targets for use with
 :doc:`MinIO Bucket Notifications </concepts/bucket-notifications>`:
    
 - :ref:`minio-server-envvar-bucket-notification-amqp`
+- :ref:`minio-server-envvar-bucket-notification-mqtt`
 
 .. _minio-server-envvar-bucket-notification-amqp:
 
@@ -437,3 +438,140 @@ an AMQP service endpoint with ID of ``PRIMARY``.
 
    This variable corresponds to the :mc-conf:`notify_amqp comment
    <notify_amqp.comment>` configuration setting.
+
+.. _minio-server-envvar-bucket-notification-mqtt:
+
+MQTT Service for Bucket Notifications
++++++++++++++++++++++++++++++++++++++
+
+The following section documents environment variables for configuring an MQTT
+service as a target for :doc:`MinIO Bucket Notifications
+</concepts/bucket-notifications>`. See
+:ref:`minio-bucket-notifications-publish-mqtt` for a tutorial on 
+using these environment variables.
+
+You can specify multiple MQTT service endpoints by appending a unique identifier
+``_ID`` for each set of related MQTT environment variables:
+the top level key. For example, the following commands set two distinct MQTT
+service endpoints as ``PRIMARY`` and ``SECONDARY`` respectively:
+
+.. code-block:: shell
+   :class: copyable
+
+   set MINIO_NOTIFY_MQTT_ENABLE_PRIMARY="on"
+   set MINIO_NOTIFY_MQTT_BROKER_PRIMARY="tcp://user:password@mqtt-endpoint.example.net:1883"
+
+   set MINIO_NOTIFY_MQTT_ENABLE_SECONDARY="on"
+   set MINIO_NOTIFY_MQTT_BROKER_SECONDARY="tcp://user:password@mqtt-endpoint.example.net:1883"
+
+For example, :envvar:`MINIO_NOTIFY_MQTT_ENABLE_PRIMARY
+<MINIO_NOTIFY_MQTT_ENABLE>` indicates the environment variable is associated to
+an MQTT service endpoint with ID of ``PRIMARY``.
+
+.. envvar:: MINIO_NOTIFY_MQTT_ENABLE
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-enable
+      :end-before: end-minio-notify-mqtt-enable
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_BROKER
+
+   *Required*
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-broker
+      :end-before: end-minio-notify-mqtt-broker
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.broker>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_TOPIC
+
+   *Required*
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-topic
+      :end-before: end-minio-notify-mqtt-topic
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.topic>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_USERNAME
+
+   *Required if the MQTT server/broker enforces authentication/authorization*
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-username
+      :end-before: end-minio-notify-mqtt-username
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.username>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_PASSWORD
+
+   *Required if the MQTT server/broker enforces authentication/authorization*
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-password
+      :end-before: end-minio-notify-mqtt-password
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.password>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_QOS
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-qos
+      :end-before: end-minio-notify-mqtt-qos
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.qos>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_KEEP_ALIVE_INTERVAL
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-keep-alive-interval
+      :end-before: end-minio-notify-mqtt-keep-alive-interval
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.keep_alive_interval>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_RECONNECT_INTERVAL
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-reconnect-interval
+      :end-before: end-minio-notify-mqtt-reconnect-interval
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.reconnect_interval>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_QUEUE_DIR
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-queue-dir
+      :end-before: end-minio-notify-mqtt-queue-dir
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.queue_dir>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_QUEUE_LIMIT
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-queue-limit
+      :end-before: end-minio-notify-mqtt-queue-limit
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.queue_limit>` configuration setting.
+
+.. envvar:: MINIO_NOTIFY_MQTT_COMMENT
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-mqtt-comment
+      :end-before: end-minio-notify-mqtt-comment
+
+   This variable corresponds to the 
+   :mc-conf:`notify_mqtt <notify_mqtt.comment>` configuration setting.
+

--- a/sphinxext/minio.py
+++ b/sphinxext/minio.py
@@ -263,6 +263,8 @@ class MinioObject(ObjectDescription):
     option_spec = {
         'noindex': directives.flag,
         'noindexentry': directives.flag,
+        'noprefix': directives.flag,
+        'delimiter': directives.unchanged,
     }
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
@@ -273,6 +275,13 @@ class MinioObject(ObjectDescription):
         directives.
         """
         sig = sig.strip()
+
+        noprefix = 'noprefix' in self.options
+        if ('delimiter' in self.options):
+           delimiter = self.options.get('delimiter').strip('"')
+        else:
+           delimiter = "."
+
 
         member = sig
         # If construct is nested, prefix the current prefix
@@ -286,8 +295,9 @@ class MinioObject(ObjectDescription):
         signode['object'] = prefix
         signode['fullname'] = fullname
 
-        if prefix:  
-          signode += addnodes.desc_addname(prefix + '.', prefix + '.')
+        if prefix and (noprefix == False):  
+        #  signode += addnodes.desc_addname(prefix + '.', prefix + '.')
+          signode += addnodes.desc_addname(prefix + delimiter, prefix + delimiter)
         
         signode += addnodes.desc_name(member, member)
 
@@ -475,7 +485,8 @@ class MinIODomain(Domain):
         'mc-cmd':         ObjType(_('mc-cmd'),        'mc-cmd'),
         'mc-cmd-option':  ObjType(_('mc-cmd-option'), 'mc-cmd-option'),
         'policy-action':  ObjType(_('policy-action'), 'policy-action'),
-        'envvar':         ObjType(_('envvar'),        'envvar')
+        'envvar':         ObjType(_('envvar'),        'envvar'),
+        'mc-conf':        ObjType(_('mc-conf'),       'mc-conf')
     }
     directives = {
         'data':            MinioObject,
@@ -485,7 +496,8 @@ class MinIODomain(Domain):
         'mc':              MinioMCCommand,
         'mc-cmd':          MinioMCObject,
         'policy-action':   MinioObject,
-        'envvar':          MinioObject
+        'envvar':          MinioObject,
+        'mc-conf':         MinioObject,
     }
     roles = {
         'data':             MinioXRefRole(),
@@ -497,6 +509,7 @@ class MinIODomain(Domain):
         'mc-cmd-option':    MinioCMDOptionXRefRole(),
         'policy-action':    MinioXRefRole(),
         'envvar':           MinioXRefRole(),
+        'mc-conf':          MinioXRefRole(),
 
     }
     initial_data = {


### PR DESCRIPTION
# Description

Adding MQTT publishing target for bucket notifications.

Please *ignore* the page listed under `Server Features -> Bucket Notifications`. This is the legacy guide and is just there for helping me track the progress of migration.


# Build Instructions

The MinIO docs require Python 3.9+ and Node for building. For Node, use v14.5.0 or later.

1) Clone the repo, Checkout the branch (`git checkout -B bucket-notification-migration origin/bucket-notification-migration`)
2) Run `npm install` from the branch
3) Create a python venv (`python -m venv venv`)
4) Install requirements (`pip install -r requirements.txt`)
5) Run `make html`
6) Run `python -m http.server --directory build/bucket-notification-migration/html`
7) Open 127.0.0.1:8000 in your browser and take a poke around.

If you run into an error running `python -m http.server` related to `--directory`, you're python version is likely older. CD into the `build/<branch>/html` directory and run the command without the `--directory` argument.

## Key URLs

- http://127.0.0.1:8000/monitoring/bucket-notifications/bucket-notifications.html
- http://127.0.0.1:8000/reference/minio-server/minio-server.html#mqtt-bucket-notification-target
- http://127.0.0.1:8000/reference/minio-cli/minio-mc-admin/mc-admin.config.html#mc-conf.notify_mqtt
- http://127.0.0.1:8000/monitoring/bucket-notifications/publish-events-to-amqp.html#minio-bucket-notifications-publish-mqtt