### PR TITLE
DOCS-359: Fix expired-object-delete-marker arg, general cleanup

### DIFF
--- a/source/lifecycle-management/create-lifecycle-management-expiration-rule.rst
+++ b/source/lifecycle-management/create-lifecycle-management-expiration-rule.rst
@@ -107,19 +107,18 @@ Expire Versioned Objects
 Use :mc-cmd:`mc ilm add` to expiring noncurrent object versions and object
 delete markers: 
 
-- To expire noncurrent object versions, specify the
-  :mc-cmd-option:`~mc ilm add noncurrentversion-expiration-days` option.
+- To expire noncurrent object versions after a specific duration in days,
+  include :mc-cmd-option:`~mc ilm add noncurrentversion-expiration-days`.
 
 - To expire delete markers for objects with no remaining versions, 
-  specify the :mc-cmd-option:`~mc ilm add expired-object-delete-marker`
-  option.
+  include :mc-cmd-option:`~mc ilm add expired-object-delete-marker`.
 
 .. code-block:: shell
    :class: copyable
 
    mc ilm add ALIAS/PATH \ 
       --noncurrentversion-expiration-days NONCURRENT_DAYS \
-      --expired-object-delete-marker EXPIRED_DAYS
+      --expired-object-delete-marker
 
 - Replace :mc-cmd:`ALIAS <mc ilm add TARGET>` with the 
   :mc:`alias <mc alias>` of the S3-compatible host.
@@ -132,8 +131,3 @@ delete markers:
   which to expire noncurrent object versions. For example, specify ``30d`` to
   expire a version after it has been noncurrent for at least 30 days.
 
-- Replace :mc-cmd:`EXPIRED_DAYS
-  <mc ilm add expired-object-delete-marker>` with the number of days after
-  which to expire the delete marker for an object with no remaining versions.
-  For example, specify ``30d`` to remove the delete marker after it has 
-  been the only remaining "version" of that object for at least 30 days.

--- a/source/reference/minio-cli/minio-mc/mc-ilm.rst
+++ b/source/reference/minio-cli/minio-mc/mc-ilm.rst
@@ -235,6 +235,11 @@ Syntax
       limited system resources may delay application of lifecycle management
       rules. See :ref:`minio-lifecycle-management-scanner` for more information.
 
+      Mutually exclusive with the following options:
+
+      - :mc-cmd-option:`~mc ilm add expiry-days`
+      - :mc-cmd-option:`~mc ilm add expired-object-delete-marker`
+
    .. mc-cmd:: expiry-days
       :option:
 
@@ -250,6 +255,11 @@ Syntax
       lifecycle management rules. Slow scanning due to high IO workloads or
       limited system resources may delay application of lifecycle management
       rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+      Mutually exclusive with the following options:
+
+      - :mc-cmd-option:`~mc ilm add expiry-date`
+      - :mc-cmd-option:`~mc ilm add expired-object-delete-marker`
 
    .. mc-cmd:: noncurrentversion-expiration-days
       :option:
@@ -270,15 +280,15 @@ Syntax
    .. mc-cmd:: expired-object-delete-marker
       :option:
 
-      Specify ``true`` to direct MinIO to remove delete markers for
+      Specify this option to direct MinIO to remove delete markers for
       objects with no remaining object versions. Specifically, the delete
       marker is the *only* remaining "version" of the given object.
-
-      Defaults to ``false``.
 
       This option is mutually exclusive with the following option:
       
       - :mc-cmd-option:`~mc ilm add tags`
+      - :mc-cmd-option:`~mc ilm add expiry-date`
+      - :mc-cmd-option:`~mc ilm add expiry-days`
 
       MinIO uses a scanner process to check objects against all configured
       lifecycle management rules. Slow scanning due to high IO workloads or
@@ -360,6 +370,8 @@ Syntax
 
       Disables the rule.
 
+      To enable a disabled rule, specify ``--disable=false``
+
 .. mc-cmd:: edit
    :fullpath:
 
@@ -395,6 +407,172 @@ Syntax
 
       The unique ID of the rule. Use :mc-cmd:`mc ilm list` to list bucket rules
       and retrieve the ``id`` for the rule you want to modify.
+
+   .. mc-cmd:: tags
+      :option:
+
+      One or more ampersand ``&``-delimited key-value pairs describing 
+      the object tags to which to apply the lifecycle configuration rule.
+
+      This option is mutually exclusive with the following option:
+
+      - :mc-cmd-option:`~mc ilm edit expired-object-delete-marker`
+
+   .. mc-cmd:: expiry-date
+      :option:
+
+      The ISO-8601-formatted calendar date until which MinIO retains an object
+      after being created. MinIO marks the object for deletion once the
+      system host datetime passes that calendar date.
+
+      Specifying a calendar date that is *prior* to the current system host
+      datetime marks all objects covered by the rule for deletion.
+
+      For versioned buckets, the expiry rule applies only to the *current*
+      object version. Use the 
+      :mc-cmd-option:`~mc ilm edit noncurrentversion-expiration-days` option
+      to apply expiration behavior to noncurrent object versions.
+
+      MinIO uses a scanner process to check objects against all configured
+      lifecycle management rules. Slow scanning due to high IO workloads or
+      limited system resources may delay application of lifecycle management
+      rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+      Mutually exclusive with the following options:
+
+      - :mc-cmd-option:`~mc ilm edit expiry-days`
+      - :mc-cmd-option:`~mc ilm edit expired-object-delete-marker`
+
+
+   .. mc-cmd:: expiry-days
+      :option:
+
+      The number of days to retain an object after being created. MinIO
+      marks the object for deletion after the specified number of days pass.
+
+      For versioned buckets, the expiry rule applies only to the *current*
+      object version. Use the 
+      :mc-cmd-option:`~mc ilm edit noncurrentversion-expiration-days` option
+      to apply expiration behavior to noncurrent object versions.
+
+      MinIO uses a scanner process to check objects against all configured
+      lifecycle management rules. Slow scanning due to high IO workloads or
+      limited system resources may delay application of lifecycle management
+      rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+      Mutually exclusive with the following options:
+
+      - :mc-cmd-option:`~mc ilm edit expiry-date`
+      - :mc-cmd-option:`~mc ilm edit expired-object-delete-marker`
+
+   .. mc-cmd:: noncurrentversion-expiration-days
+      :option:
+
+      The number of days to retain an object version after becoming 
+      *non-current* (i.e. a different version of that object is now the `HEAD`).
+      MinIO marks noncurrent object versions for deletion after the 
+      specified number of days pass.
+
+      This option has the same behavior as the 
+      S3 ``NoncurrentVersionExpiration`` action.
+
+      MinIO uses a scanner process to check objects against all configured
+      lifecycle management rules. Slow scanning due to high IO workloads or
+      limited system resources may delay application of lifecycle management
+      rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+   .. mc-cmd:: expired-object-delete-marker
+      :option:
+
+      Specify this option to direct MinIO to remove delete markers for
+      objects with no remaining object versions. Specifically, the delete
+      marker is the *only* remaining "version" of the given object.
+
+      This option is mutually exclusive with the following option:
+      
+      - :mc-cmd-option:`~mc ilm edit tags`
+      - :mc-cmd-option:`~mc ilm edit expiry-date`
+      - :mc-cmd-option:`~mc ilm edit expiry-days`
+
+      MinIO uses a scanner process to check objects against all configured
+      lifecycle management rules. Slow scanning due to high IO workloads or
+      limited system resources may delay application of lifecycle management
+      rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+   .. mc-cmd:: transition-date
+      :option:
+
+      The ISO-8601-formatted calendar date after which MinIO marks an object as
+      eligible for transition to the remote tier. MinIO transitions the object
+      to the configured remote storage tier specified to the 
+      :mc-cmd-option:`~mc ilm edit storage-class` once the system host datetime
+      passes that calendar date.
+
+      For versioned buckets, the transition rule applies only to the *current*
+      object version. Use the 
+      :mc-cmd-option:`~mc ilm edit noncurrentversion-transition-days` option
+      to apply transition behavior to noncurrent object versions.
+
+      MinIO uses a scanner process to check objects against all configured
+      lifecycle management rules. Slow scanning due to high IO workloads or
+      limited system resources may delay application of lifecycle management
+      rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+            
+   .. mc-cmd:: transition-days
+      :option:
+
+      The number of calendar days from object creation after which MinIO marks
+      an object as eligible for transition. MinIO transitions the object to the
+      configured remote storage tier specified to the 
+      :mc-cmd-option:`~mc ilm edit storage-class`. 
+
+      For versioned buckets, the transition rule applies only to the *current*
+      object version. Use the 
+      :mc-cmd-option:`~mc ilm edit noncurrentversion-transition-days` option
+      to apply transition behavior to noncurrent object versions.
+
+      MinIO uses a scanner process to check objects against all configured
+      lifecycle management rules. Slow scanning due to high IO workloads or
+      limited system resources may delay application of lifecycle management
+      rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+   .. mc-cmd:: noncurrentversion-transition-days
+      :option:
+
+      The number of days an object has been non-current (i.e. replaced by a
+      newer version of that same object) after which MinIO marks the object
+      version as eligible for transition. MinIO transitions the object to the
+      configured remote storage tier specified to the 
+      :mc-cmd-option:`~mc ilm edit storage-class` once the system host datetime
+      passes that calendar date.
+
+      This option has no effect on non-versioned buckets.
+
+      This option has the same behavior as the 
+      S3 ``NoncurrentVersionTransition`` action.
+
+      MinIO uses a scanner process to check objects against all configured
+      lifecycle management rules. Slow scanning due to high IO workloads or
+      limited system resources may delay application of lifecycle management
+      rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+   .. mc-cmd:: storage-class
+      :option:
+
+      The remote storage tier to which MinIO 
+      :ref:`transition objects <minio-lifecycle-management-tiering>`.
+      Specify a remote storage tier created by :mc-cmd:`mc admin tier`. 
+
+      If using :mc-cmd:`mc ilm edit` against an Amazon S3 service, this argument
+      is the Amazon S3 storage class to transition objects covered by the rule.
+      See :s3-docs:`Transition objects using Amazon S3 Lifecycle
+      <lifecycle-transition-general-considerations.html>` for more information
+      on S3 storage classes.
+
+   .. mc-cmd:: disable
+      :option:
+
+      Disables the rule.
 
 .. mc-cmd:: remove
    :fullpath:


### PR DESCRIPTION
# Summary

Resolves #359 , also makes explicit some observed behavior where you cannot specify certain arguments together.

Also noticed the entire `mc ilm edit` section was missing args, so fixed those.

# Goals

- Fix example on `expired-object-delete-marker`
- Add docs for `mc ilm edit`

# Non Goals

Show how to manually edit JSON for disabling `expired-object-delete-marker` rule.
