### PR TITLE
DOCS-352: Add replica metadata sync, existing object replication

### DIFF
--- a/source/lifecycle-management/lifecycle-management-overview.rst
+++ b/source/lifecycle-management/lifecycle-management-overview.rst
@@ -92,6 +92,10 @@ options to create new expiration rules on a bucket:
 - :mc-cmd-option:`mc ilm add expiry-days` to expire objects after a
   specified number of calendar days.
 
+For buckets with :ref:`replication <minio-bucket-replication>` configured, MinIO
+does not replicate objects deleted by a lifecycle management expiration rule.
+See :ref:`minio-replication-behavior-delete` for more information.
+
 Versioned Buckets
 ~~~~~~~~~~~~~~~~~
 

--- a/source/replication/enable-server-side-one-way-bucket-replication.rst
+++ b/source/replication/enable-server-side-one-way-bucket-replication.rst
@@ -239,18 +239,17 @@ Considerations
 Replication of Existing Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-MinIO performs replication as part of writing an object (PUT operations). MinIO
-does *not* apply replication rules to existing objects in the bucket. Use
-:mc:`mc cp` or :mc:`mc mirror` to migrate existing objects to the destination
-bucket.
+Starting with :mc:`mc` :minio-git:`RELEASE.2021-06-13T17-48-22Z
+<mc/releases/tag/RELEASE.2021-06-13T17-48-22Z>` and :mc:`minio`
+:minio-git:`RELEASE.2021-06-07T21-40-51Z
+<minio/releases/tag/RELEASE.2021-06-07T21-40-51Z>`, MinIO supports automatically
+replicating existing objects in a bucket.
 
-For buckets with active write operations during the procedure, any objects
-written *before* configuring bucket replication remain unreplicated. 
-
-Consider scheduling a maintenance period during which applications stop
-all write operations to the bucket or buckets for which you are configuring
-bucket replication. Restart write operations at the completion of the
-procedure to ensure consistent object replication.
+MinIO requires explicitly enabling replication of existing objects using the
+:mc-cmd-option:`mc replicate add replicate` or
+:mc-cmd-option:`mc replicate edit replicate` and including the 
+``existing-objects`` replication feature flag. This procedure includes the
+required flags for enabling replication of existing objects.
 
 Replication of Delete Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -399,7 +398,7 @@ replication rule to the source MinIO cluster.
    mc replicate add AlphaReplication/SOURCEBUCKET \
       --remote-bucket DESTINATIONBUCKET \
       --arn 'arn:minio:replication::<UUID>:DESTINATIONBUCKET' \
-      --replicate "delete,delete-marker"
+      --replicate "delete,delete-marker,existing-objects"
 
 - Replace ``SOURCEBUCKET`` with the name of the bucket from which Alpha
   replicates data. The name *must* match the bucket specified when
@@ -414,12 +413,15 @@ replication rule to the source MinIO cluster.
   :mc-cmd:`mc admin bucket remote ls` to list all remote ARNs configured
   on the cluster.
 
-- The ``--replicate "delete,delete-marker"`` flag enables replicating delete
-  markers and deletion of object versions. See 
-  :mc-cmd-option:`mc replicate add replicate` for more complete
-  documentation. Omit these fields to disable replication of delete 
-  operations.
-
+- The ``--replicate "delete,delete-marker,existing-objects"`` flag enables
+  the following replication features:
+  
+  - :ref:`Replication of Deletes <minio-replication-behavior-delete>` 
+  - :ref:`Replication of existing Objects <minio-replication-behavior-existing-objects>`
+  
+  See :mc-cmd-option:`mc replicate add replicate` for more complete
+  documentation. Omit these fields to disable replication of delete operations
+  or replication of existing objects respectively.
 
 Specify any other supported optional arguments for 
 :mc-cmd:`mc replicate add`.

--- a/source/replication/enable-server-side-two-way-bucket-replication.rst
+++ b/source/replication/enable-server-side-two-way-bucket-replication.rst
@@ -238,18 +238,17 @@ Considerations
 Replication of Existing Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-MinIO performs replication as part of writing an object (PUT operations). MinIO
-does *not* apply replication rules to existing objects in the bucket. Use
-:mc:`mc cp` or :mc:`mc mirror` to migrate existing objects to the destination
-bucket.
+Starting with :mc:`mc` :minio-git:`RELEASE.2021-06-13T17-48-22Z
+<mc/releases/tag/RELEASE.2021-06-13T17-48-22Z>` and :mc:`minio`
+:minio-git:`RELEASE.2021-06-07T21-40-51Z
+<minio/releases/tag/RELEASE.2021-06-07T21-40-51Z>`, MinIO supports automatically
+replicating existing objects in a bucket.
 
-For buckets with active write operations during the procedure, any objects
-written *before* configuring bucket replication remain unreplicated. 
-
-Consider scheduling a maintenance period during which applications stop
-all write operations to the bucket or buckets for which you are configuring
-bucket replication. Restart write operations at the completion of the
-procedure to ensure consistent object replication.
+MinIO requires explicitly enabling replication of existing objects using the
+:mc-cmd-option:`mc replicate add replicate` or
+:mc-cmd-option:`mc replicate edit replicate` and including the 
+``existing-objects`` replication feature flag. This procedure includes the
+required flags for enabling replication of existing objects.
 
 Replication of Delete Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -460,7 +459,7 @@ A\) Create Replication Rule on Alpha
       mc replicate add AlphaReplication/SOURCEBUCKET \
          --remote-bucket DESTINATIONBUCKET \
          --arn 'arn:minio:replication::<UUID>:DESTINATIONBUCKET' \
-         --replicate "delete,delete-marker"
+         --replicate "delete,delete-marker,existing-objects"
 
    - Replace ``SOURCEBUCKET`` with the name of the bucket from which Alpha
      replicates data. The name *must* match the bucket specified when
@@ -475,11 +474,15 @@ A\) Create Replication Rule on Alpha
      :mc-cmd:`mc admin bucket remote ls` to list all remote ARNs configured
      on the cluster.
    
-   - The ``--replicate "delete,delete-marker"`` flag enables replicating delete
-     markers and deletion of object versions. See 
-     :mc-cmd-option:`mc replicate add replicate` for more complete
-     documentation. Omit these fields to disable replication of delete 
-     operations.
+   - The ``--replicate "delete,delete-marker,existing-objects"`` flag enables
+     the following replication features:
+      
+     - :ref:`Replication of Deletes <minio-replication-behavior-delete>` 
+     - :ref:`Replication of existing Objects <minio-replication-behavior-existing-objects>`
+      
+     See :mc-cmd-option:`mc replicate add replicate` for more complete
+     documentation. Omit these fields to disable replication of delete operations
+     or replication of existing objects respectively.
 
    Specify any other supported optional arguments for 
    :mc-cmd:`mc replicate add`.
@@ -496,7 +499,7 @@ B\) Create Replication Rule on Baker
       mc replicate add BakerReplication/SOURCEBUCKET \
          --remote-bucket DESTINATIONBUCKET \
          --arn 'arn:minio:replication::<UUID>:DESTINATIONBUCKET' \
-         --replicate "delete,delete-marker"
+         --replicate "delete,delete-marker,existing-objects"
 
    - Replace ``SOURCEBUCKET`` with the name of the bucket from which Baker
      replicates data. The name *must* match the bucket specified when
@@ -511,11 +514,18 @@ B\) Create Replication Rule on Baker
      :mc-cmd:`mc admin bucket remote ls` to list all remote ARNs configured
      on the cluster.
 
-   - The ``--replicate "delete,delete-marker"`` flag enables replicating delete
-     markers and deletion of object versions. See 
-     :mc-cmd-option:`mc replicate add replicate` for more complete
-     documentation. Omit these fields to disable replication of delete 
-     operations.
+   - The ``--replicate "delete,delete-marker,existing-objects"`` flag enables
+     the following replication features:
+      
+     - :ref:`Replication of Deletes <minio-replication-behavior-delete>` 
+     - :ref:`Replication of existing Objects <minio-replication-behavior-existing-objects>`
+      
+     See :mc-cmd-option:`mc replicate add replicate` for more complete
+     documentation. Omit these fields to disable replication of delete operations
+     or replication fof existing objects respectively.
+
+   Specify any other supported optional arguments for 
+   :mc-cmd:`mc replicate add`.
 
    Specify any other supported optional arguments for 
    :mc-cmd:`mc replicate add`.


### PR DESCRIPTION
# Summary

We've added features for existing object replication and metadata sync.

This adds docs for these new features and does some general reorg.

# Goals

- Address #352 
- Minor fix to include delete behavior interaction w/ ILM expiry.

# Non-Goals

Larger rewrites or cleanups of replication docs.