### PR TITLE
MinIO Implicit Prefix Trimming on Removal of Last Object 

### DIFF
--- a/source/includes/common-admonitions.rst
+++ b/source/includes/common-admonitions.rst
@@ -16,3 +16,51 @@
    this procedure.
 
 .. end-restart-downtime
+
+
+.. Used in the following pages:
+
+   /reference/minio-cli/minio-mc/mc-rm.rst
+   /reference/minio-cli/minio-mc/mc-mv.rst
+   /reference/minio-cli/minio-mc/mc-mirror.rst
+
+.. start-remove-api-trims-prefixes
+
+|command| relies on the :mc:`mc` removal API for deleting objects. As part of
+removing the last object in a bucket prefix, :mc:`mc` also recursively removes
+each empty part of the prefix up to the bucket root. :mc:`mc` only applies the
+recursive removal to prefixes created *implicitly* as part of object write
+operations - that is, the prefix was not created using an explicit directory
+creation command such as :mc:`mc mb`.
+
+For example, consider a bucket ``photos`` with the following object prefixes:
+
+- ``photos/2021/january/myphoto.jpg``
+- ``photos/2021/february/myotherphoto.jpg``
+- ``photos/NYE21/NewYears.jpg``
+
+``photos/NYE21`` is the *only* prefix explicitly created using :mc:`mc mb`.
+All other prefixes were *implicitly* created as part of writing the object
+located at that prefix. 
+
+If an :mc:`mc` command removes ``myphoto.jpg``, the removal API automatically
+trims the empty ``/january`` prefix. If a subsequent :mc:`mc` command removes
+``myotherphoto.jpg``, the removal API automatically trims both the ``/february``
+prefix *and* the now-empty ``/2021`` prefix. If an :mc:`mc` command removes
+``NewYears.jpg``, the ``/NYE21`` prefix remains in place since it was
+*explicitly* created.
+
+.. end-remove-api-trims-prefixes
+
+.. Following is linked topically to the remove-api-trims-prefixes core
+
+.. start-remove-api-trims-prefixes-fs
+
+If using |command| for operations on a filesystem, :mc:`mc` applies this same
+behavior by recursively trimming empty directory paths up to the root. However,
+the :mc:`mc` remove API cannot distinguish between an explicitly created
+directory path and an implicitly created one. If |command| deletes the last
+object at a filesystem path, :mc:`mc` recursively deletes all empty directories
+within that path up to the root as part of the removal operation.
+
+.. end-remove-api-trims-prefixes-fs

--- a/source/reference/minio-cli/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-cli/minio-mc/mc-mirror.rst
@@ -21,6 +21,23 @@ S3-compatible hosts as the synchronization source.
 
 .. end-mc-mirror-desc
 
+MinIO Trims Empty Prefixes on Object Removal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :mc-cmd-option:`mc mirror watch` command continuously synchronizes the
+source and destination targets. This includes automatically removing objects
+on the destination if they are removed on the source.
+
+.. |command| replace:: :mc-cmd-option:`mc mirror watch`
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-remove-api-trims-prefixes
+   :end-before: end-remove-api-trims-prefixes
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-remove-api-trims-prefixes-fs
+   :end-before: end-remove-api-trims-prefixes-fs
+
 Examples
 --------
 

--- a/source/reference/minio-cli/minio-mc/mc-mv.rst
+++ b/source/reference/minio-cli/minio-mc/mc-mv.rst
@@ -32,6 +32,19 @@ Resume Move Operations
 Use :mc-cmd-option:`mc mv continue` to resume an interrupted or failed
 move operation from the point of failure. 
 
+MinIO Trims Empty Prefixes on Object Removal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. |command| replace:: :mc-cmd:`mc mv`
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-remove-api-trims-prefixes
+   :end-before: end-remove-api-trims-prefixes
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-remove-api-trims-prefixes-fs
+   :end-before: end-remove-api-trims-prefixes-fs
+
 Examples
 --------
 

--- a/source/reference/minio-cli/minio-mc/mc-rm.rst
+++ b/source/reference/minio-cli/minio-mc/mc-rm.rst
@@ -29,6 +29,17 @@ itself. Any configurations associated to the bucket remain in place, such as
 
 To completely remove a bucket, use :mc:`mc rb` instead of :mc:`mc rm`.
 
+MinIO Trims Empty Prefixes on Object Removal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-remove-api-trims-prefixes
+   :end-before: end-remove-api-trims-prefixes
+
+.. include:: /includes/common-admonitions.rst
+   :start-after: start-remove-api-trims-prefixes-fs
+   :end-before: end-remove-api-trims-prefixes-fs
+
 Examples
 --------
 


### PR DESCRIPTION
mc's removal API trims implicitly created prefixes as part of removing the last object in that prefix. This can result in deleting an entire "path" if that path was created implicitly. 

`mc` *also* applies this logic to filesystem directories, which can result in aggressive trimming of directories. This has surprised some users in the past, as per  [mc issue 3621](https://github.com/minio/mc/issues/3621)

This PR documents the trimming behavior for those mc commands which rely on the remove API for normal operations. Specifically:

- `mc rm`
- `mc mv`
- `mc ilm`
- `mc mirror`

# Build Instructions

The MinIO docs require Python 3.9+ and Node for building. For Node, use v14.5.0 or later.

1) Clone the repo, Checkout the branch (`git checkout -B DOCS-324 origin/DOCS-324`)
2) Run `npm install` from the branch
3) Create a python venv (`python -m venv venv`)
4) Install requirements (`pip install -r requirements.txt`)
5) Run `make html`
6) Run `python -m http.server --directory build/DOCS-324/html`
7) Open 127.0.0.1:8000 in your browser and take a poke around.

If you run into an error running `python -m http.server` related to `--directory`, you're python version is likely older. CD into the `build/<branch>/html` directory and run the command without the `--directory` argument.

# Key URLS

- http://127.0.0.1:8000/reference/minio-cli/minio-mc/mc-mv.html#minio-trims-empty-prefixes-on-object-removal
- http://127.0.0.1:8000/reference/minio-cli/minio-mc/mc-rm.html#minio-trims-empty-prefixes-on-object-removal
- http://127.0.0.1:8000/reference/minio-cli/minio-mc/mc-mirror.html#minio-trims-empty-prefixes-on-object-removal
- http://127.0.0.1:8000/reference/minio-cli/minio-mc/mc-ilm.html#minio-trims-empty-prefixes-on-object-removal