### PR TITLE
Fix region setting AWS SDK for .NET example

### DIFF
--- a/docs/aws-sdk-for-dotnet-with-minio.md
+++ b/docs/aws-sdk-for-dotnet-with-minio.md
@@ -42,7 +42,7 @@ class Program
     {
         var config = new AmazonS3Config
         {
-            RegionEndpoint = RegionEndpoint.USEast1, // MUST set this before setting ServiceURL and it should match the `MINIO_REGION` environment variable.
+            AuthenticationRegion = RegionEndpoint.USEast1.SystemName, // Should match the `MINIO_REGION` environment variable.
             ServiceURL = "http://localhost:9000", // replace http://localhost:9000 with URL of your MinIO server
             ForcePathStyle = true // MUST be true to work correctly with MinIO server
         };


### PR DESCRIPTION
I tried to use MinIO with the AWS SDK for .NET and got the same error descripted on this post:
https://stackoverflow.com/questions/68678953/error-when-configuring-minio-in-c-sharp-the-authorization-header-is-malformed/69199735

So I found that the solution was to change the `RegionEndpoint` setting to `AuthenticationRegion`, as the region is used on the authentication process.
Also the AWS SDK sets the `RegionEndpoint` as null when `ServiceURL` is set.