### PR TITLE
rectify expiry in ilm command

### DIFF
--- a/source/lifecycle-management/create-lifecycle-management-expiration-rule.rst
+++ b/source/lifecycle-management/create-lifecycle-management-expiration-rule.rst
@@ -77,7 +77,7 @@ expire bucket contents a number of days after object creation:
   S3-compatible host.
 
 - Replace :mc-cmd:`DATE <mc ilm add expiry-date>` with the number of days after
-  which to expire the object. For example, specify ``30d`` to expire the
+  which to expire the object. For example, specify ``30`` to expire the
   object 30 days after creation.
 
 Expire Versioned Objects


### PR DESCRIPTION
Error when adding ilm rules using `--expiry-days "1d" `

```
ashish@ashish:~/code/go/src/github/minio/mc$ mc ilm add --expiry-days "1d" myminio/sinha
mc: <ERROR> Unable to generate new lifecycle rules for the input: strconv.Atoi: parsing "1d": invalid syntax.
```

passed expiry as ``--expiry-days "1" ` and it ran

ashish@ashish:~/code/go/src/github/minio/mc$ mc ilm add --expiry-days "1" myminio/sinha
Lifecycle configuration rule added with ID `c723aorp8fs9k7sn7rt0` to myminio/sinha.


```
ashish@ashish:~/code/go/src/github/minio/mc$ ./mc ilm ls myminio/sinha
          ID          |     Prefix     |  Enabled   | Expiry |  Date/Days   |  Transition  |    Date/Days     |  Storage-Class   |          Tags          
----------------------|----------------|------------|--------|--------------|--------------|------------------|------------------|------------------------
 c723aorp8fs9k7sn7rt0 |                |    ✓       |  ✓     |   1 day(s)   |     ✗        |                  |                  |                        
----------------------|----------------|------------|--------|--------------|--------------|------------------|------------------|------------------------



`
