### PR TITLE
Add new KMS encryption feature, deprecate MINIO_ACCESS_KEY and MINIO_…

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -53,17 +53,18 @@ extensions = [
 # Helpful for sites we tend to make lots of references to.
 
 extlinks = {
-    'kube-docs' : ('https://kubernetes.io/docs/%s', ''),
-    'minio-git' : ('https://github.com/minio/%s',''),
-    'github'    : ('https://github.com/%s',''),
-    'kube-api'  : ('https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/%s',''),
-    'aws-docs'  : ('https://docs.aws.amazon.com/%s',''),
-    's3-docs'   : ('https://docs.aws.amazon.com/AmazonS3/latest/userguide/%s',''),
-    's3-api'    : ('https://docs.aws.amazon.com/AmazonS3/latest/API/%s',''),
-    'iam-docs'  : ('https://docs.aws.amazon.com/IAM/latest/UserGuide/%s',''),
-    'release'   : ('https://github.com/minio/mc/releases/tag/%s',''),
-    'legacy'    : ('https://docs.min.io/docs/%s',''),
-    'docs-k8s'  : ('https://docs.min.io/minio/k8s/%s',''),
+    'kube-docs'       : ('https://kubernetes.io/docs/%s', ''),
+    'minio-git'       : ('https://github.com/minio/%s',''),
+    'github'          : ('https://github.com/%s',''),
+    'kube-api'        : ('https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/%s',''),
+    'aws-docs'        : ('https://docs.aws.amazon.com/%s',''),
+    's3-docs'         : ('https://docs.aws.amazon.com/AmazonS3/latest/userguide/%s',''),
+    's3-api'          : ('https://docs.aws.amazon.com/AmazonS3/latest/API/%s',''),
+    'iam-docs'        : ('https://docs.aws.amazon.com/IAM/latest/UserGuide/%s',''),
+    'minio-release'   : ('https://github.com/minio/minio/releases/tag/%s',''),
+    'mc-release'      : ('https://github.com/minio/mc/releases/tag/%s',''),
+    'legacy'          : ('https://docs.min.io/docs/%s',''),
+    'docs-k8s'        : ('https://docs.min.io/minio/k8s/%s',''),
 
 }
 

--- a/source/extra/examples/ConsoleAdmin.json
+++ b/source/extra/examples/ConsoleAdmin.json
@@ -1,0 +1,22 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "admin:*"
+            ],
+            "Effect": "Allow",
+            "Sid": ""
+        },
+        {
+            "Action": [
+                "s3:*"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::*"
+            ],
+            "Sid": ""
+        }
+    ]
+}

--- a/source/index.rst
+++ b/source/index.rst
@@ -68,9 +68,32 @@ such as versioning and replication.
 
       export MINIO_ROOT_USER_FILE=myminioaccesskey
       export MINIO_ROOT_PASSWORD_FILE=myminiosecretkey
-      export MINIO_KMS_SECRET_KEY=myminioencryptionkey
+      export MINIO_KMS_SECRET_KEY=my-minio-encryption-key:bXltaW5pb2VuY3J5cHRpb25rZXljaGFuZ2VtZTEyMwo=
 
       minio server /mnt/data
+
+   .. list-table::
+      :stub-columns: 1
+      :widths: 30 60
+      :width: 100%
+
+      * - :envvar:`MINIO_ROOT_USER_FILE`
+        - The :ref:`root user <minio-users-root>` access key. Replace the
+          sample value with a long, random, and unique string.
+
+      * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+        - The :ref:`root user <minio-users-root>` secret key. Replace the
+          sample value with a long, random, and unique string.
+
+      * - :envvar:`MINIO_KMS_SECRET_KEY`
+        - The encryption key for the MinIO IAM backend. Replace the
+          sample value with a 32-bit base-64 encoded value. For example,
+          use the following command to generate a random key:
+
+          .. code-block:: shell
+             :class: copyable
+
+             cat /dev/urandom`` | head -c 32 | base64 -
 
    MinIO by default listens on port ``9000``. Applications running on the
    same host can connect and perform S3 operations on the MinIO server
@@ -79,13 +102,6 @@ such as versioning and replication.
    You can also use the :mc:`mc` commandline tool to perform operations on the
    MinIO server. Use :mc:`mc alias set` to update the ``myminio`` alias with
    the access key and secret key set on the MinIO server.
-
-   For complete documentation on the environment variables specified above, see
-   the corresponding reference documentation:
-
-   - :envvar:`MINIO_ROOT_USER_FILE`
-   - :envvar:`MINIO_ROOT_PASSWORD_FILE`
-   - :envvar:`MINIO_KMS_SECRET_KEY`
 
 3\) Configure Console User for MinIO
    Create a a :ref:`policy <minio-policy>` and :ref:`user <minio-users>` for

--- a/source/index.rst
+++ b/source/index.rst
@@ -66,8 +66,8 @@ such as versioning and replication.
    .. code-block:: shell
       :class: copyable
 
-      export MINIO_ROOT_USER_FILE=myminioaccesskey
-      export MINIO_ROOT_PASSWORD_FILE=myminiosecretkey
+      export MINIO_ROOT_USER=myminioaccesskey
+      export MINIO_ROOT_PASSWORD=myminiosecretkey
       export MINIO_KMS_SECRET_KEY=my-minio-encryption-key:bXltaW5pb2VuY3J5cHRpb25rZXljaGFuZ2VtZTEyMwo=
 
       minio server /mnt/data
@@ -77,11 +77,11 @@ such as versioning and replication.
       :widths: 30 60
       :width: 100%
 
-      * - :envvar:`MINIO_ROOT_USER_FILE`
+      * - :envvar:`MINIO_ROOT_USER`
         - The :ref:`root user <minio-users-root>` access key. Replace the
           sample value with a long, random, and unique string.
 
-      * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+      * - :envvar:`MINIO_ROOT_PASSWORD`
         - The :ref:`root user <minio-users-root>` secret key. Replace the
           sample value with a long, random, and unique string.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -8,11 +8,124 @@ Welcome to the MinIO Documentation! MinIO is a high performance object storage
 solution with native support for Kubernetes deployments. MinIO provides an 
 Amazon Web Services S3-compatible API and supports all core S3 features. 
 
-First-time users of MinIO *or* object storage services should start with 
-our :doc:`Introduction </introduction/minio-overview>`.
+You can get started exploring MinIO features using our ``play`` server at
+https://play.min.io. ``play`` is a *public* MinIO cluster running the latest
+stable MinIO server. Any file uploaded to ``play`` should be considered public
+and non-protected.
 
-Users deploying onto a Kubernetes cluster should start with our 
-:docs-k8s:`Kubernetes documentation <>`.
+The MinIO Client :mc:`mc` commandline interface includes an
+:mc-cmd:`alias <mc alias>` for the ``play`` server. After 
+`Downloading the MinIO Client <https://min.io/downloads>`__, use the 
+``play`` alias to perform S3-compatible object storage operations:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc alias list play
+   mc mb --with-lock play/mynewbucket
+   mc cp ~/data/mytestdata play/mynewbucket
+
+See the :doc:`MinIO Client Complete Reference </reference/minio-cli/minio-mc>`
+for complete documentation on the available :mc:`mc` commands.
+
+- First-time users of MinIO *or* object storage services should start with 
+  our :doc:`Introduction </introduction/minio-overview>`.
+
+- Users deploying onto a Kubernetes cluster should start with our 
+  :docs-k8s:`Kubernetes documentation <>`.
+
+Quickstart
+----------
+
+The following steps deploys MinIO in filesystem mode with a single folder or
+disk on the local host. This deployment is best used for initial evaluation of
+MinIO S3-compatible object storage. Filesystem mode does not support features
+such as versioning and replication.
+
+1\) Create a Data Folder
+   Create a folder on the local drive for MinIO to use for object storag
+   operations. For example:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mkdir /mnt/data
+      sudo chmod -R 775 /mnt/data
+      
+2\) Download MinIO Server and Commandline Tools
+   Visit `https://min.io/downloads <https://min.io/downloads?ref=docs>`__ and
+   following the instructions for your host operating system to download and
+   configure the :mc:`minio` and :mc:`mc` binaries.  Consider adding the
+   ``minio`` and ``mc`` binaries to the operating system PATH for simplified
+   operations.
+
+   Follow the instructions on the download site to start the :mc:`minio server`
+   process. For example, the following command starts the
+   :mc:`minio server` using the created directory:
+
+   .. code-block:: shell
+      :class: copyable
+
+      export MINIO_ROOT_USER_FILE=myminioaccesskey
+      export MINIO_ROOT_PASSWORD_FILE=myminiosecretkey
+      export MINIO_KMS_SECRET_KEY=myminioencryptionkey
+
+      minio server /mnt/data
+
+   MinIO by default listens on port ``9000``. Applications running on the
+   same host can connect and perform S3 operations on the MinIO server
+   using the ``http://localhost:9000`` url.
+
+   You can also use the :mc:`mc` commandline tool to perform operations on the
+   MinIO server. Use :mc:`mc alias set` to update the ``myminio`` alias with
+   the access key and secret key set on the MinIO server.
+
+   For complete documentation on the environment variables specified above, see
+   the corresponding reference documentation:
+
+   - :envvar:`MINIO_ROOT_USER_FILE`
+   - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+   - :envvar:`MINIO_KMS_SECRET_KEY`
+
+3\) Configure Console User for MinIO
+   Create a a :ref:`policy <minio-policy>` and :ref:`user <minio-users>` for
+   supporting the :minio-git:`MinIO Console <console>`. The Console provides a
+   rich graphical user interface for interacting with the MinIO server.
+
+   The following command downloads the JSON policy file, creates the appropriate
+   policy, and assigns that policy to a user:
+
+   .. code-block:: shell
+      :class: copyable
+
+      wget -O - https://docs.min.io/minio/baremetal/examples/ConsoleAdmin.json | \
+      mc admin policy add myminio ConsoleAdminPolicy /dev/stdin
+      mc admin user add myminio consoleAdmin LongRandomSecretKey
+      mc admin policy set Alpha ConsoleAdminPolicy user=consoleAdmin
+
+4\) Install and run the MinIO Console
+   Download the :minio-git:`Latest Stable <console/releases/latest>` version
+   of MinIO Console for the host operating system.
+   
+   Set the ``CONSOLE_MINIO_SERVER`` environment variable with the
+   URL of the MinIO server:
+
+   .. code-block:: shell
+      :class: copyable
+
+      export CONSOLE_MINIO_SERVER=http://localhost:9000
+
+   Run the Console:
+
+   .. code-block:: shell
+      :class: copyable
+
+      ./console server
+
+5\) Open the MinIO Console
+   Open your browser and navigate to ``http://localhost:9090`` to access the
+   MinIO Console. Log in with the ``consoleAdmin`` access key and secret key to
+   begin interacting with the MinIO Tenant.
 
 .. toctree::
    :titlesonly:

--- a/source/reference/minio-cli/minio-mc.rst
+++ b/source/reference/minio-cli/minio-mc.rst
@@ -19,7 +19,9 @@ support for both filesystems and Amazon S3-compatible cloud storage services
 
 .. code-block:: shell
 
-   mc [FLAGS] COMMAND [COMMAND FLAGS | -h] [ARGUMENTS...] ALIAS
+   mc [FLAGS] COMMAND [ARGUMENTS...] [COMMAND FLAGS | -h] 
+
+See :ref:`minio-mc-commands` for a list of supported commands:
 
 .. _mc-install:
 
@@ -185,7 +187,7 @@ The following table lists :mc-cmd:`mc` commands:
      
    * - :mc:`mc lock`
      - Deprecated since 
-       :release:`RELEASE.2020-09-18T00-13-21Z`. Use :mc:`mc retention`.
+       :mc-release:`RELEASE.2020-09-18T00-13-21Z`. Use :mc:`mc retention`.
 
    * - :mc:`mc ls`
      - .. include:: /reference/minio-cli/minio-mc/mc-ls.rst

--- a/source/reference/minio-cli/minio-mc/mc-lock.rst
+++ b/source/reference/minio-cli/minio-mc/mc-lock.rst
@@ -20,7 +20,7 @@ object retention for a configurable period of time.
 .. admonition:: DEPRECATED
    :class: important
 
-   :mc:`mc lock` was deprecated in :release:`RELEASE.2020-09-18T00-13-21Z`. Use
+   :mc:`mc lock` was deprecated in :mc-release:`RELEASE.2020-09-18T00-13-21Z`. Use
    :mc:`mc retention` to set, retrieve, or clear the bucket default object lock
    configuration.
 

--- a/source/reference/minio-cli/minio-mc/mc-retention.rst
+++ b/source/reference/minio-cli/minio-mc/mc-retention.rst
@@ -24,7 +24,7 @@ object lock settings inherit the bucket default.
 
 .. note::
 
-   Starting in version :release:`RELEASE.2020-09-18T00-13-21Z`, 
+   Starting in version :mc-release:`RELEASE.2020-09-18T00-13-21Z`, 
    :mc:`mc retention` fully replaces :mc:`mc lock` for setting the default 
    object lock settings for a bucket.
 
@@ -385,7 +385,7 @@ Syntax
       If specifying :mc-cmd-option:`~mc retention set default`, 
       :mc-cmd:`mc retention set` ignores all other flags.
 
-      Starting in :release:`RELEASE.2020-09-18T00-13-21Z`, 
+      Starting in :mc-release:`RELEASE.2020-09-18T00-13-21Z`, 
       :mc-cmd-option:`mc retention set default` replaces the functionality of
       the deprecated :mc-cmd:`mc lock` command.
 
@@ -482,7 +482,7 @@ Syntax
       If specifying :mc-cmd-option:`~mc retention info default`, 
       :mc-cmd:`mc retention info` ignores all other flags.
 
-      Starting in :release:`RELEASE.2020-09-18T00-13-21Z`, 
+      Starting in :mc-release:`RELEASE.2020-09-18T00-13-21Z`, 
       :mc-cmd-option:`mc retention info default` replaces the functionality of
       the deprecated :mc-cmd:`mc lock` command.
 
@@ -576,7 +576,7 @@ Syntax
       If specifying :mc-cmd-option:`~mc retention clear default`, 
       :mc-cmd:`mc retention clear` ignores all other flags.
 
-      Starting in :release:`RELEASE.2020-09-18T00-13-21Z`, 
+      Starting in :mc-release:`RELEASE.2020-09-18T00-13-21Z`, 
       :mc-cmd-option:`mc retention clear default` replaces the functionality of
       the deprecated :mc-cmd:`mc lock` command.
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -277,8 +277,7 @@ Key Management Service and Encryption
 
    The private key associated to the the :envvar:`MINIO_KMS_KES_CERT_FILE` 
    x.509 certificate to use when authenticating to the KES server. 
-   The KES server requires clients to present both their certificate and
-   private key for performing mutual TLS (mTLS).
+   The KES server requires clients to present their certificate for performing mutual TLS (mTLS).
 
    See the :minio-git:`KES wiki <kes/wiki/Configuration#policy-configuration>` 
    for more complete documentation on KES access control.
@@ -286,8 +285,7 @@ Key Management Service and Encryption
 .. envvar:: MINIO_KMS_KES_CERT_FILE
 
    The x.509 certificate to present to the KES server. 
-   The KES server requires clients to present both their certificate and
-   private key for performing mutual TLS (mTLS).
+   The KES server requires clients to present their certificate and for performing mutual TLS (mTLS).
 
    The KES server computes an 
    :minio-git:`identity <kes/wiki/Configuration#policy-configuration>`
@@ -301,7 +299,7 @@ Key Management Service and Encryption
 
 .. envvar:: MINIO_KMS_KES_KEY_NAME
 
-   The name of an external ke to retrieve from the Key Management System (KMS)
+   The name of an external key at the Key Management System (KMS) to perform en/decryption operations
    configured on the KES server. MinIO uses this key for supporting
    server-side encryption of objects (SSE-S3) and MinIO backend encryption.
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -175,31 +175,31 @@ environment variables during startup to set configuration settings.
 Root Credentials
 ~~~~~~~~~~~~~~~~
 
-.. envvar:: MINIO_ROOT_USER_FILE
+.. envvar:: MINIO_ROOT_USER
 
    The access key for the :ref:`root <minio-users-root>` user.
 
    .. warning::
 
-      If :envvar:`MINIO_ROOT_USER_FILE` is unset, 
+      If :envvar:`MINIO_ROOT_USER` is unset, 
       :mc:`minio` defaults to ``minioadmin``.
 
       **NEVER** use the default credentials in production environments. 
       MinIO strongly recommends specifying a unique, long, and random
-      :envvar:`MINIO_ROOT_USER_FILE` value for all environments.
+      :envvar:`MINIO_ROOT_USER` value for all environments.
 
-.. envvar:: MINIO_ROOT_PASSWORD_FILE
+.. envvar:: MINIO_ROOT_PASSWORD
 
    The access key for the :ref:`root <minio-users-root>` user.
 
    .. warning::
 
-      If :envvar:`MINIO_ROOT_PASSWORD_FILE` is unset, 
+      If :envvar:`MINIO_ROOT_PASSWORD` is unset, 
       :mc:`minio` defaults to ``minioadmin``.
 
       **NEVER** use the default credentials in production environments. 
       MinIO strongly recommends specifying a unique, long, and random
-      :envvar:`MINIO_ROOT_PASSWORD_FILE` value for all environments.
+      :envvar:`MINIO_ROOT_PASSWORD` value for all environments.
 
 .. envvar:: MINIO_ACCESS_KEY
 
@@ -208,7 +208,7 @@ Root Credentials
    The access key for the :ref:`root <minio-users-root>` user. 
 
    This environment variable is *deprecated* in favor of the 
-   :envvar:`MINIO_ROOT_USER_FILE` environment variable. 
+   :envvar:`MINIO_ROOT_USER` environment variable. 
 
    .. warning::
 
@@ -226,7 +226,7 @@ Root Credentials
    The secret key for the :ref:`root <minio-users-root>` user.
 
    This environment variable is *deprecated* in favor of the
-   :envvar:`MINIO_ROOT_PASSWORD_FILE` environment variable.
+   :envvar:`MINIO_ROOT_PASSWORD` environment variable.
 
    .. warning::
 
@@ -242,7 +242,7 @@ Root Credentials
    .. deprecated:: RELEASE.2021-04-22T15-44-28Z
 
    To perform root credential rotation, modify the
-   :envvar:`MINIO_ROOT_USER_FILE` and `MINIO_ROOT_PASSWORD_FILE` environment
+   :envvar:`MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` environment
    variables.
 
 .. envvar:: MINIO_SECRET_KEY_OLD
@@ -250,7 +250,7 @@ Root Credentials
    .. deprecated:: RELEASE.2021-04-22T15-44-28Z
 
    To perform root credential rotation, modify the
-   :envvar:`MINIO_ROOT_USER_FILE` and `MINIO_ROOT_PASSWORD_FILE` environment
+   :envvar:`MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` environment
    variables.
 
 Key Management Service and Encryption

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -265,6 +265,22 @@ Key Management Service and Encryption
    See :minio-git:`KMS IAM/Config Encryption
    <minio/blob/master/docs/kms/IAM.md>` for more information.
 
+   Specify a 32-bit base-64 encrypted string in the following format:
+
+   ``<key-name>:<encryption-string>``
+
+   - Replace the ``<key-name>`` with any string. You must use this
+     key name if you later migrate to using a dedicated KMS for 
+     managing encryption keys.
+
+   - Replace ``<encryption-key>`` with a 32-bit base64 encoded value.
+     For example:
+
+     .. code-block:: shell
+        :class: copyable
+
+        cat /dev/urandom | head -c 32 | base64 -
+
    Prior to :minio-release:`RELEASE.2021-04-22T15-44-28Z`, MinIO used the
    :ref:`root <minio-users-root>` user credentials for encrypting the backend. 
 
@@ -275,17 +291,18 @@ Key Management Service and Encryption
 
 .. envvar:: MINIO_KMS_KES_KEY_FILE
 
-   The private key associated to the the :envvar:`MINIO_KMS_KES_CERT_FILE` 
-   x.509 certificate to use when authenticating to the KES server. 
-   The KES server requires clients to present their certificate for performing mutual TLS (mTLS).
+   The private key associated to the the :envvar:`MINIO_KMS_KES_CERT_FILE` x.509
+   certificate to use when authenticating to the KES server. The KES server
+   requires clients to present their certificate for performing mutual TLS
+   (mTLS).
 
    See the :minio-git:`KES wiki <kes/wiki/Configuration#policy-configuration>` 
    for more complete documentation on KES access control.
 
 .. envvar:: MINIO_KMS_KES_CERT_FILE
 
-   The x.509 certificate to present to the KES server. 
-   The KES server requires clients to present their certificate and for performing mutual TLS (mTLS).
+   The x.509 certificate to present to the KES server. The KES server requires
+   clients to present their certificate for performing mutual TLS (mTLS).
 
    The KES server computes an 
    :minio-git:`identity <kes/wiki/Configuration#policy-configuration>`
@@ -299,10 +316,10 @@ Key Management Service and Encryption
 
 .. envvar:: MINIO_KMS_KES_KEY_NAME
 
-   The name of an external key at the Key Management System (KMS) to perform en/decryption operations
-   configured on the KES server. MinIO uses this key for supporting
-   server-side encryption of objects (SSE-S3) and MinIO backend encryption.
-
+   The name of an external key on the Key Management system (KMS) configured on
+   the KES server and used for performing en/decryption operations. MinIO uses
+   this key for supporting server-side encryption of objects (SSE-S3) and MinIO
+   backend encryption.
 
 Storage Class
 ~~~~~~~~~~~~~

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -175,9 +175,40 @@ environment variables during startup to set configuration settings.
 Root Credentials
 ~~~~~~~~~~~~~~~~
 
+.. envvar:: MINIO_ROOT_USER_FILE
+
+   The access key for the :ref:`root <minio-users-root>` user.
+
+   .. warning::
+
+      If :envvar:`MINIO_ROOT_USER_FILE` is unset, 
+      :mc:`minio` defaults to ``minioadmin``.
+
+      **NEVER** use the default credentials in production environments. 
+      MinIO strongly recommends specifying a unique, long, and random
+      :envvar:`MINIO_ROOT_USER_FILE` value for all environments.
+
+.. envvar:: MINIO_ROOT_PASSWORD_FILE
+
+   The access key for the :ref:`root <minio-users-root>` user.
+
+   .. warning::
+
+      If :envvar:`MINIO_ROOT_PASSWORD_FILE` is unset, 
+      :mc:`minio` defaults to ``minioadmin``.
+
+      **NEVER** use the default credentials in production environments. 
+      MinIO strongly recommends specifying a unique, long, and random
+      :envvar:`MINIO_ROOT_PASSWORD_FILE` value for all environments.
+
 .. envvar:: MINIO_ACCESS_KEY
 
+   .. deprecated:: RELEASE.2021-04-22T15-44-28Z
+
    The access key for the :ref:`root <minio-users-root>` user. 
+
+   This environment variable is *deprecated* in favor of the 
+   :envvar:`MINIO_ROOT_USER_FILE` environment variable. 
 
    .. warning::
 
@@ -190,7 +221,12 @@ Root Credentials
 
 .. envvar:: MINIO_SECRET_KEY
 
+   .. deprecated:: RELEASE.2021-04-22T15-44-28Z
+
    The secret key for the :ref:`root <minio-users-root>` user.
+
+   This environment variable is *deprecated* in favor of the
+   :envvar:`MINIO_ROOT_PASSWORD_FILE` environment variable.
 
    .. warning::
 
@@ -203,39 +239,72 @@ Root Credentials
 
 .. envvar:: MINIO_ACCESS_KEY_OLD
 
-   Used for rotating the :ref:`root <minio-users-root>` user access
-   key.
+   .. deprecated:: RELEASE.2021-04-22T15-44-28Z
 
-   Restart the :mc:`minio server` process with *all* of the following
-   environment variables to rotate the root credentials:
-
-   - :envvar:`MINIO_ACCESS_KEY_OLD` set to the old access key.
-   - :envvar:`MINIO_ACCESS_KEY` set to the new access key.
-   - :envvar:`MINIO_SECRET_KEY_OLD` set to the old secret key.
-   - :envvar:`MINIO_SECRET_KEY` set to the new secret key.
-
-   The :mc:`minio server` process automatically detects and re-encrypts 
-   the server configuration with the new credentials. After the process
-   restarts successfully, you can restart it without 
-   :envvar:`MINIO_ACCESS_KEY_OLD`.
+   To perform root credential rotation, modify the
+   :envvar:`MINIO_ROOT_USER_FILE` and `MINIO_ROOT_PASSWORD_FILE` environment
+   variables.
 
 .. envvar:: MINIO_SECRET_KEY_OLD
 
-   Used for rotating the :ref:`root <minio-users-root>` user secret
-   key.
+   .. deprecated:: RELEASE.2021-04-22T15-44-28Z
 
-   Restart the :mc:`minio server` process with *all* of the following
-   environment variables to rotate the root credentials:
+   To perform root credential rotation, modify the
+   :envvar:`MINIO_ROOT_USER_FILE` and `MINIO_ROOT_PASSWORD_FILE` environment
+   variables.
 
-   - :envvar:`MINIO_ACCESS_KEY_OLD` set to the old access key.
-   - :envvar:`MINIO_ACCESS_KEY` set to the new access key.
-   - :envvar:`MINIO_SECRET_KEY_OLD` set to the old secret key.
-   - :envvar:`MINIO_SECRET_KEY` set to the new secret key.
+Key Management Service and Encryption
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   The :mc:`minio server` process automatically detects and re-encrypts 
-   the server configuration with the new credentials. After the process
-   restarts successfully, you can restart it without 
-   :envvar:`MINIO_SECRET_KEY_OLD`.
+.. envvar:: MINIO_KMS_SECRET_KEY
+
+   .. versionadded:: RELEASE.2021-04-22T15-44-28Z
+
+   The client-provided encryption key to use for encrypting the
+   MinIO backend (users, groups, policies, and server configuration).
+   See :minio-git:`KMS IAM/Config Encryption
+   <minio/blob/master/docs/kms/IAM.md>` for more information.
+
+   Prior to :minio-release:`RELEASE.2021-04-22T15-44-28Z`, MinIO used the
+   :ref:`root <minio-users-root>` user credentials for encrypting the backend. 
+
+.. envvar:: MINIO_KMS_KES_ENDPOINT
+
+   The endpoint for the MinIO Key Encryption Service (KES) process to use
+   for supporting SSE-S3 and MinIO backend encryption operations.
+
+.. envvar:: MINIO_KMS_KES_KEY_FILE
+
+   The private key associated to the the :envvar:`MINIO_KMS_KES_CERT_FILE` 
+   x.509 certificate to use when authenticating to the KES server. 
+   The KES server requires clients to present both their certificate and
+   private key for performing mutual TLS (mTLS).
+
+   See the :minio-git:`KES wiki <kes/wiki/Configuration#policy-configuration>` 
+   for more complete documentation on KES access control.
+
+.. envvar:: MINIO_KMS_KES_CERT_FILE
+
+   The x.509 certificate to present to the KES server. 
+   The KES server requires clients to present both their certificate and
+   private key for performing mutual TLS (mTLS).
+
+   The KES server computes an 
+   :minio-git:`identity <kes/wiki/Configuration#policy-configuration>`
+   from the certificate and compares it to its configured    
+   policies. The KES server grants the
+   :mc:`minio` server access to only those operations explicitly granted by the
+   policy.
+
+   See the :minio-git:`KES wiki <kes/wiki/Configuration#policy-configuration>`
+   for more complete documentation on KES access control.
+
+.. envvar:: MINIO_KMS_KES_KEY_NAME
+
+   The name of an external ke to retrieve from the Key Management System (KMS)
+   configured on the KES server. MinIO uses this key for supporting
+   server-side encryption of objects (SSE-S3) and MinIO backend encryption.
+
 
 Storage Class
 ~~~~~~~~~~~~~

--- a/source/security/IAM/iam-users.rst
+++ b/source/security/IAM/iam-users.rst
@@ -86,19 +86,11 @@ MinIO deployments have a ``root`` user with access to all actions and resources
 on the deployment. When a :mc:`minio` server first starts, it sets the ``root``
 user credentials by checking the value of the following environment variables:
 
-- :envvar:`MINIO_ACCESS_KEY`
-- :envvar:`MINIO_SECRET_KEY`
+- :envvar:`MINIO_ROOT_USER_FILE`
+- :envvar:`MINIO_ROOT_PASSWORD_FILE`
 
-To rotate the ``root`` user credentials, set the following environment 
-variables and restart the :mc:`minio` server:
-
-- :envvar:`MINIO_ACCESS_KEY` to the new access key.
-- :envvar:`MINIO_SECRET_KEY` to the new secret key.
-- :envvar:`MINIO_ACCESS_KEY_OLD` to the old access key.
-- :envvar:`MINIO_SECRET_KEY_OLD` to the old secret key.
-
-After the :mc:`minio` server starts successfully, you can unset the
-:envvar:`MINIO_ACCESS_KEY_OLD` and :envvar:`MINIO_SECRET_KEY_OLD`. 
+Rotating the root user credentials requires updating either or both 
+variables for all MinIO servers in the deployment.
 
 When specifying the ``root`` access key and secret key, consider using *long,
 unique, and random* strings. Exercise all possible precautions in storing the
@@ -118,11 +110,44 @@ If these variables are unset, :mc:`minio` defaults to ``minioadmin`` and
 discourages* use of the default credentials regardless of deployment
 environment.
 
+MinIO :minio-release:`RELEASE.2021-04-22T15-44-28Z` and later deprecates the
+following variables used for setting or updating root user
+credentials:
+
+- :envvar:`MINIO_ACCESS_KEY` to the new access key.
+- :envvar:`MINIO_SECRET_KEY` to the new secret key.
+- :envvar:`MINIO_ACCESS_KEY_OLD` to the old access key.
+- :envvar:`MINIO_SECRET_KEY_OLD` to the old secret key.
+
 Create a User
 -------------
 
 Use the :mc-cmd:`mc admin user add` command to create a new user on the
 MinIO deployment:
+
+.. code-block:: shell
+   :class: copyable
+
+      mc admin user add ALIAS ACCESSKEY SECRETKEY
+
+- Replace :mc-cmd:`ALIAS <mc admin user add TARGET>` with the
+  :mc-cmd:`alias <mc alias>` of the MinIO deployment.
+
+- Replace :mc-cmd:`ACCESSKEY <mc admin user add ACCESSKEY>` with the 
+  access key for the user. MinIO allows retrieving the access key after
+  user creation through the :mc-cmd:`mc admin user info` command.
+
+- Replace :mc-cmd:`SECRETKEY <mc admin user add SECRETKEY>` with the
+  secret key for the user. MinIO *does not* provide any method for retrieving
+  the secret key once set.
+
+Specify a unique, random, and long string for both the ``ACCESSKEY`` and 
+``SECRETKEY``. Your organization may have specific internal or regulatory
+requirements around generating values for use with access or secret keys. 
+
+After creating the user, use :mc-cmd:`mc admin policy set` to associate 
+a :ref:`minio-policy` to the new user. You can also use
+:mc-cmd:`mc admin group add` to add the user to a :ref:`minio-groups`.
 
 Delete a User
 -------------
@@ -130,9 +155,13 @@ Delete a User
 Use the :mc-cmd:`mc admin user remove` command to remove a user on a 
 MinIO deployment:
 
-Authenticate as a User
-----------------------
+.. code-block:: shell
+   :class: copyable
 
-ToDo: Examples of authenticating to a MinIO deployment with a created user. 
+   mc admin user remove ALIAS USERNAME
 
-Should have examples with `mc` and each of the SDKs. 
+- Replace :mc-cmd:`ALIAS <mc admin user remove TARGET>` with the
+  :mc-cmd:`alias <mc alias>` of the MinIO deployment.
+
+- Replace :mc-cmd:`USERNAME <mc admin user remove USERNAME>` with the name of
+  the user to remove.

--- a/source/security/IAM/iam-users.rst
+++ b/source/security/IAM/iam-users.rst
@@ -86,8 +86,8 @@ MinIO deployments have a ``root`` user with access to all actions and resources
 on the deployment. When a :mc:`minio` server first starts, it sets the ``root``
 user credentials by checking the value of the following environment variables:
 
-- :envvar:`MINIO_ROOT_USER_FILE`
-- :envvar:`MINIO_ROOT_PASSWORD_FILE`
+- :envvar:`MINIO_ROOT_USER`
+- :envvar:`MINIO_ROOT_PASSWORD`
 
 Rotating the root user credentials requires updating either or both 
 variables for all MinIO servers in the deployment.

--- a/source/tutorials/minio-installation.rst
+++ b/source/tutorials/minio-installation.rst
@@ -71,8 +71,8 @@ procedure.
    .. code-block:: shell
       :class: copyable
 
-      export MINIO_ROOT_USER_FILE=minio-admin
-      export MINIO_ROOT_PASSWORD_FILE=minio-secret-key-CHANGE-ME
+      export MINIO_ROOT_USER=minio-admin
+      export MINIO_ROOT_PASSWORD=minio-secret-key-CHANGE-ME
       export MINIO_KMS_SECRET_KEY=my-minio-encryption-key:bXltaW5pb2VuY3J5cHRpb25rZXljaGFuZ2VtZTEyMwo=
 
       minio server https://minio{1...4}.example.com/mnt/disk{1...4}/data
@@ -83,12 +83,12 @@ procedure.
       :widths: 40 60
       :width: 100%
 
-      * - :envvar:`MINIO_ROOT_USER_FILE`
+      * - :envvar:`MINIO_ROOT_USER`
         - The access key for the :ref:`root <minio-users-root>` user.
 
           Replace this value with a unique, random, and long string. 
 
-      * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+      * - :envvar:`MINIO_ROOT_PASSWORD`
         - The corresponding secret key to use for the 
           :ref:`root <minio-users-root>` user.
 
@@ -171,7 +171,7 @@ version of the ``minio`` server process:
    docker run -p 9000:9000 \
    -e "MINIO_ROOT_USER_FILE=ROOT_ACCESS_KEY" \
    -e "MINIO_ROOT_PASSWORD_FILE=SECRET_ACCESS_KEY_CHANGE_ME" \
-   -e "MINIO_KMS_SECRET_KEY=my-minio-encryption-key:bXltaW5pb2VuY3J5cHRpb25rZXljaGFuZ2VtZTEyMwo=" \
+   -e "MINIO_KMS_SECRET_KEY_FILE=my-minio-encryption-key:bXltaW5pb2VuY3J5cHRpb25rZXljaGFuZ2VtZTEyMwo=" \
    -v /mnt/disk1:/disk1 \
    -v /mnt/disk2:/disk2 \
    -v /mnt/disk3:/disk3 \
@@ -184,20 +184,20 @@ The command uses the following options:
    :widths: 40 60
    :width: 100%
 
-   * - :envvar:`MINIO_ROOT_USER_FILE`
+   * - :envvar:`MINIO_ROOT_USER_FILE <MINIO_ROOT_USER>`
      - The access key for the :ref:`root <minio-users-root>` user.
 
        Replace this value with a unique, random, and long string. 
 
-   * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+   * - :envvar:`MINIO_ROOT_PASSWORD_FILE <MINIO_ROOT_PASSWORD>`
      - The corresponding secret key to use for the 
        :ref:`root <minio-users-root>` user.
 
        Replace this value with a unique, random, and long string.
 
-   * - :envvar:`MINIO_KMS_SECRET_KEY`
-     - The key to use for encrypting the MinIO backend (S3 objects, users, groups,
-       policies, and server configuration).
+   * - :envvar:`MINIO_KMS_SECRET_KEY_FILE <MINIO_KMS_SECRET_KEY>`
+     - The key to use for encrypting the MinIO backend (S3 objects, users,
+       groups, policies, and server configuration).
 
        Use the following format when specifying the encryption key:
 
@@ -232,7 +232,7 @@ bleeding-edge version of the ``minio`` server process:
    docker run -p 9000:9000 \
    -e "MINIO_ROOT_USER_FILE=ROOT_ACCESS_KEY" \
    -e "MINIO_ROOT_PASSWORD_FILE=SECRET_ACCESS_KEY_CHANGE_ME" \
-   -e "MINIO_KMS_SECRET_KEY=my-minio-encryption-key:bXltaW5pb2VuY3J5cHRpb25rZXljaGFuZ2VtZTEyMwo=" \
+   -e "MINIO_KMS_SECRET_KEY_FILE=my-minio-encryption-key:bXltaW5pb2VuY3J5cHRpb25rZXljaGFuZ2VtZTEyMwo=" \
    -v /mnt/disk1:/disk1 \
    -v /mnt/disk2:/disk2 \
    -v /mnt/disk3:/disk3 \
@@ -245,20 +245,20 @@ The command uses the following options:
    :widths: 40 60
    :width: 100%
 
-   * - :envvar:`MINIO_ROOT_USER_FILE`
+   * - :envvar:`MINIO_ROOT_USER_FILE <MINIO_ROOT_USER>`
      - The access key for the :ref:`root <minio-users-root>` user.
 
        Replace this value with a unique, random, and long string. 
 
-   * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+   * - :envvar:`MINIO_ROOT_PASSWORD_FILE <MINIO_ROOT_PASSWORD>`
      - The corresponding secret key to use for the 
        :ref:`root <minio-users-root>` user.
 
        Replace this value with a unique, random, and long string.
 
-   * - :envvar:`MINIO_KMS_SECRET_KEY`
-     - The key to use for encrypting the MinIO backend (users, groups,
-       policies, and server configuration).
+   * - :envvar:`MINIO_KMS_SECRET_KEY_FILE <MINIO_KMS_SECRET_KEY>`
+     - The key to use for encrypting the MinIO backend (S3 objects, users,
+       groups, policies, and server configuration).
 
        Replace this value with a 32-bit base64-encrypted string:
 
@@ -325,8 +325,8 @@ environments.
    .. code-block:: shell
       :class: copyable
 
-      export MINIO_ROOT_USER_FILE=minio-admin
-      export MINIO_ROOT_PASSWORD_FILE=minio-secret-key-CHANGE-ME
+      export MINIO_ROOT_USER=minio-admin
+      export MINIO_ROOT_PASSWORD=minio-secret-key-CHANGE-ME
       export MINIO_KMS_SECRET_KEY=my-minio-encryption-key:bXltaW5pb2VuY3J5cHRpb25rZXljaGFuZ2VtZTEyMwo=
 
       minio server /mnt/disk{1...4}/data
@@ -337,12 +337,12 @@ environments.
       :widths: 40 60
       :width: 100%
 
-      * - :envvar:`MINIO_ROOT_USER_FILE`
+      * - :envvar:`MINIO_ROOT_USER`
         - The access key for the :ref:`root <minio-users-root>` user.
 
           Replace this value with a unique, random, and long string. 
 
-      * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+      * - :envvar:`MINIO_ROOT_PASSWORD`
         - The corresponding secret key to use for the 
           :ref:`root <minio-users-root>` user.
 

--- a/source/tutorials/minio-installation.rst
+++ b/source/tutorials/minio-installation.rst
@@ -58,7 +58,21 @@ procedure.
       products and services, and is not intended as a complete guide to the larger
       topic of TLS/SSL certificate creation and management.
 
-3\) Run the ``minio`` Server
+3\) Generate an Encryption Key for the MinIO Backend
+   Starting in the :minio-release:`RELEASE.2021-04-22T15-44-28Z` release, MinIO
+   requires a user-specified encryption key or Key Management System (KMS) for
+   encrypting the backend (users, groups, policies, and server configuration). 
+
+   Generate a 256-bit encryption key and encode it as a base64 string:
+
+   .. code-block:: shell
+      :class: copyable
+
+      cat /dev/urandom | head -c 32 | base64 -
+
+   Copy the value for use in the next step.
+
+4\) Run the ``minio`` Server
    Issue the following command on each host machine in the deployment. The
    following example assumes that:
 
@@ -71,8 +85,9 @@ procedure.
    .. code-block:: shell
       :class: copyable
 
-      export MINIO_ACCESS_KEY=minio-admin
-      export MINIO_SECRET_KEY=minio-secret-key-CHANGE-ME
+      export MINIO_ROOT_USER_FILE=minio-admin
+      export MINIO_ROOT_PASSWORD_FILE=minio-secret-key-CHANGE-ME
+      export MINIO_KMS_SECRET_KEY=base64encoded256bitkey
       minio server https://minio{1...4}.example.com/mnt/disk{1...4}/data
 
    The example command breaks down as follows:
@@ -81,16 +96,20 @@ procedure.
       :widths: 40 60
       :width: 100%
 
-      * - :envvar:`MINIO_ACCESS_KEY`
+      * - :envvar:`MINIO_ROOT_USER_FILE`
         - The access key for the :ref:`root <minio-users-root>` user.
 
           Replace this value with a unique, random, and long string. 
 
-      * - :envvar:`MINIO_SECRET_KEY`
+      * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
         - The corresponding secret key to use for the 
           :ref:`root <minio-users-root>` user.
 
           Replace this value with a unique, random, and long string.
+
+      * - :envvar:`MINIO_KMS_SECRET_KEY`
+        - The key to use for encrypting the MinIO backend (users, groups,
+          policies, and server configuration).
 
       * - ``https://minio{1...4}.example.com/``
         - The DNS hostname of each server in the distributed deployment. 
@@ -147,8 +166,9 @@ version of the ``minio`` server process:
    :class: copyable
 
    docker run -p 9000:9000 \
-   -e "MINIO_ACCESS_KEY=ROOT_ACCESS_KEY" \
-   -e "MINIO_SECRET_KEY=SECRET_ACCESS_KEY_CHANGE_ME" \
+   -e "MINIO_ROOT_USER_FILE=ROOT_ACCESS_KEY" \
+   -e "MINIO_ROOT_PASSWORD_FILE=SECRET_ACCESS_KEY_CHANGE_ME" \
+   -e "MINIO_KMS_SECRET_KEY=base64encoded256bitkey" \
    -v /mnt/disk1:/disk1 \
    -v /mnt/disk2:/disk2 \
    -v /mnt/disk3:/disk3 \
@@ -157,11 +177,34 @@ version of the ``minio`` server process:
 
 The command uses the following options:
 
-- ``-e MINIO_ACCESS_KEY`` and ``-e MINIO_SECRET_KEY`` for configuring the
-   :ref:`root <minio-users-root>` user credentials.
+.. list-table::
+   :widths: 40 60
+   :width: 100%
 
-- ``-v /mnt/disk<int>:/disk<int>`` for configuring each disk the ``minio``
-   server uses.
+   * - :envvar:`MINIO_ROOT_USER_FILE`
+     - The access key for the :ref:`root <minio-users-root>` user.
+
+       Replace this value with a unique, random, and long string. 
+
+   * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+     - The corresponding secret key to use for the 
+       :ref:`root <minio-users-root>` user.
+
+       Replace this value with a unique, random, and long string.
+
+   * - :envvar:`MINIO_KMS_SECRET_KEY`
+     - The key to use for encrypting the MinIO backend (users, groups,
+       policies, and server configuration).
+
+       Replace this value with a 256-bit base64-encrypted string:
+
+       .. code-block:: shell
+         :class: copyable
+ 
+         cat /dev/urandom | head -c 32 | base64 -
+
+   * - ``-v /mnt/disk<int>:/disk<int>`` 
+     - The path to each each disk the ``minio`` server uses. 
 
 Bleeding Edge MinIO
 ~~~~~~~~~~~~~~~~~~~
@@ -175,8 +218,9 @@ bleeding-edge version of the ``minio`` server process:
    :class: copyable
 
    docker run -p 9000:9000 \
-   -e "MINIO_ACCESS_KEY=ROOT_ACCESS_KEY" \
-   -e "MINIO_SECRET_KEY=SECRET_ACCESS_KEY_CHANGE_ME" \
+   -e "MINIO_ROOT_USER_FILE=ROOT_ACCESS_KEY" \
+   -e "MINIO_ROOT_PASSWORD_FILE=SECRET_ACCESS_KEY_CHANGE_ME" \
+   -e "MINIO_KMS_SECRET_KEY=base64encoded256bitkey" \
    -v /mnt/disk1:/disk1 \
    -v /mnt/disk2:/disk2 \
    -v /mnt/disk3:/disk3 \
@@ -185,11 +229,34 @@ bleeding-edge version of the ``minio`` server process:
 
 The command uses the following options:
 
-- ``MINIO_ACCESS_KEY`` and ``MINIO_SECRET_KEY`` for configuring the
-   :ref:`root <minio-users-root>` user credentials.
+.. list-table::
+   :widths: 40 60
+   :width: 100%
 
-- ``-v /mnt/disk<int>:/disk<int>`` for configuring each disk the ``minio`` 
-   server uses. 
+   * - :envvar:`MINIO_ROOT_USER_FILE`
+     - The access key for the :ref:`root <minio-users-root>` user.
+
+       Replace this value with a unique, random, and long string. 
+
+   * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
+     - The corresponding secret key to use for the 
+       :ref:`root <minio-users-root>` user.
+
+       Replace this value with a unique, random, and long string.
+
+   * - :envvar:`MINIO_KMS_SECRET_KEY`
+     - The key to use for encrypting the MinIO backend (users, groups,
+       policies, and server configuration).
+
+       Replace this value with a 256-bit base64-encrypted string:
+
+       .. code-block:: shell
+         :class: copyable
+ 
+         cat /dev/urandom | head -c 32 | base64 -
+
+   * - ``-v /mnt/disk<int>:/disk<int>`` 
+     - The path to each each disk the ``minio`` server uses. 
 
 Standalone Installation
 -----------------------
@@ -222,7 +289,21 @@ environments.
       products and services, and is not intended as a complete guide to the larger
       topic of TLS/SSL certificate creation and management.
 
-3\) Run the ``minio`` Server
+3\) Generate an Encryption Key for the MinIO Backend
+   Starting in the :minio-release:`RELEASE.2021-04-22T15-44-28Z` release, MinIO
+   requires a user-specified encryption key or Key Management System (KMS) for
+   encrypting the backend (users, groups, policies, and server configuration). 
+
+   Generate a 256-bit encryption key and encode it as a base64 string:
+
+   .. code-block:: shell
+      :class: copyable
+
+      cat /dev/urandom | head -c 32 | base64 -
+
+   Copy the value for use in the next step.
+
+4\) Run the ``minio`` Server
    Issue the following command to start the :program:`minio` server. The following
    example assumes the host machine has *at least* four disks, which is the minimum
    required number of disks to enable :ref:`erasure coding <minio-erasure-coding>`:
@@ -230,8 +311,8 @@ environments.
    .. code-block:: shell
       :class: copyable
 
-      export MINIO_ACCESS_KEY=minio-admin
-      export MINIO_SECRET_KEY=minio-secret-key-CHANGE-ME
+      export MINIO_ROOT_USER_FILE=minio-admin
+      export MINIO_ROOT_PASSWORD_FILE=minio-secret-key-CHANGE-ME
       minio server /mnt/disk{1...4}/data
 
    The example command breaks down as follows:
@@ -240,12 +321,12 @@ environments.
       :widths: 40 60
       :width: 100%
 
-      * - :envvar:`MINIO_ACCESS_KEY`
+      * - :envvar:`MINIO_ROOT_USER_FILE`
         - The access key for the :ref:`root <minio-users-root>` user.
 
           Replace this value with a unique, random, and long string. 
 
-      * - :envvar:`MINIO_SECRET_KEY`
+      * - :envvar:`MINIO_ROOT_PASSWORD_FILE`
         - The corresponding secret key to use for the 
           :ref:`root <minio-users-root>` user.
 

--- a/source/tutorials/minio-installation.rst
+++ b/source/tutorials/minio-installation.rst
@@ -193,7 +193,7 @@ The command uses the following options:
        Replace this value with a unique, random, and long string.
 
    * - :envvar:`MINIO_KMS_SECRET_KEY`
-     - The key to use for encrypting the MinIO backend (users, groups,
+     - The key to use for encrypting the MinIO backend (S3 objects, users, groups,
        policies, and server configuration).
 
        Replace this value with a 256-bit base64-encrypted string:


### PR DESCRIPTION
…SECRET_KEY

# Summary

Updating the installation instructions for upcoming changes to environment variables and backend encryption.

# Goals
- Update landing page quickstart + dedicated installation pages
- update environment variables

# Non-Goals

- Complete reference for KES

# Build Instructions

The MinIO docs require Python 3.9+ and Node for building. For Node, use v14.5.0 or later.

1) Clone the repo, Checkout the branch (`git checkout -B installation-fixes origin/installation-fixes`)
2) Run `npm install` from the branch
3) Create a python venv (`python -m venv venv`)
4) Install requirements (`pip install -r requirements.txt`)
5) Run `make html`
6) Run `python -m http.server --directory build/installation-fixes/html`
7) Open 127.0.0.1:8000 in your browser and take a poke around.

If you run into an error running `python -m http.server` related to `--directory`, you're python version is likely older. CD into the `build/<branch>/html` directory and run the command without the `--directory` argument.

# Key URLS

- http://127.0.0.1:8000/index.html
- http://127.0.0.1:8000/tutorials/minio-installation.html
- http://127.0.0.1:8000/reference/minio-server/minio-server.html#root-credentials
- http://127.0.0.1:8000/reference/minio-server/minio-server.html#envvar.MINIO_KMS_SECRET_KEY