### PR TITLE
Rectify the typo in user creation for replication

### DIFF
--- a/source/replication/enable-server-side-two-way-bucket-replication.rst
+++ b/source/replication/enable-server-side-two-way-bucket-replication.rst
@@ -302,7 +302,7 @@ A\) Create Replication Administrators
       wget -O - https://docs.min.io/minio/baremetal/examples/ReplicationAdminPolicy.json | \
       mc admin policy add Baker ReplicationAdminPolicy /dev/stdin
       mc admin user add Baker bakerReplicationAdmin LongRandomSecretKey
-      mc admin policy set baker ReplicationAdminPolicy user=bakerReplicationAdmin
+      mc admin policy set Baker ReplicationAdminPolicy user=bakerReplicationAdmin
 
 B\) Create Remote Replication User
    The following code creates policies and users for supporting synchronizing data


### PR DESCRIPTION
There was a typo(lowercase was used) in user creation while replication which led to the failure of the command. 

Error 
```
mc: <ERROR> Unable to initialize admin connection. No valid configuration found for 'baker' host alias.
````