### PR TITLE
DOCS-388: Azure tiering does not support changing storage account names

### DIFF
--- a/source/lifecycle-management/transition-objects-to-azure.rst
+++ b/source/lifecycle-management/transition-objects-to-azure.rst
@@ -98,6 +98,16 @@ objects.
 MinIO also ignores any objects in the remote bucket or bucket prefix not
 explicitly managed by MinIO. 
 
+.. important::
+
+   MinIO does *not* support changing the account name associated to an Azure
+   remote tier. Azure storage backends are tied to the account, such that
+   changing the account would change the storage backend and prevent access
+   to any objects transitioned to the original account/backend.
+
+   Please contact `MinIO Support <https://min.io/pricing?ref=docs>`__ if you need
+   situation-specific guidance around configuring Azure remote tiers.
+
 Procedure
 ---------
 
@@ -162,6 +172,8 @@ The example above uses the following arguments:
        *must* correspond to an :abbr:`Azure (Microsoft Azure)` user with the
        required :ref:`permissions
        <minio-lifecycle-management-transition-to-azure-permissions-remote>`.
+
+       You cannot change this account name after creating the tier.
 
    * - :mc-cmd:`KEY <mc admin tier add account-key>`
      - The corresponding key for the specified ``ACCOUNT``.

--- a/source/reference/minio-cli/minio-mc-admin/mc-admin-tier.rst
+++ b/source/reference/minio-cli/minio-mc-admin/mc-admin-tier.rst
@@ -206,12 +206,18 @@ Syntax
       Required if :mc-cmd:`~mc admin tier add TIER_TYPE` is ``azure``. 
       This option has no effect for any other value of ``TIER_TYPE``.
 
+      MinIO does *not* support changing the account name associated to an Azure
+      remote tier. Azure storage backends are tied to the account, such that
+      changing the account would change the storage backend and prevent access
+      to any objects transitioned to the original account/backend.
+
    .. mc-cmd:: account-key
       :option:
 
       *Required*
       
-      The account key for a user on the remote Azure tier.
+      The account key for the :mc-cmd-option:`~mc admin tier add account-name` 
+      associated to the remote Azure tier.
 
       Required if :mc-cmd:`~mc admin tier add TIER_TYPE` is ``azure``. 
       This option has no effect for any other value of ``TIER_TYPE``.
@@ -327,25 +333,15 @@ Syntax
       :mc-cmd:`~mc admin tier add TIER_TYPE` is ``s3``. 
       This option has no effect for any other ``TIER_TYPE``.
 
-   .. mc-cmd:: account-name
-      :option:
-
-      *Required*
-      
-      The account name for a user on the remote Azure tier. The user
-      must have permission to perform read/write/list/delete operations on the
-      remote bucket or bucket prefix.
-      
-      This option only applies to remote storage tiers with 
-      :mc-cmd:`~mc admin tier add TIER_TYPE` is ``azure``. 
-      This option has no effect for any other ``TIER_TYPE``.
-
    .. mc-cmd:: account-key
       :option:
 
       *Required*
-      
+
       The account key for a user on the remote Azure tier.
+      Use this option to rotate the credentials for the
+      :mc-cmd-option:`~mc admin tier add account-name` 
+      associated to the remote tier.
 
       This option only applies to remote storage tiers with 
       :mc-cmd:`~mc admin tier add TIER_TYPE` is ``azure``. 


### PR DESCRIPTION
Closes #388 

- [ ] Update `mc admin tier edit` to remove Azure account modification
- [ ] Update tutorials to note that Azure accounts cannot be changed after creating a new tier