### PR TITLE
Update minio.py and mc references for simplified structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 build
 venv
-sphinx4
 .vscode
 __pycache__
 node_modules
@@ -8,3 +7,5 @@ npm-debug.log
 .python-version
 main.min.css
 main.css
+objects.inv
+output.log

--- a/source/concepts/erasure-coding.rst
+++ b/source/concepts/erasure-coding.rst
@@ -205,7 +205,7 @@ interfacing with the MinIO server.
 
 - For the :mc:`mc` command line tool, certain commands include a specific
   option for setting the storage class. For example, the :mc:`mc cp` command
-  has the :mc-cmd-option:`~mc cp storage-class` option for specifying the
+  has the :mc-cmd:`~mc cp storage-class` option for specifying the
   storage class to assign to the object being copied.
 
 - For MinIO SDKs, the ``S3Client`` object has specific methods for setting

--- a/source/conf.py
+++ b/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'sphinxcontrib.images',
     'myst_parser',
     'sphinx_design',
+    'sphinx.ext.intersphinx'
 ]
 
 # -- External Links

--- a/source/console/minio-console.rst
+++ b/source/console/minio-console.rst
@@ -112,7 +112,7 @@ the risk of a port collision on systems which were running MinIO *before* the
 embedded Console update.
 
 You can select an explicit static port by passing the 
-:mc-cmd-option:`minio server console-address` commandline option when starting 
+:mc-cmd:`minio server --console-address` commandline option when starting 
 each MinIO Server in the deployment. 
 
 For example, the following command starts a distributed MinIO deployment using

--- a/source/design.rst
+++ b/source/design.rst
@@ -472,7 +472,7 @@ definitions. The initial table links to each definition.
 
 - :mc:`foo`
 - :mc-cmd:`foo bar`
-- :mc-cmd-option:`foo bar baz`
+- :mc-cmd:`foo bar baz`
 - :data:`foo`
 - :data:`foo.bar`
 
@@ -492,7 +492,7 @@ for display. This is intentional (For now).
       Used for defining various arguments to a CLI command
 
    .. mc-cmd:: baz
-      :option:
+      
 
       Used for defining an option to a CLI command
 

--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -70,7 +70,7 @@ for creating this user with a home directory ``/home/minio-user``.
 
 If the ``minio.service`` file specifies a different user account, use the
 ``$HOME`` directory for that account. Alternatively, specify a custom
-certificate directory using the :mc-cmd-option:`minio server certs-dir`
+certificate directory using the :mc-cmd:`minio server certs-dir`
 commandline argument. Modify the ``MINIO_OPTS`` variable in
 ``/etc/defaults/minio`` to set this option. The ``systemd`` user which runs the
 MinIO server process *must* have read and listing permissions for the specified

--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -96,7 +96,7 @@ more information.
 
    The embedded MinIO Console by default uses a random port number selected at
    server startup. Start the MinIO server process with the
-   :mc-cmd-option:`~minio server console-address` option to specify a static
+   :mc-cmd:`~minio server --console-address` option to specify a static
    port number.
 
 .. end-minio-openid-redirect-uri

--- a/source/includes/common-minio-mc.rst
+++ b/source/includes/common-minio-mc.rst
@@ -1,8 +1,8 @@
 .. start-minio-mc-globals
 
-.. mc-cmd:: debug
-   :option:
-
+.. mc-cmd:: --debug
+   :optional:
+   
    Enables verbose output to the console.
 
    For example:
@@ -12,8 +12,8 @@
 
       mc --debug COMMAND
 
-.. mc-cmd:: config-dir
-   :option:
+.. mc-cmd:: --config-dir
+   :optional:
 
    The path to a ``JSON`` formatted configuration file that
    :program:`mc` uses for storing data. See :ref:`mc-configuration` for
@@ -21,8 +21,8 @@
 
 .. start-minio-mc-json-globals
 
-.. mc-cmd:: JSON
-   :option:
+.. mc-cmd:: --JSON
+   :optional:
 
    Enables `JSON lines <http://jsonlines.org/>`_ formatted output to the
    console.
@@ -36,31 +36,31 @@
 
 .. end-minio-mc-json-globals
 
-.. mc-cmd:: no-color
-   :option:
+.. mc-cmd:: --no-color
+   :optional:
 
    Disables the built-in color theme for console output. Useful for dumb
    terminals.
 
-.. mc-cmd:: quiet
-   :option:
+.. mc-cmd:: --quiet
+   :optional:
 
    Suppresses console output. 
 
-.. mc-cmd:: insecure
-   :option:
+.. mc-cmd:: --insecure
+   :optional:
 
    Disables TLS/SSL certificate verification. Allows TLS connectivity to 
    servers with invalid certificates. Exercise caution when using this
    option against untrusted S3 hosts.
 
-.. mc-cmd:: version
-   :option:
+.. mc-cmd:: --version
+   :optional:   
 
    Displays the current version of :mc-cmd:`mc`. 
 
-.. mc-cmd:: help
-   :option:
+.. mc-cmd:: --help
+   :optional:
 
    Displays a summary of command usage on the terminal.
 

--- a/source/includes/common-minio-tiering.rst
+++ b/source/includes/common-minio-tiering.rst
@@ -31,15 +31,15 @@ The example above specifies the following arguments:
      - Specify the full path to the bucket for which you are
        creating the lifecycle management rule.
 
-   * - :mc-cmd:`TIERNAME <mc ilm add storage-class>`
+   * - :mc-cmd:`TIERNAME <mc ilm add --storage-class>`
      - The remote storage tier to which MinIO transitions objects. 
        Specify the remote storage tier name created in the previous step.
 
        If you want to transition noncurrent object versions to a distinct
        remote tier, specify a different tier name for 
-       :mc-cmd-option:`~mc ilm add noncurrentversion-transition-storage-class`.
+       :mc-cmd:`~mc ilm add noncurrentversion-transition-storage-class`.
 
-   * - :mc-cmd:`DAYS <mc ilm add transition-days>`
+   * - :mc-cmd:`DAYS <mc ilm add --transition-days>`
      - The number of calendar days after which MinIO marks an object as 
        eligible for transition. Specify the number of days as an integer,
        e.g. ``30`` for 30 days.

--- a/source/includes/facts-locking.rst
+++ b/source/includes/facts-locking.rst
@@ -2,7 +2,7 @@
 
    The bucket *must* have object locking enabled to use this command. 
    You can only enable object locking when creating a bucket. See
-   :mc-cmd-option:`mc mb with-lock` for more information on creating buckets
+   :mc-cmd:`mc mb with-lock` for more information on creating buckets
    with object locking enabled.
 
 .. end-command-requires-locking-desc

--- a/source/installation/deploy-minio-standalone.rst
+++ b/source/installation/deploy-minio-standalone.rst
@@ -93,7 +93,7 @@ certificate (``public.crt``) in the MinIO ``certs`` directory:
 - For Windows: ``%%USERPROFILE%%\.minio\certs``
 
 You can override the certificate directory using the 
-:mc-cmd-option:`minio server certs-dir` commandline argument.
+:mc-cmd:`minio server certs-dir` commandline argument.
 
 3) Run the MinIO Server with Non-Default Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/lifecycle-management/create-lifecycle-management-expiration-rule.rst
+++ b/source/lifecycle-management/create-lifecycle-management-expiration-rule.rst
@@ -62,7 +62,7 @@ transition lifecycle management rules on any bucket in the cluster:.
 Expire Objects after Number of Days
 -----------------------------------
 
-Use :mc-cmd:`mc ilm add` with :mc-cmd-option:`~mc ilm add expiry-days` to
+Use :mc-cmd:`mc ilm add` with :mc-cmd:`~mc ilm add --expiry-days` to
 expire bucket contents a number of days after object creation:
 
 .. code-block:: shell
@@ -76,7 +76,7 @@ expire bucket contents a number of days after object creation:
 - Replace :mc-cmd:`PATH <mc ilm add ALIAS>` with the path to the bucket on the
   S3-compatible host.
 
-- Replace :mc-cmd:`DAYS <mc ilm add expiry-days>` with the number of days after
+- Replace :mc-cmd:`DAYS <mc ilm add --expiry-days>` with the number of days after
   which to expire the object. For example, specify ``30`` to expire the
   object 30 days after creation.
 
@@ -87,10 +87,10 @@ Use :mc-cmd:`mc ilm add` to expiring noncurrent object versions and object
 delete markers: 
 
 - To expire noncurrent object versions after a specific duration in days,
-  include :mc-cmd-option:`~mc ilm add noncurrentversion-expiration-days`.
+  include :mc-cmd:`~mc ilm add noncurrentversion-expiration-days`.
 
 - To expire delete markers for objects with no remaining versions, 
-  include :mc-cmd-option:`~mc ilm add expired-object-delete-marker`.
+  include :mc-cmd:`~mc ilm add expired-object-delete-marker`.
 
 .. code-block:: shell
    :class: copyable

--- a/source/lifecycle-management/lifecycle-management-overview.rst
+++ b/source/lifecycle-management/lifecycle-management-overview.rst
@@ -43,7 +43,7 @@ without any additional application-side logic.
 
 Use the :mc-cmd:`mc admin tier` command to create a remote target for tiering
 data to a supported Cloud Service Provider object storage. You can then use the
-:mc-cmd-option:`mc ilm add transition-days` command to transition objects to the
+:mc-cmd:`mc ilm add --transition-days` command to transition objects to the
 remote tier after a specified number of calendar days.
 
 Exclusive Access to Remote Data
@@ -69,8 +69,8 @@ on :ref:`versioned buckets <minio-bucket-versioning>`. Specifically, MinIO by
 default applies the transition operation to the *current* object version. 
 
 To transition noncurrent object versions, specify the 
-:mc-cmd-option:`~mc ilm add noncurrentversion-transition-days` and
-:mc-cmd-option:`~mc ilm add noncurrentversion-transition-storage-class` options
+:mc-cmd:`~mc ilm add noncurrentversion-transition-days` and
+:mc-cmd:`~mc ilm add noncurrentversion-transition-storage-class` options
 when creating the transition rule. 
 
 .. _minio-lifecycle-management-expiration:
@@ -85,7 +85,7 @@ older than 365 days.
 
 .. todo: Diagram of MinIO Expiration
 
-Use :mc-cmd-option:`mc ilm add expiry-days` to expire objects after a specified
+Use :mc-cmd:`mc ilm add --expiry-days` to expire objects after a specified
 number of calendar days.
 
 For buckets with :ref:`replication <minio-bucket-replication>` configured, MinIO
@@ -104,14 +104,14 @@ specific default behaviors for versioned buckets:
   creating a ``DeleteMarker`` as is normal with versioned delete.
 
   To expire noncurrent object versions, specify the 
-  :mc-cmd-option:`~mc ilm add noncurrentversion-expiration-days` option
+  :mc-cmd:`~mc ilm add noncurrentversion-expiration-days` option
   when creating the expiration rule. 
 
 - MinIO does not expire ``DeleteMarkers`` *even if* no other versions of 
   that object exist.
 
   To expire delete markers when there are no remaining versions for that
-  object, specify the :mc-cmd-option:`~mc ilm add expired-object-delete-marker`
+  object, specify the :mc-cmd:`~mc ilm add expired-object-delete-marker`
   option when creating the expiration rule.
 
 .. _minio-lifecycle-management-scanner:

--- a/source/monitoring/bucket-notifications/publish-events-to-amqp.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-amqp.rst
@@ -182,7 +182,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured AMQP
@@ -207,7 +207,7 @@ event with the configured AMQP service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:amqp \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -226,7 +226,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the AMQP service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -286,7 +286,7 @@ configured AMQP service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_amqp
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -353,7 +353,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured AMQP
@@ -368,7 +368,7 @@ target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 AMQP service endpoint and check the AMQP service for the notification data. The
-action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+action required depends on which :mc-cmd:`events <mc event add --event>` were
 specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-elasticsearch.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-elasticsearch.rst
@@ -173,7 +173,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured Elasticsearch
@@ -198,7 +198,7 @@ event with the configured Elasticsearch service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:elasticsearch \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -217,7 +217,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the Elasticsearch service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -269,7 +269,7 @@ configured Elasticsearch service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_elasticsearch
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -333,7 +333,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured
@@ -349,7 +349,7 @@ Elasticsearch target similar to the following:
 Perform an action on a bucket which has an event configuration using the updated
 Elasticsearch service endpoint and check the Elasticsearch service for the
 notification data. The action required depends on which 
-:mc-cmd:`events <mc-event-add-event>` were specified when configuring the bucket
+:mc-cmd:`events <mc event add --event>` were specified when configuring the bucket
 notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-kafka.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-kafka.rst
@@ -180,7 +180,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured
@@ -205,7 +205,7 @@ event with the configured Kafka service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:kafka \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -224,7 +224,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the Kafka service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -277,7 +277,7 @@ configured Kafka service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_kafka
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -346,7 +346,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured
@@ -361,7 +361,7 @@ Kafka target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 Kafka service endpoint and check the Kafka service for the notification data.
-The action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+The action required depends on which :mc-cmd:`events <mc event add --event>` were
 specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-mqtt.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-mqtt.rst
@@ -185,7 +185,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured MQTT
@@ -210,7 +210,7 @@ event with the configured MQTT service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:mqtt \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -229,7 +229,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the MQTT service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -286,7 +286,7 @@ configured MQTT service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_mqtt
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -360,7 +360,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured MQTT
@@ -375,7 +375,7 @@ target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 MQTT service endpoint and check the MQTT service for the notification data. The
-action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+action required depends on which :mc-cmd:`events <mc event add --event>` were
 specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-mysql.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-mysql.rst
@@ -172,7 +172,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured MySQL
@@ -197,7 +197,7 @@ event with the configured MySQL service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:mysql \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -216,7 +216,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the MySQL service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -266,7 +266,7 @@ configured MySQL service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_mysql
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -333,7 +333,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured MySQL
@@ -348,7 +348,7 @@ target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 MySQL service endpoint and check the MySQL service for the notification data. The
-action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+action required depends on which :mc-cmd:`events <mc event add --event>` were
 specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-nats.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-nats.rst
@@ -172,7 +172,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured NATS
@@ -197,7 +197,7 @@ event with the configured NATS service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:nats \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -216,7 +216,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the NATS service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -261,7 +261,7 @@ configured NATS service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_nats
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -333,7 +333,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured NATS
@@ -348,7 +348,7 @@ target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 NATS service endpoint and check the NATS service for the notification data. The
-action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+action required depends on which :mc-cmd:`events <mc event add --event>` were
 specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-nsq.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-nsq.rst
@@ -153,7 +153,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured NSQ
@@ -178,7 +178,7 @@ event with the configured NSQ service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:nsq \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -197,7 +197,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the NSQ service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -242,7 +242,7 @@ configured NSQ service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_nsq
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -304,7 +304,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured NSQ
@@ -319,7 +319,7 @@ target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 NSQ service endpoint and check the NSQ service for the notification data. The
-action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+action required depends on which :mc-cmd:`events <mc event add --event>` were
 specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-postgresql.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-postgresql.rst
@@ -175,7 +175,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured PostgreSQL
@@ -200,7 +200,7 @@ event with the configured PostgreSQL service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:postgresql \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -219,7 +219,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the PostgreSQL service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -269,7 +269,7 @@ configured PostgreSQL service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_postgresql
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -338,7 +338,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured PostgreSQL
@@ -353,7 +353,7 @@ target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 PostgreSQL service endpoint and check the PostgreSQL service for the notification data. The
-action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+action required depends on which :mc-cmd:`events <mc event add --event>` were
 specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-redis.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-redis.rst
@@ -155,7 +155,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured Redis
@@ -180,7 +180,7 @@ event with the configured Redis service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:redis \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -199,7 +199,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the Redis service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -244,7 +244,7 @@ configured Redis service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_redis
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -306,7 +306,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured Redis
@@ -321,7 +321,7 @@ target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 Redis service endpoint and check the Redis service for the notification data. The
-action required depends on which :mc-cmd:`events <mc-event-add-event>` were
+action required depends on which :mc-cmd:`events <mc event add --event>` were
 specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/monitoring/bucket-notifications/publish-events-to-webhook.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-webhook.rst
@@ -153,7 +153,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured
@@ -178,7 +178,7 @@ event with the configured Webhook service as a target:
    mc event add ALIAS/BUCKET arn:minio:sqs::primary:webhook \
      --event EVENTS
 
-- Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of a MinIO deployment.
+- Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
 - Replace ``BUCKET`` with the name of the bucket in which to configure the 
   event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
@@ -197,7 +197,7 @@ a given notification target:
 
 Perform an action on the bucket for which you configured the new event and 
 check the Webhook service for the notification data. The action required
-depends on which :mc-cmd:`events <mc-event-add-event>` were specified
+depends on which :mc-cmd:`events <mc event add --event>` were specified
 when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 
@@ -242,7 +242,7 @@ configured Webhook service endpoints in the deployment:
 
    mc admin config get ALIAS/ notify_webhook
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the MinIO deployment.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment.
 
 The command output resembles the following:
 
@@ -304,7 +304,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 The :mc:`minio server` process prints a line on startup for each configured Webhook
@@ -319,7 +319,7 @@ target similar to the following:
 
 Perform an action on a bucket which has an event configuration using the updated
 Webhook service endpoint and check the Webhook service for the notification
-data. The action required depends on which :mc-cmd:`events <mc-event-add-event>`
+data. The action required depends on which :mc-cmd:`events <mc event add --event>`
 were specified when configuring the bucket notification.
 
 For example, if the bucket notification configuration includes the 

--- a/source/object-retention/bucket-versioning.rst
+++ b/source/object-retention/bucket-versioning.rst
@@ -103,8 +103,8 @@ more information.
 You can alternatively perform manual removal of object versions using the 
 following commands:
 
-- :mc-cmd-option:`mc rm versions` - Removes all versions of an object.
-- :mc-cmd-option:`mc rm --versions --older-than <mc rm older-than>` -
+- :mc-cmd:`mc rm --versions` - Removes all versions of an object.
+- :mc-cmd:`mc rm --versions --older-than <mc rm --older-than>` -
    Removes all versions of an object older than the specified calendar date.
 
 .. _minio-bucket-versioning-id:
@@ -189,16 +189,16 @@ are **irreversible**.
 The following :mc:`mc` commands operate on ``DeleteMarkers`` or versioned 
 objects:
 
-- Use :mc-cmd-option:`mc ls versions` to view all versions of an object,
+- Use :mc-cmd:`mc ls --versions` to view all versions of an object,
   including delete markers.
 
-- Use :mc-cmd-option:`mc cp --version-id=UUID ... <mc cp version-id>` to 
+- Use :mc-cmd:`mc cp --version-id=UUID ... <mc cp version-id>` to 
   retrieve the version of the "deleted" object with matching ``UUID``.
 
-- Use :mc-cmd-option:`mc rm --version-id=UUID ... <mc rm version-id>` to delete
+- Use :mc-cmd:`mc rm --version-id=UUID ... <mc rm version-id>` to delete
   the version of the object with matching ``UUID``.
 
-- Use :mc-cmd-option:`mc rm versions` to delete *all* versions of an object.
+- Use :mc-cmd:`mc rm --versions` to delete *all* versions of an object.
 
 Tutorials
 ---------

--- a/source/object-retention/minio-object-locking.rst
+++ b/source/object-retention/minio-object-locking.rst
@@ -216,7 +216,7 @@ the MinIO :mc:`mc` CLI, or using an S3-compatible SDK.
    .. tab-item:: MinIO CLI
       :sync: cli
 
-      Use The command command with the :mc-cmd-option:`~mc mb with-lock`
+      Use The command command with the :mc-cmd:`~mc mb with-lock`
       option to create a bucket with object locking enabled:
 
       .. code-block:: shell
@@ -287,8 +287,8 @@ preferred SDK.
       :sync: cli
 
       Use The command command with the
-      :mc-cmd-option:`--recursive <mc retention set recursive>` and
-      :mc-cmd-option:`--default <mc retention set default>` options to set the
+      :mc-cmd:`--recursive <mc retention set --recursive>` and
+      :mc-cmd:`--default <mc retention set --default>` options to set the
       default retention mode for a bucket:
 
       .. code-block:: shell

--- a/source/reference/minio-mc-admin/mc-admin-bucket-quota.rst
+++ b/source/reference/minio-mc-admin/mc-admin-bucket-quota.rst
@@ -32,7 +32,7 @@ storage quotas.
 Units of Measurement
 ~~~~~~~~~~~~~~~~~~~~
 
-The :mc-cmd-option:`mc admin bucket quota hard` flag
+The :mc-cmd:`mc admin bucket quota --hard` flag
 accepts the following case-insensitive suffixes to represent the unit of the
 specified size value:
 
@@ -77,7 +77,7 @@ Configure a Hard Quota on a Bucket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc:`mc admin bucket quota` with the
-:mc-cmd-option:`~mc admin bucket quota hard` flag to specify a hard quota 
+:mc-cmd:`~mc admin bucket quota --hard` flag to specify a hard quota 
 on a bucket. Hard quotas prevent the bucket size from growing past the specified
 limit.
 
@@ -113,7 +113,7 @@ Clear Configured Bucket Quota
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc:`mc admin bucket quota` with the
-:mc-cmd-option:`~mc admin bucket quota clear` flag to clear all quotas from
+:mc-cmd:`~mc admin bucket quota --clear` flag to clear all quotas from
 a bucket.
 
 .. code-block:: shell
@@ -151,8 +151,8 @@ Syntax
    Omit all other arguments to return the current quota settings for the
    specified bucket.
 
-.. mc-cmd:: hard
-   :option:
+.. mc-cmd:: --hard
+   
 
    Sets a maximum limit to the bucket storage size. The MinIO server rejects any
    incoming ``PUT`` request whose contents would exceed the bucket's configured
@@ -163,8 +163,8 @@ Syntax
 
    See :ref:`mc-admin-bucket-quota-units` for supported unit sizes.
 
-.. mc-cmd:: clear
-   :option:
+.. mc-cmd:: --clear
+   
 
    Clears all quotas configured for the bucket. 
 

--- a/source/reference/minio-mc-admin/mc-admin-bucket-remote.rst
+++ b/source/reference/minio-mc-admin/mc-admin-bucket-remote.rst
@@ -145,21 +145,21 @@ Syntax
          destination.
 
    .. mc-cmd:: service
-      :option:
+      
 
       *Required*
 
       Specify ``"replication"``.
 
    .. mc-cmd:: region
-      :option:
+      
 
       The region of the :mc-cmd:`~mc admin bucket remote add DESTINATION`. 
 
-      Mutually exclusive with :mc-cmd-option:`~mc admin bucket remote add path`
+      Mutually exclusive with :mc-cmd:`~mc admin bucket remote add path`
 
    .. mc-cmd:: path
-      :option:
+      
 
       The bucket path lookup supported by the destination server. Specify
       one of the following:
@@ -169,10 +169,10 @@ Syntax
       - ``auto`` (Default)
 
       Mutually exclusive with 
-      :mc-cmd-option:`~mc admin bucket remote add region`
+      :mc-cmd:`~mc admin bucket remote add region`
 
    .. mc-cmd:: sync
-      :option:
+      
 
       Enables synchronous replication, where MinIO attempts to replicate
       the object *prior* to returning the PUT object response. Synchronous 
@@ -208,7 +208,7 @@ Syntax
          mc admin bucket ls play/mybucket
 
    .. mc-cmd:: service
-      :option:
+      
 
       *Required*
 
@@ -243,7 +243,7 @@ Syntax
          mc admin bucket remove play/mybucket
 
    .. mc-cmd:: ARN
-      :option:
+      
 
       *Required*
 

--- a/source/reference/minio-mc-admin/mc-admin-console.rst
+++ b/source/reference/minio-mc-admin/mc-admin-console.rst
@@ -49,13 +49,13 @@ Syntax
 
    The specific MinIO server node from which the command retrieves server logs.
 
-.. mc-cmd:: limit, l
-   :option:
+.. mc-cmd:: --limit, l
+   
 
    The number of most recent log entries to show. Defaults to ``10``.
 
-.. mc-cmd:: type, t
-   :option:
+.. mc-cmd:: --type, t
+   
 
    The type of errog logs to return. Specify one or more of the following
    options as a comma-seperated ``,`` list:

--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -60,8 +60,8 @@ Syntax
    If the ``TARGET`` bucket or bucket prefix has an active healing scan,
    the command returns the status of that scan.
 
-.. mc-cmd:: scan
-   :option:
+.. mc-cmd:: --scan
+   
 
    The type of scan to perform. Specify one of the following supported scan
    modes:
@@ -69,28 +69,28 @@ Syntax
    - ``normal`` (default)
    - ``deep``
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    Recursively scans for objects in the specified bucket or bucket prefix.
 
-.. mc-cmd:: dry-run
-   :option:
+.. mc-cmd:: --dry-run
+   
 
    Inspects the :mc-cmd:`~mc admin heal TARGET` bucket or bucket prefix, 
    but does *not* perform any object healing.
 
 .. mc-cmd:: force-start, f
-   :option:
+   
 
    Force starts the healing process.
 
 .. mc-cmd:: force-stop, s
-   :option:
+   
 
    Force stops the healing sequence.
 
-.. mc-cmd:: remove
-   :option:
+.. mc-cmd:: --remove
+   
 
    Removes dangling objects in the healing process. 

--- a/source/reference/minio-mc-admin/mc-admin-obd.rst
+++ b/source/reference/minio-mc-admin/mc-admin-obd.rst
@@ -61,8 +61,8 @@ Syntax
    The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment from which
    the command retrieves the diagnostic data.
 
-.. mc-cmd:: deadline
-   :option:
+.. mc-cmd:: --deadline
+   
 
    The maximum duration the command can run. Specify a string as 
    ``##h##m##s``. Defaults to ``1h0m0s``. 

--- a/source/reference/minio-mc-admin/mc-admin-profile.rst
+++ b/source/reference/minio-mc-admin/mc-admin-profile.rst
@@ -42,7 +42,7 @@ Profile Data for Single Resource
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc-cmd:`mc admin profile start` with the
-:mc-cmd-option:`~mc admin profile start type` flag to start profiling the
+:mc-cmd:`~mc admin profile start type` flag to start profiling the
 resource:
 
 .. code-block:: shell
@@ -70,7 +70,7 @@ Profile Data for Multiple Resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc-cmd:`mc admin profile start` with the
-:mc-cmd-option:`~mc admin profile start type` flag to start profiling the
+:mc-cmd:`~mc admin profile start type` flag to start profiling the
 resources:
 
 .. code-block:: shell
@@ -125,7 +125,7 @@ Syntax
       which the command collects profiling data.
 
    .. mc-cmd:: type
-      :option:
+      
 
       The type(s) of profiling data to collect from the 
       :mc-cmd:`~mc admin profile start TARGET` MinIO deployment.

--- a/source/reference/minio-mc-admin/mc-admin-speedtest.rst
+++ b/source/reference/minio-mc-admin/mc-admin-speedtest.rst
@@ -52,17 +52,17 @@ Syntax
 
    The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment to run the speedtest against.
 
-.. mc-cmd:: duration
-   :option:
+.. mc-cmd:: --duration
+   
 
    The duration the entire speedtests are run. Defaults to ``10s``.
 
-.. mc-cmd:: size
-   :option:
+.. mc-cmd:: --size
+   
 
    The size of the objects used for uploads/downloads. Defaults to ``64MiB``.
 
-.. mc-cmd:: concurrent
-   :option:
+.. mc-cmd:: --concurrent
+   
 
    The number of concurrent requests per server. Defaults to ``32``.

--- a/source/reference/minio-mc-admin/mc-admin-tier.rst
+++ b/source/reference/minio-mc-admin/mc-admin-tier.rst
@@ -129,8 +129,8 @@ Syntax
 
              Requires specifying the following additional options:
 
-             - :mc-cmd-option:`~mc admin tier add access-key`
-             - :mc-cmd-option:`~mc admin tier add secret-key`
+             - :mc-cmd:`~mc admin tier add access-key`
+             - :mc-cmd:`~mc admin tier add secret-key`
 
          * - ``azure``
            - Use :abbr:`Azure (Microsoft Azure)` Blob Storage as the storage
@@ -138,8 +138,8 @@ Syntax
 
              Requires specifying the following additional options:
 
-             - :mc-cmd-option:`~mc admin tier add account-name`
-             - :mc-cmd-option:`~mc admin tier add account-key`
+             - :mc-cmd:`~mc admin tier add account-name`
+             - :mc-cmd:`~mc admin tier add account-key`
          
          * - ``gcs`` 
            - Use :abbr:`GCP (Google Cloud Platform)` Cloud Storage as the
@@ -147,7 +147,7 @@ Syntax
 
              Requires specifying the following additional option:
 
-             - :mc-cmd-option:`~mc admin tier add credentials-file`
+             - :mc-cmd:`~mc admin tier add credentials-file`
 
    .. mc-cmd:: TARGET
 
@@ -166,7 +166,7 @@ Syntax
       You **must** specify the tier in all-caps, e.g. ``WARM_TIER``.
    
    .. mc-cmd:: endpoint
-      :option:
+      
 
       *Required*
       
@@ -175,7 +175,7 @@ Syntax
       :mc-cmd:`~mc admin tier add TIER_TYPE`. 
 
    .. mc-cmd:: access-key
-      :option:
+      
 
       *Required*
       
@@ -187,7 +187,7 @@ Syntax
       This option has no effect for any other value of ``TIER_TYPE``.
 
    .. mc-cmd:: secret-key
-      :option:
+      
 
       *Required*
       
@@ -197,7 +197,7 @@ Syntax
       This option has no effect for any other value of ``TIER_TYPE``.
 
    .. mc-cmd:: account-name
-      :option:
+      
 
       *Required*
       
@@ -214,18 +214,18 @@ Syntax
       to any objects transitioned to the original account/backend.
 
    .. mc-cmd:: account-key
-      :option:
+      
 
       *Required*
       
-      The account key for the :mc-cmd-option:`~mc admin tier add account-name` 
+      The account key for the :mc-cmd:`~mc admin tier add account-name` 
       associated to the remote Azure tier.
 
       Required if :mc-cmd:`~mc admin tier add TIER_TYPE` is ``azure``. 
       This option has no effect for any other value of ``TIER_TYPE``.
 
    .. mc-cmd:: credentials-file
-      :option:
+      
 
       *Required*
       
@@ -238,14 +238,14 @@ Syntax
       This option has no effect for any other value of ``TIER_TYPE``.
 
    .. mc-cmd:: bucket
-      :option:
+      
 
       *Required*
       
       The bucket on the remote tier to which MinIO transitions objects.
 
    .. mc-cmd:: prefix
-      :option:
+      
 
       *Optional*
       
@@ -255,7 +255,7 @@ Syntax
       Omit this field to transition objects into the bucket root.
 
    .. mc-cmd:: storage-class
-      :option:
+      
 
       *Optional*
 
@@ -271,7 +271,7 @@ Syntax
       ``s3``. This option has no effect for any other value of ``TIER_TYPE``.
 
    .. mc-cmd:: region
-      :option:
+      
 
       *Optional*
 
@@ -312,7 +312,7 @@ Syntax
       when creating the remote tier.
 
    .. mc-cmd:: access-key
-      :option:
+      
 
       *Optional*
       
@@ -325,7 +325,7 @@ Syntax
       This option has no effect for any other ``TIER_TYPE``.
 
    .. mc-cmd:: secret-key
-      :option:
+      
 
       *Optional*
       
@@ -336,13 +336,13 @@ Syntax
       This option has no effect for any other ``TIER_TYPE``.
 
    .. mc-cmd:: account-key
-      :option:
+      
 
       *Required*
 
       The account key for a user on the remote Azure tier.
       Use this option to rotate the credentials for the
-      :mc-cmd-option:`~mc admin tier add account-name` 
+      :mc-cmd:`~mc admin tier add account-name` 
       associated to the remote tier.
 
       This option only applies to remote storage tiers with 
@@ -350,7 +350,7 @@ Syntax
       This option has no effect for any other ``TIER_TYPE``.
 
    .. mc-cmd:: credentials-file
-      :option:
+      
 
       *Required*
       

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -59,18 +59,18 @@ Syntax
    Specify the :mc:`alias <mc alias>` of a configured MinIO deployment
    against which the command issues ``HTTP TRACE`` requests.
 
-.. mc-cmd:: all, a
-   :option:
+.. mc-cmd:: --all, a
+   
 
    Returns all traffic on the MinIO deployment, including internode traffic
    between MinIO servers.
 
-.. mc-cmd:: verbose
-   :option:
+.. mc-cmd:: --verbose
+   
 
    Returns verbose ``HTTP TRACE`` output.
 
-.. mc-cmd:: errors, e
-   :option:
+.. mc-cmd:: --errors, e
+   
 
    Returns failed ``HTTP TRACE`` requests only.

--- a/source/reference/minio-mc/mc-alias-set.rst
+++ b/source/reference/minio-mc/mc-alias-set.rst
@@ -88,8 +88,8 @@ Parameters
 
    The secret key for authenticating to the S3 service.
 
-.. mc-cmd:: api
-   :option:
+.. mc-cmd:: --api
+   
    
    *Optional*
 
@@ -110,8 +110,8 @@ Parameters
       MinIO server does not rely on nor require ``S3v2``, nor are all API
       operations available on ``S3v2``. 
 
-.. mc-cmd:: path
-   :option:
+.. mc-cmd:: --path
+   
 
    *Optional*
 

--- a/source/reference/minio-mc/mc-cat.rst
+++ b/source/reference/minio-mc/mc-cat.rst
@@ -15,9 +15,9 @@
 .. Replacement substitutions
 
 .. |command| replace:: :mc-cmd:`mc cat`
-.. |rewind| replace:: :mc-cmd-option:`~mc cat rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc cat version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc cat ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc cat --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc cat version-id`
+.. |alias| replace:: :mc-cmd:`~mc cat ALIAS`
 
 Syntax
 ------
@@ -90,22 +90,22 @@ Parameters
 
       mc cat ~/data/object.txt
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
       :end-before: end-version-id-desc
 
-.. mc-cmd:: encrypt-key
-   :option:
+.. mc-cmd:: --encrypt-key
+   
 
    Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
@@ -115,9 +115,9 @@ Parameters
       object(s).
 
    Enclose the entire list of key-value pairs passed to 
-   :mc-cmd-option:`~mc cat encrypt-key` in double quotes ``"``.
+   :mc-cmd:`~mc cat --encrypt-key` in double quotes ``"``.
 
-   :mc-cmd-option:`~mc cat encrypt-key` can use the ``MC_ENCRYPT_KEY``
+   :mc-cmd:`~mc cat --encrypt-key` can use the ``MC_ENCRYPT_KEY``
    environment variable for retrieving a list of encryption key-value pairs
    as an alternative to specifying them on the command line.
 
@@ -150,7 +150,7 @@ Use :mc-cmd:`mc cat` to return the object:
 View an S3 Object at a Point-In-Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc cat rewind` to return the object at a specific
+Use :mc-cmd:`mc cat --rewind` to return the object at a specific
 point-in-time in the past:
 
 .. code-block:: shell
@@ -164,7 +164,7 @@ point-in-time in the past:
 - Replace :mc-cmd:`PATH <mc cat ALIAS>` with the path to the object on the
   S3-compatible host.
 
-- Replace :mc-cmd:`DURATION <mc cat rewind>` with the point-in-time in the past
+- Replace :mc-cmd:`DURATION <mc cat --rewind>` with the point-in-time in the past
   at which the command returns the object. For example, specify ``30d`` to
   return the version of the object 30 days prior to the current date.
 
@@ -175,7 +175,7 @@ point-in-time in the past:
 View an S3 Object with Specific Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc cat version-id` to return a specific version of the 
+Use :mc-cmd:`mc cat version-id` to return a specific version of the 
 object:
 
 .. code-block:: shell

--- a/source/reference/minio-mc/mc-cp.rst
+++ b/source/reference/minio-mc/mc-cp.rst
@@ -13,9 +13,9 @@
 .. mc:: mc cp
 
 .. |command| replace:: :mc-cmd:`mc cp`
-.. |rewind| replace:: :mc-cmd-option:`~mc cp rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc cp version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc cp SOURCE`
+.. |rewind| replace:: :mc-cmd:`~mc cp --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc cp version-id`
+.. |alias| replace:: :mc-cmd:`~mc cp SOURCE`
 
 Syntax
 ------
@@ -104,7 +104,7 @@ Parameters
       mc cp ~/mydata/object.txt play/mybucket/object.txt
    
    If you specify a directory or bucket to :mc-cmd:`~mc cp SOURCE`, you must
-   also specify :mc-cmd-option:`~mc cp recursive` to recursively copy the
+   also specify :mc-cmd:`~mc cp --recursive` to recursively copy the
    contents of that directory or bucket. If you omit the ``--recursive``
    argument, :mc:`~mc cp` only copies objects in the top level of the specified
    directory or bucket.
@@ -129,25 +129,25 @@ Parameters
 
       mc cp play/mybucket/object.txt ~/mydata/object.txt
 
-.. mc-cmd:: attr
-   :option:
+.. mc-cmd:: --attr
+   
 
    *Optional* Add custom metadata for the object. Specify key-value pairs as
    ``KEY=VALUE\;``. For example, ``--attr
    key1=value1\;key2=value2\;key3=value3``.
 
-.. mc-cmd:: continue, c
-   :option:
+.. mc-cmd:: --continue, c
+   
 
    *Optional* Create or resume a copy session. 
 
-.. mc-cmd:: disable-multipart
-   :option:
+.. mc-cmd:: --disable-multipart
+   
 
    *Optional* Disables multipart upload for the copy session.
 
-.. mc-cmd:: encrypt
-   :option:
+.. mc-cmd:: --encrypt
+   
 
    *Optional* Encrypt or decrypt objects using 
    :ref:`server-side encryption <minio-sse>` with
@@ -158,14 +158,14 @@ Parameters
       object(s).
 
    Enclose the entire list of key-value pairs passed to
-   :mc-cmd-option:`~mc cp encrypt` in double-quotes ``"``.
+   :mc-cmd:`~mc cp --encrypt` in double-quotes ``"``.
 
-   :mc-cmd-option:`~mc cp encrypt` can use the ``MC_ENCRYPT`` environment
+   :mc-cmd:`~mc cp --encrypt` can use the ``MC_ENCRYPT`` environment
    variable for retrieving a list of encryption key-value pairs as an
    alternative to specifying them on the command line.
 
-.. mc-cmd:: encrypt-key
-   :option:
+.. mc-cmd:: --encrypt-key
+   
 
    *Optional* Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
@@ -175,14 +175,14 @@ Parameters
       object(s).
 
    Enclose the entire list of key-value pairs passed to 
-   :mc-cmd-option:`~mc cp encrypt-key` in double quotes ``"``.
+   :mc-cmd:`~mc cp --encrypt-key` in double quotes ``"``.
 
-   :mc-cmd-option:`~mc cp encrypt-key` can use the ``MC_ENCRYPT_KEY``
+   :mc-cmd:`~mc cp --encrypt-key` can use the ``MC_ENCRYPT_KEY``
    environment variable for retrieving a list of encryption key-value pairs
    as an alternative to specifying them on the command line.
 
-.. mc-cmd:: legal-hold
-   :option:
+.. mc-cmd:: --legal-hold
+   
 
    *Optional* Enables indefinite :ref:`Legal Hold 
    <minio-object-locking-legalhold>` object locking on the copied objects.
@@ -190,42 +190,42 @@ Parameters
    Specify ``on``.
 
 .. mc-cmd:: md5
-   :option:
+   
 
    *Optional* Forces all uploads to calculate MD5 checksums. 
 
-.. mc-cmd:: newer-than
-   :option:
+.. mc-cmd:: --newer-than
+   
 
    *Optional* Remove object(s) newer than the specified number of days.  Specify
    a string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``
 
    Defaults to ``0`` (all objects).
 
-.. mc-cmd:: older-than
-   :option:
+.. mc-cmd:: --older-than
+   
 
    *Optional* Remove object(s) older than the specified time limit. Specify a
    string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``
       
    Defaults to ``0`` (all objects).
 
-.. mc-cmd:: preserve, a
-   :option:
+.. mc-cmd:: --preserve, a
+   
 
    *Optional* Preserve file system attributes and bucket policy rules of the
    :mc-cmd:`~mc cp SOURCE` directories, buckets, and objects on the 
    :mc-cmd:`~mc cp TARGET` bucket(s).
 
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
    
    *Optional* Recursively copy the contents of each bucket or directory
    :mc-cmd:`~mc cp SOURCE` to the :mc-cmd:`~mc cp TARGET` bucket.
 
-.. mc-cmd:: retention-duration
-   :option:
+.. mc-cmd:: --retention-duration
+   
 
    *Optional* The duration of the :ref:`WORM retention mode 
    <minio-object-locking-retention-modes>` to apply to the copied object(s).
@@ -233,10 +233,10 @@ Parameters
    Specify the duration as a string in
    ``#d#hh#mm#ss`` format. For example: ``--retention-duration "1d2hh3mm4ss"``.
 
-   Requires specifying :mc-cmd-option:`~mc cp retention-mode`.
+   Requires specifying :mc-cmd:`~mc cp --retention-mode`.
 
-.. mc-cmd:: retention-mode
-   :option:
+.. mc-cmd:: --retention-mode
+   
 
    *Optional* enables :ref:`object locking mode
    <minio-object-locking-retention-modes>` on the copied object(s).
@@ -245,17 +245,17 @@ Parameters
    - ``GOVERNANCE``
    - ``COMPLIANCE``
 
-   Requires specifying :mc-cmd-option:`~mc cp retention-duration`.
+   Requires specifying :mc-cmd:`~mc cp --retention-duration`.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
 .. mc-cmd:: storage-class, sc
-   :option:
+   
 
    *Optional* Set the storage class for the new object(s) on the 
    :mc-cmd:`~mc cp TARGET`. 
@@ -263,8 +263,8 @@ Parameters
    See :aws-docs:`AmazonS3/latest/dev/storage-class-intro.html` for
    more information on S3 storage classses.
 
-.. mc-cmd:: tags
-   :option:
+.. mc-cmd:: --tags
+   
 
    *Optional* Applies one or more tags to the copied objects.
 
@@ -273,7 +273,7 @@ Parameters
    assign to the objects.
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -336,7 +336,7 @@ Use :mc-cmd:`mc cp` to copy an object to an S3-compatible host:
 Recursively Copy Objects to S3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc cp recursive` to recursively copy objects to an
+Use :mc-cmd:`mc cp --recursive` to recursively copy objects to an
 S3-compatible host:
 
 .. tab-set::
@@ -382,7 +382,7 @@ S3-compatible host:
 Copy Point-In-Time Version of Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc cp rewind` to copy an object as it existed at a 
+Use :mc-cmd:`mc cp --rewind` to copy an object as it existed at a 
 specific point in time. This command only applies to S3-to-S3 copy.
 
 .. code-block:: shell
@@ -390,7 +390,7 @@ specific point in time. This command only applies to S3-to-S3 copy.
 
    mc cp --rewind DURATION SRCALIAS/SRCPATH TGTALIAS/TGTPATH
 
-- Replace :mc-cmd:`DURATION <mc cp rewind>` with the point-in-time in the 
+- Replace :mc-cmd:`DURATION <mc cp --rewind>` with the point-in-time in the 
   past at which the command copies the object. For example, specify
   ``30d`` to copy the version of the object 30 days prior to the 
   current date.
@@ -415,7 +415,7 @@ specific point in time. This command only applies to S3-to-S3 copy.
 Copy Specific Version of Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc cp version-id` to copy a specific version of an object. This
+Use :mc-cmd:`mc cp version-id` to copy a specific version of an object. This
 command only applies to S3-to-S3 copy.
 
 .. code-block:: shell
@@ -423,7 +423,7 @@ command only applies to S3-to-S3 copy.
 
    mc cp --version-id VERSION SRCALIAS/SRCPATH TGTALIAS/TGTPATH
 
-- Replace :mc-cmd:`VERSION <mc cp rewind>` with the version of the object to
+- Replace :mc-cmd:`VERSION <mc cp --rewind>` with the version of the object to
   copy.
 
 - Replace :mc-cmd:`SRCALIAS <mc cp SOURCE>` with the 
@@ -452,7 +452,7 @@ checksums.
 
 Interrupted or failed copy operations can resume from the point of failure
 by issuing the :mc:`mc cp` operation again with the 
-:mc-cmd-option:`~mc cp continue` argument.
+:mc-cmd:`~mc cp --continue` argument.
 
 S3 Compatibility
 ~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-encrypt-set.rst
+++ b/source/reference/minio-mc/mc-encrypt-set.rst
@@ -145,7 +145,7 @@ server cannot support may result in undesired behavior.
 Setting or modifying the default server-side encryption settings does *not*
 automatically encrypt or decrypt the existing bucket contents. If the bucket
 contents *must* have consistent encryption, use the
-:mc:`mc mv` mc with the :mc-cmd-option:`~mc mv encrypt` or
-:mc-cmd-option:`~mc mv encrypt-key` arguments to manually modify the
+:mc:`mc mv` mc with the :mc-cmd:`~mc mv --encrypt` or
+:mc-cmd:`~mc mv --encrypt-key` arguments to manually modify the
 encryption settings or encrypted state of the bucket contents *before*
 changing the bucket default. 

--- a/source/reference/minio-mc/mc-event-add.rst
+++ b/source/reference/minio-mc/mc-event-add.rst
@@ -83,8 +83,8 @@ Parameters
    :doc:`/monitoring/bucket-notifications/bucket-notifications` for more
    information.
 
-.. mc-cmd:: event
-   :option:
+.. mc-cmd:: --event
+   
 
    *Optional* The event(s) for which MinIO generates bucket notifications. 
 
@@ -102,31 +102,31 @@ Parameters
    associated to each of the supported values.
 
 .. mc-cmd:: ignore-existing, p
-   :option:
+   
 
    *Optional* Directs MinIO to ignore applying the specified event
    triggers if an existing matching trigger exists.
 
-.. mc-cmd:: prefix
-   :option:
+.. mc-cmd:: --prefix
+   
 
    *Optional* The bucket prefix in which the specified 
-   :mc-cmd-option:`~mc event add event` can trigger a bucket notification.
+   :mc-cmd:`~mc event add --event` can trigger a bucket notification.
 
    For example, given a :mc-cmd:`~mc event add ALIAS` of ``play/mybucket``
-   and a :mc-cmd-option:`~mc event add prefix` of ``photos``, only events in
+   and a :mc-cmd:`~mc event add --prefix` of ``photos``, only events in
    ``play/mybucket/photos`` trigger bucket notifications.
 
    Omit to trigger the event for all prefixes and objects in the bucket.
 
-.. mc-cmd:: suffix
-   :option:
+.. mc-cmd:: --suffix
+   
 
    *Optional* The bucket suffix in which the specified 
-   :mc-cmd-option:`~mc event add event` can trigger a bucket notification. 
+   :mc-cmd:`~mc event add --event` can trigger a bucket notification. 
 
    For example, given a :mc-cmd:`~mc event add ALIAS` of ``play/mybucket``
-   and a :mc-cmd-option:`~mc event add suffix` of ``.jpg``, only events in
+   and a :mc-cmd:`~mc event add --suffix` of ``.jpg``, only events in
    ``play/mybucket/*.jpg`` trigger bucket notifications.
 
    Omit to trigger the event for all objects regardless of suffix.

--- a/source/reference/minio-mc/mc-event-remove.rst
+++ b/source/reference/minio-mc/mc-event-remove.rst
@@ -81,40 +81,40 @@ Parameters
    :ref:`minio-bucket-notifications` for more
    information.
 
-.. mc-cmd:: event
-   :option:
+.. mc-cmd:: --event
+   
    
    *Optional* The event(s) to remove. Specify multiple events using a comma
    ``,`` delimiter. See :ref:`mc-event-supported-events` for supported events.
 
    Defaults to removing all events on the :mc-cmd:`~mc event remove ALIAS`
-   bucket with the :mc-cmd-option:`~mc event remove ARN` notification target.
+   bucket with the :mc-cmd:`~mc event remove ARN` notification target.
 
-.. mc-cmd:: force
-   :option:
+.. mc-cmd:: --force
+   
    
    *Optional* Removes all events on the :mc-cmd:`~mc event remove ALIAS` bucket
-   with the :mc-cmd-option:`~mc event remove ARN` notification target.
+   with the :mc-cmd:`~mc event remove ARN` notification target.
 
-.. mc-cmd:: prefix
-   :option:
+.. mc-cmd:: --prefix
+   
 
    *Optional* The bucket prefix in which the command removes bucket
    notifications.
 
    For example, given a :mc-cmd:`~mc event remove ALIAS` of
-   ``play/mybucket`` and a :mc-cmd-option:`~mc event remove prefix` of
+   ``play/mybucket`` and a :mc-cmd:`~mc event remove --prefix` of
    ``photos``, the command only removes bucket notifications in
    ``play/mybucket/photos``.
 
-.. mc-cmd:: suffix
-   :option:
+.. mc-cmd:: --suffix
+   
 
    *Optional* The bucket suffix in which the command removes bucket
    notifications. 
 
    For example, given a :mc-cmd:`~mc event remove ALIAS` of
-   ``play/mybucket`` and a :mc-cmd-option:`~mc event remove suffix` of
+   ``play/mybucket`` and a :mc-cmd:`~mc event remove --suffix` of
    ``.jpg``, the command only removes bucket notifications in
    ``play/mybucket/*.jpg``.
 

--- a/source/reference/minio-mc/mc-find.rst
+++ b/source/reference/minio-mc/mc-find.rst
@@ -86,75 +86,75 @@ Parameters
    Issuing :mc-cmd:`mc find ALIAS` with no other arguments returns a list of
    *all* objects or files at the specified path, similar to :mc-cmd:`mc ls`.
 
-.. mc-cmd:: exec
-   :option:
+.. mc-cmd:: --exec
+   
    
    *Optional* Spawns an external process for each object returned by 
    :mc:`mc find`. Supports :ref:`substitution formatting
    <mc-find-substitution-format>` of the output.
 
-.. mc-cmd:: ignore
-   :option:
+.. mc-cmd:: --ignore
+   
 
    *Optional* Exclude objects whose names match the specified wildcard pattern.
 
 
-.. mc-cmd:: larger
-   :option:
+.. mc-cmd:: --larger
+   
 
    *Optional* Match all objects larger than the specified size in 
    :ref:`units <mc-find-units>`.
 
-.. mc-cmd:: maxdepth
-   :option:
+.. mc-cmd:: --maxdepth
+   
 
    *Optional* Limits directory navigation to the specified depth.
 
-.. mc-cmd:: name
-   :option:
+.. mc-cmd:: --name
+   
 
    *Optional* Return objects whose names match the specified wildcard pattern.
 
-.. mc-cmd:: newer-than
-   :option:
+.. mc-cmd:: --newer-than
+   
 
    *Optional* Mirror object(s) newer than the specified number of days.  Specify
    a string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``
 
-.. mc-cmd:: older-than
-   :option:
+.. mc-cmd:: --older-than
+   
 
    *Optional* Mirror object(s) older than the specified time limit. Specify a
    string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``
       
    Defaults to ``0`` (all objects).
 
-.. mc-cmd:: path
-   :option:
+.. mc-cmd:: --path
+   
 
    *Optional* Return the contents of directories whose names match the specified
    wildcard pattern.
 
-.. mc-cmd:: print
-   :option:
+.. mc-cmd:: --print
+   
 
    *Optional* Prints results to ``STDOUT``.  Supports 
    :ref:`substitution formatting <mc-find-substitution-format>` of the output.
 
-.. mc-cmd:: regex
-   :option:
+.. mc-cmd:: --regex
+   
 
    *Optional* Returns objects or the contents of directories whose names match
    the specified PCRE regex pattern.
 
-.. mc-cmd:: smaller
-   :option:
+.. mc-cmd:: --smaller
+   
 
    *Optional* Match all objects smaller than the specifized size in 
    :ref:`units <mc-find-units>`.
 
-.. mc-cmd:: watch
-   :option:
+.. mc-cmd:: --watch
+   
 
    *Optional* Continuously monitor the :mc-cmd:`~mc find ALIAS` and return any
    new objects which match the specified criteria.
@@ -183,7 +183,7 @@ Find a Specific Object in a Bucket
 - Replace :mc-cmd:`PATH <mc find ALIAS>` with the path to a bucket on the
   S3-compatible host. Omit the path to search from the root of the S3 host.
 
-- Replace :mc-cmd:`NAME <mc find name>` with the object.
+- Replace :mc-cmd:`NAME <mc find --name>` with the object.
 
 Find Objects with File Extention in Bucket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -199,13 +199,13 @@ Find Objects with File Extention in Bucket
 - Replace :mc-cmd:`PATH <mc find ALIAS>` with the path to a bucket on the
   S3-compatible host.
 
-- Replace :mc-cmd:`EXTENSION <mc find name>` with the file extention of the 
+- Replace :mc-cmd:`EXTENSION <mc find --name>` with the file extention of the 
   object.
 
 Find All Matching Files and Copy To S3 Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc find` with the :mc-cmd-option:`~mc find exec` option to find
+Use :mc:`mc find` with the :mc-cmd:`~mc find --exec` option to find
 files on a local filesystem and pass them to an :program:`mc` command for
 further processing. The following example uses :mc:`mc cp` to copy the 
 output of :mc:`mc find` to an S3-compatible host.
@@ -218,7 +218,7 @@ output of :mc:`mc find` to an S3-compatible host.
 - Replace :mc-cmd:`FILEPATH <mc find ALIAS>` with the full file path to the
   directory to search.
 
-- Replace :mc-cmd:`EXTENSION <mc find name>` with the file extention of the 
+- Replace :mc-cmd:`EXTENSION <mc find --name>` with the file extention of the 
   object.
 
 - Replace :mc-cmd:`ALIAS <mc find ALIAS>` with the 
@@ -228,7 +228,7 @@ output of :mc:`mc find` to an S3-compatible host.
   S3-compatible host.
 
 To continuously watch the specified directory and copy new objects, 
-include the :mc-cmd-option:`~mc find watch` argument:
+include the :mc-cmd:`~mc find --watch` argument:
 
 .. code-block:: shell
    :class: copyable
@@ -243,7 +243,7 @@ Behavior
 Units of Measurement
 ~~~~~~~~~~~~~~~~~~~~
 
-The :mc-cmd-option:`mc find smaller` and :mc-cmd-option:`mc find larger` flags
+The :mc-cmd:`mc find --smaller` and :mc-cmd:`mc find --larger` flags
 accept the following case-insensitive suffixes to represent the unit of the
 specified size value:
 
@@ -287,7 +287,7 @@ Omitting the suffix defaults to ``bytes``.
 Substitution Format
 ~~~~~~~~~~~~~~~~~~~
 
-The :mc-cmd-option:`mc find exec` and :mc-cmd-option:`mc find print` commands
+The :mc-cmd:`mc find --exec` and :mc-cmd:`mc find --print` commands
 support string substitutions with special interpretations for following
 keywords. 
 

--- a/source/reference/minio-mc/mc-head.rst
+++ b/source/reference/minio-mc/mc-head.rst
@@ -14,9 +14,9 @@
 
 
 .. |command| replace:: :mc-cmd:`mc head`
-.. |rewind| replace:: :mc-cmd-option:`~mc head rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc head version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc head ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc head --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc head version-id`
+.. |alias| replace:: :mc-cmd:`~mc head ALIAS`
 
 Syntax
 ------
@@ -92,14 +92,14 @@ Parameters
       mc head ~/mydata/object.txt
 
 .. mc-cmd::  lines, n
-   :option:
+   
 
    *Optional* The number of lines to print.
 
    Defaults to ``10``.
 
 .. mc-cmd::  encrypt-key
-   :option:
+   
 
    *Optional*  Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
@@ -109,21 +109,21 @@ Parameters
       object(s).
 
    Enclose the entire list of key-value pairs passed to 
-   :mc-cmd-option:`~mc head encrypt-key` in double quotes ``"``.
+   :mc-cmd:`~mc head encrypt-key` in double quotes ``"``.
 
-   :mc-cmd-option:`~mc head encrypt-key` can use the ``MC_ENCRYPT_KEY``
+   :mc-cmd:`~mc head encrypt-key` can use the ``MC_ENCRYPT_KEY``
    environment variable for retrieving a list of encryption key-value pairs
    as an alternative to specifying them on the command line.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -159,7 +159,7 @@ Use :mc-cmd:`mc head` to return the first 10 lines of an object:
 View Partial Contents of an Object at a Point in Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc head rewind` to return the first 10 lines of the
+Use :mc-cmd:`mc head --rewind` to return the first 10 lines of the
 object at a specific point-in-time in the past:
 
 .. code-block:: shell
@@ -173,7 +173,7 @@ object at a specific point-in-time in the past:
 - Replace :mc-cmd:`PATH <mc head ALIAS>` with the path to the object on the
   S3-compatible host.
 
-- Replace :mc-cmd:`DURATION <mc head rewind>` with the point-in-time in the past
+- Replace :mc-cmd:`DURATION <mc head --rewind>` with the point-in-time in the past
   at which the command returns the object. For example, specify ``30d`` to
   return the version of the object 30 days prior to the current date.
 
@@ -184,7 +184,7 @@ object at a specific point-in-time in the past:
 View Partial Contents of an Object with Specific Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc head version-id` to return the first 10 lines of the
+Use :mc-cmd:`mc head version-id` to return the first 10 lines of the
 object at a specific point-in-time in the past:
 
 .. code-block:: shell

--- a/source/reference/minio-mc/mc-ilm-add.rst
+++ b/source/reference/minio-mc/mc-ilm-add.rst
@@ -94,8 +94,8 @@ Parameters
 
       mc ilm add myminio/mydata/someprefix
 
-.. mc-cmd:: expiry-days
-   :option:
+.. mc-cmd:: --expiry-days
+   
 
    *Required* The number of days to retain an object after being created. MinIO
    marks the object for deletion after the specified number of days pass. 
@@ -103,7 +103,7 @@ Parameters
 
    For versioned buckets, the expiry rule applies only to the *current*
    object version. Use the 
-   :mc-cmd-option:`~mc ilm add noncurrentversion-expiration-days` option
+   :mc-cmd:`~mc ilm add noncurrentversion-expiration-days` option
    to apply expiration behavior to noncurrent object versions.
 
    MinIO uses a scanner process to check objects against all configured
@@ -113,13 +113,13 @@ Parameters
 
    Mutually exclusive with the following options:
 
-   - :mc-cmd-option:`~mc ilm add expired-object-delete-marker`
+   - :mc-cmd:`~mc ilm add expired-object-delete-marker`
 
    For more complete documentation on object expiration, see
    :ref:`minio-lifecycle-management-expiration`.
 
 .. mc-cmd:: expired-object-delete-marker
-   :option:
+   
 
    *Required* Specify this option to direct MinIO to remove delete markers for
    objects with no remaining object versions. Specifically, the delete
@@ -127,8 +127,8 @@ Parameters
 
    This option is mutually exclusive with the following option:
    
-   - :mc-cmd-option:`~mc ilm add tags`
-   - :mc-cmd-option:`~mc ilm add expiry-days`
+   - :mc-cmd:`~mc ilm add --tags`
+   - :mc-cmd:`~mc ilm add --expiry-days`
 
    MinIO uses a scanner process to check objects against all configured
    lifecycle management rules. Slow scanning due to high IO workloads or
@@ -138,21 +138,21 @@ Parameters
    For more complete documentation on object expiration, see
    :ref:`minio-lifecycle-management-expiration`.
 
-.. mc-cmd:: transition-days
-   :option:
+.. mc-cmd:: --transition-days
+   
 
    *Required* The number of calendar days from object creation after which MinIO
    marks an object as eligible for transition. MinIO transitions the object to
    the configured remote storage tier specified to the 
-   :mc-cmd-option:`~mc ilm add storage-class`. Specify the number of days as an 
+   :mc-cmd:`~mc ilm add --storage-class`. Specify the number of days as an 
    integer, e.g. ``30`` for 30 days.
 
    For versioned buckets, the transition rule applies only to the *current*
    object version. Use the 
-   :mc-cmd-option:`~mc ilm add noncurrentversion-transition-days` option
+   :mc-cmd:`~mc ilm add noncurrentversion-transition-days` option
    to apply transition behavior to noncurrent object versions.
 
-   Requires specifying :mc-cmd-option:`~mc ilm add storage-class`.
+   Requires specifying :mc-cmd:`~mc ilm add --storage-class`.
 
    MinIO uses a scanner process to check objects against all configured
    lifecycle management rules. Slow scanning due to high IO workloads or
@@ -162,17 +162,17 @@ Parameters
    For more complete documentation on object transition, see
    :ref:`minio-lifecycle-management-tiering`.
 
-.. mc-cmd:: storage-class
-   :option:
+.. mc-cmd:: --storage-class
+   
 
    *Required* The remote storage tier to which MinIO 
    :ref:`transition objects <minio-lifecycle-management-tiering>`.
    Specify a remote storage tier created by :mc-cmd:`mc admin tier`. 
 
-   Required if specifying :mc-cmd-option:`~mc ilm add transition-days`.
+   Required if specifying :mc-cmd:`~mc ilm add --transition-days`.
 
-.. mc-cmd:: tags
-   :option:
+.. mc-cmd:: --tags
+   
 
    *Optional* One or more ampersand ``&``-delimited key-value pairs describing
    the object tags to use for filtering objects to which the lifecycle
@@ -180,10 +180,10 @@ Parameters
 
    This option is mutually exclusive with the following option:
 
-   - :mc-cmd-option:`~mc ilm add expired-object-delete-marker`
+   - :mc-cmd:`~mc ilm add expired-object-delete-marker`
 
 .. mc-cmd:: noncurrentversion-expiration-days
-   :option:
+   
 
    *Optional* The number of days to retain an object version after becoming
    *non-current* (i.e. a different version of that object is now the `HEAD`).
@@ -199,17 +199,17 @@ Parameters
    rules. See :ref:`minio-lifecycle-management-scanner` for more information.
 
 .. mc-cmd:: noncurrentversion-transition-days
-   :option:
+   
 
    *Optional* The number of days an object has been non-current (i.e. replaced
    by a newer version of that same object) after which MinIO marks the object
    version as eligible for transition. MinIO transitions the object to the
    configured remote storage tier specified to the 
-   :mc-cmd-option:`~mc ilm add storage-class` once the system host datetime
+   :mc-cmd:`~mc ilm add --storage-class` once the system host datetime
    passes that calendar date.
 
    This option has no effect on non-versioned buckets. Requires specifying
-   :mc-cmd-option:`~mc ilm add noncurrentversion-transition-storage-class`.
+   :mc-cmd:`~mc ilm add noncurrentversion-transition-storage-class`.
 
    This option has the same behavior as the 
    S3 ``NoncurrentVersionTransition`` action.
@@ -220,7 +220,7 @@ Parameters
    rules. See :ref:`minio-lifecycle-management-scanner` for more information.
 
 .. mc-cmd:: noncurrentversion-transition-storage-class
-   :option:
+   
 
    *Optional* The remote storage tier to which MinIO 
    :ref:`transitions noncurrent objects versions
@@ -241,7 +241,7 @@ Examples
 Expire Bucket Contents After Number of Days
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd:`mc ilm add` with :mc-cmd-option:`~mc ilm add expiry-days` to
+Use :mc-cmd:`mc ilm add` with :mc-cmd:`~mc ilm add --expiry-days` to
 expire bucket contents a number of days after object creation:
 
 .. code-block:: shell
@@ -255,7 +255,7 @@ expire bucket contents a number of days after object creation:
 - Replace :mc-cmd:`PATH <mc ilm add ALIAS>` with the path to the bucket on the
   S3-compatible host.
 
-- Replace :mc-cmd:`DATE <mc ilm add expiry-days>` with the number of days after
+- Replace :mc-cmd:`DATE <mc ilm add --expiry-days>` with the number of days after
   which to expire the object. For example, specify ``30`` to expire the
   object 30 days after creation.
 

--- a/source/reference/minio-mc/mc-ilm-edit.rst
+++ b/source/reference/minio-mc/mc-ilm-edit.rst
@@ -79,14 +79,14 @@ Parameters
 
       mc ilm edit myminio/mydata
 
-.. mc-cmd:: id
-   :option:
+.. mc-cmd:: --id
+   
 
    *Required* The unique ID of the rule. Use :mc-cmd:`mc ilm ls` to list bucket
    rules and retrieve the ``id`` for the rule you want to modify.
 
-.. mc-cmd:: expiry-days
-   :option:
+.. mc-cmd:: --expiry-days
+   
 
    *Optional* The number of days to retain an object after being created. MinIO
    marks the object for deletion after the specified number of days pass.
@@ -101,7 +101,7 @@ Parameters
 
    For versioned buckets, the expiry rule applies only to the *current*
    object version. Use the 
-   :mc-cmd-option:`~mc ilm edit noncurrentversion-expiration-days` option
+   :mc-cmd:`~mc ilm edit noncurrentversion-expiration-days` option
    to apply expiration behavior to noncurrent object versions.
 
    MinIO uses a scanner process to check objects against all configured
@@ -111,10 +111,10 @@ Parameters
 
    Mutually exclusive with the following options:
 
-   - :mc-cmd-option:`~mc ilm edit expired-object-delete-marker`
+   - :mc-cmd:`~mc ilm edit expired-object-delete-marker`
 
 .. mc-cmd:: expired-object-delete-marker
-   :option:
+   
 
    *Optional* Specify this option to direct MinIO to remove delete markers for
    objects with no remaining object versions. Specifically, the delete marker is
@@ -122,8 +122,8 @@ Parameters
 
    This option is mutually exclusive with the following option:
    
-   - :mc-cmd-option:`~mc ilm edit tags`
-   - :mc-cmd-option:`~mc ilm edit expiry-days`
+   - :mc-cmd:`~mc ilm edit --tags`
+   - :mc-cmd:`~mc ilm edit --expiry-days`
 
    MinIO uses a scanner process to check objects against all configured
    lifecycle management rules. Slow scanning due to high IO workloads or
@@ -131,7 +131,7 @@ Parameters
    rules. See :ref:`minio-lifecycle-management-scanner` for more information.
 
 .. mc-cmd:: noncurrentversion-expiration-days
-   :option:
+   
 
    *Optional* The number of days to retain an object version after becoming
    *non-current* (i.e. a different version of that object is now the `HEAD`).
@@ -147,17 +147,17 @@ Parameters
    rules. See :ref:`minio-lifecycle-management-scanner` for more information.
 
 .. mc-cmd:: noncurrentversion-transition-days
-   :option:
+   
 
    *Optional* The number of days an object has been non-current (i.e. replaced
    by a newer version of that same object) after which MinIO marks the object
    version as eligible for transition. MinIO transitions the object to the
    configured remote storage tier specified to the 
-   :mc-cmd-option:`~mc ilm edit storage-class` once the system host datetime
+   :mc-cmd:`~mc ilm edit --storage-class` once the system host datetime
    passes that calendar date.
 
    This option has no effect on non-versioned buckets. Requires specifying
-   :mc-cmd-option:`~mc ilm edit noncurrentversion-transition-storage-class`.
+   :mc-cmd:`~mc ilm edit noncurrentversion-transition-storage-class`.
 
    This option has the same behavior as the 
    S3 ``NoncurrentVersionTransition`` action.
@@ -168,7 +168,7 @@ Parameters
    rules. See :ref:`minio-lifecycle-management-scanner` for more information.
 
 .. mc-cmd:: noncurrentversion-transition-storage-class
-   :option:
+   
 
    *Optional* The remote storage tier to which MinIO 
    :ref:`transitions noncurrent objects versions
@@ -179,44 +179,44 @@ Parameters
    specified remote tier to the new remote tier. MinIO continues to
    route requests for objects stored on the old remote tier.
 
-.. mc-cmd:: tags
-   :option:
+.. mc-cmd:: --tags
+   
 
    *Optional* One or more ampersand ``&``-delimited key-value pairs describing
    the object tags to which to apply the lifecycle configuration rule.
 
    This option is mutually exclusive with the following option:
 
-   - :mc-cmd-option:`~mc ilm edit expired-object-delete-marker`
+   - :mc-cmd:`~mc ilm edit expired-object-delete-marker`
 
-.. mc-cmd:: transition-days
-   :option:
+.. mc-cmd:: --transition-days
+   
 
    *Optional* The number of calendar days from object creation after which MinIO
    marks an object as eligible for transition. MinIO transitions the object to
    the configured remote storage tier specified to the 
-   :mc-cmd-option:`~mc ilm edit storage-class`. 
+   :mc-cmd:`~mc ilm edit --storage-class`. 
 
    For versioned buckets, the transition rule applies only to the *current*
    object version. Use the 
-   :mc-cmd-option:`~mc ilm edit noncurrentversion-transition-days` option
+   :mc-cmd:`~mc ilm edit noncurrentversion-transition-days` option
    to apply transition behavior to noncurrent object versions.
 
-   Requires specifying :mc-cmd-option:`~mc ilm edit storage-class`.
+   Requires specifying :mc-cmd:`~mc ilm edit --storage-class`.
 
    MinIO uses a scanner process to check objects against all configured
    lifecycle management rules. Slow scanning due to high IO workloads or
    limited system resources may delay application of lifecycle management
    rules. See :ref:`minio-lifecycle-management-scanner` for more information.
 
-.. mc-cmd:: storage-class
-   :option:
+.. mc-cmd:: --storage-class
+   
 
    *Optional* The remote storage tier to which MinIO 
    :ref:`transition objects <minio-lifecycle-management-tiering>`. Specify a
    remote storage tier created by :mc-cmd:`mc admin tier`. 
 
-   Required if specifying :mc-cmd-option:`~mc ilm edit transition-days`.
+   Required if specifying :mc-cmd:`~mc ilm edit --transition-days`.
 
    MinIO does *not* automatically migrate objects from the previously
    specified remote tier to the new remote tier. MinIO continues to
@@ -235,7 +235,7 @@ Examples
 Modify an Existing Lifecycle Management Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd:`mc ilm edit` with :mc-cmd-option:`~mc ilm edit id` to modify
+Use :mc-cmd:`mc ilm edit` with :mc-cmd:`~mc ilm edit --id` to modify
 an existing object expiration rule:
 
 .. code-block:: shell
@@ -254,7 +254,7 @@ an existing object expiration rule:
 
 - Specify any additional flags to add or modify the lifecycle management
   rule. For example, specify
-  :mc-cmd:`~mc ilm edit transition-days` to override the existing 
+  :mc-cmd:`~mc ilm edit --transition-days` to override the existing 
   transition days value for the rule.
 
 Behavior

--- a/source/reference/minio-mc/mc-ilm-ls.rst
+++ b/source/reference/minio-mc/mc-ilm-ls.rst
@@ -62,21 +62,21 @@ Parameters
       mc ilm ls myminio/mydata
 
 
-.. mc-cmd:: expiry
-   :option:
+.. mc-cmd:: --expiry
+   
 
    *Optional* :mc-cmd:`mc ilm ls` returns only fields related to lifecycle rule
    expiration.
 
-   Mutually exclusive with :mc-cmd-option:`~mc ilm ls transition`.
+   Mutually exclusive with :mc-cmd:`~mc ilm ls --transition`.
 
-.. mc-cmd:: transition
-   :option:
+.. mc-cmd:: --transition
+   
 
    *Optional* :mc-cmd:`mc ilm ls` returns only fields related to lifecycle rule
    transition.
 
-   Mutually exclusive with :mc-cmd-option:`~mc ilm ls expiry`.
+   Mutually exclusive with :mc-cmd:`~mc ilm ls --expiry`.
 
 
 Global Flags

--- a/source/reference/minio-mc/mc-ilm-restore.rst
+++ b/source/reference/minio-mc/mc-ilm-restore.rst
@@ -71,26 +71,26 @@ Parameters
 
 
 .. mc-cmd:: days value                     
-   :option:
+   
 
    *Optional* The number of days after which MinIO expires the restored copy
    of the archived object.
 
 
 .. mc-cmd:: recursive, r                  
-   :option:
+   
 
    *Optional* Restores all objects under the specified prefix.
 
 
 .. mc-cmd:: versions                       
-   :option:
+   
 
    *Optional* Restores all versions of the object on the remote tier.
 
 
 .. mc-cmd:: version-id, vid  
-   :option:
+   
 
    *Optional* Restores the specified version of the object on the remote tier.
 

--- a/source/reference/minio-mc/mc-ilm-rm.rst
+++ b/source/reference/minio-mc/mc-ilm-rm.rst
@@ -65,22 +65,22 @@ Parameters
 .. mc-cmd:: all
 
    *Required* Removes all rules in the bucket. Mutually exclusive with
-   :mc-cmd-option:`mc ilm rm id`.
+   :mc-cmd:`mc ilm rm id`.
 
-   Mutually exclusive with :mc-cmd-option:`mc ilm rm id`
+   Mutually exclusive with :mc-cmd:`mc ilm rm id`
 
-   Requires including :mc-cmd-option:`~mc ilm rm force`.
+   Requires including :mc-cmd:`~mc ilm rm force`.
 
 .. mc-cmd:: force
 
-   Required if specifying :mc-cmd-option:`~mc ilm rm all`.
+   Required if specifying :mc-cmd:`~mc ilm rm all`.
 
 .. mc-cmd:: id
 
    *Required* The unique ID of the rule. Use :mc-cmd:`mc ilm ls` to list bucket
    rules and retrieve the ``id`` for the rule you want to remove.
 
-   Mutually exclusive with :mc-cmd-option:`mc ilm rm all`
+   Mutually exclusive with :mc-cmd:`mc ilm rm all`
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-legalhold-clear.rst
+++ b/source/reference/minio-mc/mc-legalhold-clear.rst
@@ -13,9 +13,9 @@
 .. mc:: mc legalhold clear
 
 .. |command| replace:: :mc-cmd:`mc legalhold clear`
-.. |rewind| replace:: :mc-cmd-option:`~mc legalhold clear rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc legalhold clear version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc legalhold clear ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc legalhold clear --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc legalhold clear version-id`
+.. |alias| replace:: :mc-cmd:`~mc legalhold clear ALIAS`
 
 Syntax
 ------
@@ -74,21 +74,21 @@ Parameters
       
       mc legalhold clear play/mybucket/myobjects/objects.txt
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    Removes the legal hold on all objects in the 
    :mc-cmd:`~mc legalhold clear ALIAS` bucket or bucket prefix.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -108,7 +108,7 @@ Retrieve the Legal Hold Status Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc-cmd:`mc legalhold clear` to retrieve the legal hold status of an object.
-Include :mc-cmd-option:`~mc legalhold clear recursive` to return the legal hold
+Include :mc-cmd:`~mc legalhold clear --recursive` to return the legal hold
 status of the contents of a bucket:
 
 .. code-block:: shell
@@ -121,7 +121,7 @@ status of the contents of a bucket:
 
 - Replace :mc-cmd:`PATH <mc legalhold clear ALIAS>` with the path to the bucket
   or object on the S3-compatible host. If specifying the path to a bucket or
-  bucket prefix, include the :mc-cmd-option:`~mc legalhold clear recursive`
+  bucket prefix, include the :mc-cmd:`~mc legalhold clear --recursive`
   option.
 
 Behavior

--- a/source/reference/minio-mc/mc-legalhold-info.rst
+++ b/source/reference/minio-mc/mc-legalhold-info.rst
@@ -13,9 +13,9 @@
 .. mc:: mc legalhold info
 
 .. |command| replace:: :mc-cmd:`mc legalhold info`
-.. |rewind| replace:: :mc-cmd-option:`~mc legalhold info rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc legalhold info version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc legalhold info ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc legalhold info --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc legalhold info version-id`
+.. |alias| replace:: :mc-cmd:`~mc legalhold info ALIAS`
 
 Syntax
 ------
@@ -29,7 +29,7 @@ The :mc:`mc legalhold info` command returns the current :ref:`legal hold
 
 :mc:`mc legalhold` *requires* that the specified bucket has object locking
 enabled. You can **only** enable object locking at bucket creation. See
-:mc-cmd-option:`mc mb with-lock` for documentation on creating buckets with
+:mc-cmd:`mc mb with-lock` for documentation on creating buckets with
 object locking enabled. 
 
 .. tab-set::
@@ -73,21 +73,21 @@ Parameters
       
       mc legalhold info play/mybucket/myobjects/objects.txt
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    Returns the legal hold status of all objects in the 
    :mc-cmd:`~mc legalhold info ALIAS` bucket or bucket prefix.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -107,7 +107,7 @@ Retrieve the Legal Hold Status Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc-cmd:`mc legalhold info` to retrieve the legal hold status of an object.
-Include :mc-cmd-option:`~mc legalhold info recursive` to return the legal hold
+Include :mc-cmd:`~mc legalhold info --recursive` to return the legal hold
 status of the contents of a bucket:
 
 .. code-block:: shell
@@ -120,7 +120,7 @@ status of the contents of a bucket:
 
 - Replace :mc-cmd:`PATH <mc legalhold info ALIAS>` with the path to the bucket
   or object on the S3-compatible host. If specifying the path to a bucket or
-  bucket prefix, include the :mc-cmd-option:`~mc legalhold info recursive`
+  bucket prefix, include the :mc-cmd:`~mc legalhold info --recursive`
   option.
 
 

--- a/source/reference/minio-mc/mc-legalhold-set.rst
+++ b/source/reference/minio-mc/mc-legalhold-set.rst
@@ -14,9 +14,9 @@
 .. mc:: mc legalhold set
 
 .. |command| replace:: :mc-cmd:`mc legalhold set`
-.. |rewind| replace:: :mc-cmd-option:`~mc legalhold set rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc legalhold set version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc legalhold set ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc legalhold set --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc legalhold set version-id`
+.. |alias| replace:: :mc-cmd:`~mc legalhold set ALIAS`
 
 Syntax
 ------
@@ -31,7 +31,7 @@ an object or objects.
 
 :mc:`mc legalhold` *requires* that the specified bucket has 
 :ref:`object locking enabled <minio-object-locking>`. You can **only** enable
-object locking at bucket creation. See :mc-cmd-option:`mc mb with-lock` for
+object locking at bucket creation. See :mc-cmd:`mc mb with-lock` for
 documentation on creating buckets with object locking enabled. 
 
 .. tab-set::
@@ -75,21 +75,21 @@ Parameters
       
       mc legalhold set play/mybucket/myobjects/objects.txt
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    *Optional* Applies the legal hold to all objects in the 
    :mc-cmd:`~mc legalhold set ALIAS` bucket or bucket prefix.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -117,7 +117,7 @@ Use :mc-cmd:`mc legalhold set` to enable legal hold on objects:
 
 - Replace :mc-cmd:`PATH <mc legalhold set ALIAS>` with the path to the bucket
   or object on the S3-compatible host. If specifying the path to a bucket or
-  bucket prefix, include the :mc-cmd-option:`~mc legalhold set recursive`
+  bucket prefix, include the :mc-cmd:`~mc legalhold set --recursive`
   option.
 
 Behavior

--- a/source/reference/minio-mc/mc-ls.rst
+++ b/source/reference/minio-mc/mc-ls.rst
@@ -13,9 +13,9 @@
 .. Replacement substitutions
 
 .. |command| replace:: :mc-cmd:`mc ls`
-.. |rewind| replace:: :mc-cmd-option:`~mc ls rewind`
-.. |versions| replace:: :mc-cmd-option:`~mc ls versions`
-.. |alias| replace:: :mc-cmd-option:`~mc ls ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc ls --rewind`
+.. |versions| replace:: :mc-cmd:`~mc ls --versions`
+.. |alias| replace:: :mc-cmd:`~mc ls ALIAS`
 
 Syntax
 ------
@@ -86,48 +86,48 @@ Parameters
       mc ls ~/mydata/object.txt
    
    If you specify a directory or bucket to :mc-cmd:`~mc ls ALIAS`, you must
-   also specify :mc-cmd-option:`~mc ls recursive` to recursively list the
+   also specify :mc-cmd:`~mc ls --recursive` to recursively list the
    contents of that directory or bucket. If you omit the ``--recursive``
    argument, :mc:`~mc ls` only lists objects in the top level of the specified
    directory or bucket.
 
 
 .. mc-cmd:: incomplete, -I
-   :option:
+   
 
    *Optional* Returns any incomplete uploads on the specified 
    :mc-cmd:`~mc ls ALIAS` bucket.
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    *Optional* Recursively lists the contents of each bucket or directory in the
    :mc-cmd:`~mc ls ALIAS`.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
    
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
-   Use :mc-cmd-option:`~mc ls rewind` and 
-   :mc-cmd-option:`~mc ls versions` together to display on those object
+   Use :mc-cmd:`~mc ls --rewind` and 
+   :mc-cmd:`~mc ls --versions` together to display on those object
    versions which existed at a specific point in time.
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc ls versions` and 
-   :mc-cmd-option:`~mc ls rewind` together to display on those object
+   Use :mc-cmd:`~mc ls --versions` and 
+   :mc-cmd:`~mc ls --rewind` together to display on those object
    versions which existed at a specific point in time.
 
-.. mc-cmd:: summarize
-   :option:
+.. mc-cmd:: --summarize
+   
 
    *Optional* Displays summarized information for the specified ``ALIAS`` path.
 
@@ -158,12 +158,12 @@ Use :mc-cmd:`mc ls <mc ls ALIAS>` to list the contents of a bucket:
   S3-compatible host.
 
   If specifying the path to the S3 root (``ALIAS`` only), include the
-  :mc-cmd-option:`~mc ls recursive` option.
+  :mc-cmd:`~mc ls --recursive` option.
 
 List Object Versions
 ~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc ls versions` to list all versions of an object:
+Use :mc-cmd:`mc ls --versions` to list all versions of an object:
 
 .. code-block:: shell
    :class: copyable
@@ -183,7 +183,7 @@ Use :mc-cmd-option:`mc ls versions` to list all versions of an object:
 List Bucket Contents at Point in Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc ls versions` to list all versions of an object:
+Use :mc-cmd:`mc ls --versions` to list all versions of an object:
 
 .. code-block:: shell
    :class: copyable
@@ -196,7 +196,7 @@ Use :mc-cmd-option:`mc ls versions` to list all versions of an object:
 - Replace :mc-cmd:`PATH <mc ls ALIAS>` with the path to the bucket or object on
   the S3-compatible host.
 
-- Replace :mc-cmd:`DURATION <mc ls rewind>` with the point-in-time in the past
+- Replace :mc-cmd:`DURATION <mc ls --rewind>` with the point-in-time in the past
   at which the command returns the object. For example, specify ``30d`` to
   return the version of the object 30 days prior to the current date.
 

--- a/source/reference/minio-mc/mc-mb.rst
+++ b/source/reference/minio-mc/mc-mb.rst
@@ -77,19 +77,19 @@ Parameters
       mc ls ~/mydata/object.txt
 
 .. mc-cmd:: ignore-existing, p
-   :option:
+   
 
    Directs :mc-cmd:`mc mb` to do nothing if the bucket or directory already
    exists.
 
-.. mc-cmd:: region
-   :option:
+.. mc-cmd:: --region
+   
 
    The region in which to create the specified bucket. Has no effect if the
    specified :mc-cmd:`~mc mb ALIAS` is a filesystem directory.
 
 .. mc-cmd:: with-lock, l
-   :option:
+   
 
    Enables :ref:`object locking <minio-object-locking>` on the specified 
    bucket. Has no effect if the specified ``ALIAS`` is a 
@@ -117,7 +117,7 @@ Create Bucket
 ~~~~~~~~~~~~~
 
 Use :mc:`mc mb` to create a bucket on an S3-compatible host. The 
-:mc-cmd-option:`~mc mb with-lock` option creates the bucket with locking
+:mc-cmd:`~mc mb with-lock` option creates the bucket with locking
 enabled:
 
 .. code-block:: shell

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -114,20 +114,20 @@ Parameters
    :mc:`mc mirror` uses the object or file names from the
    :mc-cmd:`~mc mirror SOURCE` when synchronizing to the ``TARGET`` bucket.
 
-.. mc-cmd:: attr
-   :option:
+.. mc-cmd:: --attr
+   
 
    Add custom metadata for mirrored objects. Specify key-value pairs as 
    ``KEY=VALUE\;``. For example, 
    ``--attr key1=value1\;key2=value2\;key3=value3``.
 
-.. mc-cmd:: disable-multipart
-   :option:
+.. mc-cmd:: --disable-multipart
+   
 
    Disables multipart upload for the copy session.
 
-.. mc-cmd:: encrypt-key
-   :option:
+.. mc-cmd:: --encrypt-key
+   
 
    Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
@@ -137,82 +137,82 @@ Parameters
       object(s).
 
    Enclose the entire list of key-value pairs passed to 
-   :mc-cmd-option:`~mc mirror encrypt-key` in double quotes ``"``.
+   :mc-cmd:`~mc mirror --encrypt-key` in double quotes ``"``.
 
-   :mc-cmd-option:`~mc mirror encrypt-key` can use the ``MC_ENCRYPT_KEY``
+   :mc-cmd:`~mc mirror --encrypt-key` can use the ``MC_ENCRYPT_KEY``
    environment variable for retrieving a list of encryption key-value pairs
    as an alternative to specifying them on the command line.
 
    You can only delete encrypted objects if you specify the correct
-   :mc-cmd-option:`~mc mirror encrypt-key` secret key.
+   :mc-cmd:`~mc mirror --encrypt-key` secret key.
 
-.. mc-cmd:: exclude
-   :option:
+.. mc-cmd:: --exclude
+   
 
    Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path that
    match the specified object name pattern.
 
-.. mc-cmd:: fake
-   :option:
+.. mc-cmd:: --fake
+   
 
    Perform a fake mirror operation. Use this operation to perform 
    validate that the :mc:`mc mirror` operation will only
    mirror the desired objects or buckets.
 
 .. mc-cmd:: md5
-   :option:
+   
 
    Forces all uploads to calculate MD5 checksums. 
 
-.. mc-cmd:: monitoring-address
-   :option:
+.. mc-cmd:: --monitoring-address
+   
 
    Creates a `Prometheus <https://prometheus.io/>`__ endpoint for monitoring
    mirroring activity. Specify the local network adapter and port address on
    which to create the scraping endpoint. Defaults to ``localhost:8081``).
 
-.. mc-cmd:: newer-than
-   :option:
+.. mc-cmd:: --newer-than
+   
 
    Mirror object(s) newer than the specified number of days.  Specify a
    string in ``#d#hh#mm#ss`` format. For example: 
    ``--older-than 1d2hh3mm4ss``.
 
-.. mc-cmd:: older-than
-   :option:
+.. mc-cmd:: --older-than
+   
 
    Mirror object(s) older than the specified time limit. Specify a string
    in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``.
       
    Defaults to ``0`` (all objects).
 
-.. mc-cmd:: overwrite
-   :option:
+.. mc-cmd:: --overwrite
+   
    
    Overwrites object(s) on the :mc-cmd:`~mc mirror TARGET`.
 
-.. mc-cmd:: preserve, a
-   :option:
+.. mc-cmd:: --preserve, a
+   
 
    Preserve file system attributes and bucket policy rules of the
    :mc-cmd:`~mc mirror SOURCE` on the
    :mc-cmd:`~mc mirror TARGET`.
 
-.. mc-cmd:: region
-   :option:
+.. mc-cmd:: --region
+   
 
    Specify the ``string`` region when creating new bucket(s) on the
    target. 
 
    Defaults to ``"us-east-1"``.
 
-.. mc-cmd:: remove
-   :option:
+.. mc-cmd:: --remove
+   
 
    Removes extraneous object(s) on the target. 
 
 .. mc-cmd:: storage-class, sc
-   :option:
+   
 
    Set the storage class for the new object(s) on the 
    :mc-cmd:`~mc mirror TARGET`. 
@@ -221,8 +221,8 @@ Parameters
    :aws-docs:`Storage Classes <AmazonS3/latest/dev/storage-class-intro.html>` 
    for more information on S3 storage classses.
 
-.. mc-cmd:: watch, w
-   :option:
+.. mc-cmd:: --watch, w
+   
 
    Continuously monitor the :mc-cmd:`~mc mirror SOURCE` path and
    synchronize changes.
@@ -260,7 +260,7 @@ Use :mc:`mc mirror` to mirror files from a filesystem to an S3 Host:
 Continuously Mirror a Local Directory to an S3-Compatible Host
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc mirror` with :mc-cmd-option:`~mc mirror watch` to continuously mirror
+Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --watch` to continuously mirror
 files from a filesystem to an S3-compatible host:
 
 .. code-block::
@@ -279,7 +279,7 @@ files from a filesystem to an S3-compatible host:
 Continuously Mirror S3 Bucket to an S3-Compatible Host
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc mirror` with :mc-cmd-option:`~mc mirror watch` to continuously
+Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --watch` to continuously
 mirror objects in a bucket on one S3-compatible host to another S3-compatible
 host.
 
@@ -304,11 +304,11 @@ Behavior
 MinIO Trims Empty Prefixes on Object Removal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :mc-cmd-option:`mc mirror watch` command continuously synchronizes the
+The :mc-cmd:`mc mirror --watch` command continuously synchronizes the
 source and destination targets. This includes automatically removing objects
 on the destination if they are removed on the source.
 
-.. |command| replace:: :mc-cmd-option:`mc mirror watch`
+.. |command| replace:: :mc-cmd:`mc mirror --watch`
 
 .. include:: /includes/common-admonitions.rst
    :start-after: start-remove-api-trims-prefixes

--- a/source/reference/minio-mc/mc-mv.rst
+++ b/source/reference/minio-mc/mc-mv.rst
@@ -91,8 +91,8 @@ Parameters
       mc mv ~/mydata/object.txt play/mydata/otherobject.txt myminio/mydata
 
    If you specify a directory or bucket to :mc-cmd:`~mc mv SOURCE`, you must
-   also specify :mc-cmd-option:`~mc mv recursive` to recursively move the
-   contents of that directory. If you omit the :mc-cmd-option:`~mc mv recursive`
+   also specify :mc-cmd:`~mc mv --recursive` to recursively move the
+   contents of that directory. If you omit the :mc-cmd:`~mc mv --recursive`
    argument, :mc:`~mc mv` only moves objects in the top level of the specified
    directory or bucket.
 
@@ -121,24 +121,24 @@ Parameters
    The ``TARGET`` object name can differ from the ``SOURCE`` to 
    "rename" the object as part of the move operation. 
 
-   If running :mc-cmd:`mc mv` with the :mc-cmd-option:`~mc mv recursive` option, 
+   If running :mc-cmd:`mc mv` with the :mc-cmd:`~mc mv --recursive` option, 
    :mc-cmd:`mc mv` treats the ``TARGET`` as the bucket prefix for all
    objects at the ``SOURCE``. 
 
-.. mc-cmd:: attr
-   :option:
+.. mc-cmd:: --attr
+   
 
    *Optional* Add custom metadata for the object. Specify key-value pairs as 
    ``KEY=VALUE\;``. For example, 
    ``--attr key1=value1\;key2=value2\;key3=value3``.
 
-.. mc-cmd:: continue, c
-   :option:
+.. mc-cmd:: --continue, c
+   
 
    *Optional* Create or resume a move session. 
 
-.. mc-cmd:: encrypt
-   :option:
+.. mc-cmd:: --encrypt
+   
 
    *Optional* Encrypt or decrypt objects using server-side encryption with
    server-managed keys. Specify key-value pairs as ``KEY=VALUE``.
@@ -148,14 +148,14 @@ Parameters
       object(s).
 
    Enclose the entire list of key-value pairs passed to
-   :mc-cmd-option:`~mc mv encrypt` in double-quotes ``"``.
+   :mc-cmd:`~mc mv --encrypt` in double-quotes ``"``.
 
-   :mc-cmd-option:`~mc mv encrypt` can use the ``MC_ENCRYPT`` environment
+   :mc-cmd:`~mc mv --encrypt` can use the ``MC_ENCRYPT`` environment
    variable for retrieving a list of encryption key-value pairs as an
    alternative to specifying them on the command line.
 
-.. mc-cmd:: encrypt-key
-   :option:
+.. mc-cmd:: --encrypt-key
+   
 
    *Optional* Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
@@ -165,14 +165,14 @@ Parameters
       object(s).
 
    Enclose the entire list of key-value pairs passed to 
-   :mc-cmd-option:`~mc mv encrypt-key` in double quotes ``"``.
+   :mc-cmd:`~mc mv --encrypt-key` in double quotes ``"``.
 
-   :mc-cmd-option:`~mc mv encrypt-key` can use the ``MC_ENCRYPT_KEY``
+   :mc-cmd:`~mc mv --encrypt-key` can use the ``MC_ENCRYPT_KEY``
    environment variable for retrieving a list of encryption key-value pairs
    as an alternative to specifying them on the command line.
 
-.. mc-cmd:: newer-than
-   :option:
+.. mc-cmd:: --newer-than
+   
 
    *Optional* Remove object(s) newer than the specified number of days.  Specify
    a string in ``##d#hh#mm#ss`` format. For example: 
@@ -180,29 +180,29 @@ Parameters
 
    Defaults to ``0`` (all objects).
 
-.. mc-cmd:: older-than
-   :option:
+.. mc-cmd:: --older-than
+   
 
    *Optional* Remove object(s) older than the specified time limit. Specify a
    string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``.
       
    Defaults to ``0`` (all objects).
 
-.. mc-cmd:: preserve, a
-   :option:
+.. mc-cmd:: --preserve, a
+   
 
    *Optional* Preserve file system attributes and bucket policy rules of the
    :mc-cmd:`~mc mv SOURCE` directories, buckets, and objects on the 
    :mc-cmd:`~mc mv TARGET` bucket(s).
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
    
    *Optional* Recursively move the contents of each bucket or directory
    :mc-cmd:`~mc mv SOURCE` to the :mc-cmd:`~mc mv TARGET` bucket.
 
 .. mc-cmd:: storage-class, sc
-   :option:
+   
 
    *Optional* Set the storage class for the new object(s) on the 
    :mc-cmd:`~mc mv TARGET`. 
@@ -234,7 +234,7 @@ Move Files from Filesystem to S3-Compatible Host
   file to move. 
 
   If specifying the path to a directory, include the 
-  :mc-cmd-option:`~mc mv recursive` flag.
+  :mc-cmd:`~mc mv --recursive` flag.
 
   :mc:`mc mv` *removes* the files from the source after
   successfully moving it to the destination.
@@ -247,7 +247,7 @@ Move Files from Filesystem to S3-Compatible Host
 Move a File from Filesystem to S3-Compatible Host with Custom Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc mv` with the :mc-cmd-option:`~mc mv attr` option to set custom
+Use :mc:`mc mv` with the :mc-cmd:`~mc mv --attr` option to set custom
 attributes on file(s).
 
 .. code-block:: shell
@@ -264,7 +264,7 @@ attributes on file(s).
 
 - Replace :mc-cmd:`PATH <mc mv TARGET>` with the destination bucket.
 
-- Replace :mc-cmd:`ATTRIBUTES <mc mv attr>` with one or more comma-separated
+- Replace :mc-cmd:`ATTRIBUTES <mc mv --attr>` with one or more comma-separated
   key-value pairs ``KEY=VALUE``. Each pair represents one attribute key and
   value.
 
@@ -292,7 +292,7 @@ Move Bucket Between S3-Compatible Services
 Move File to S3-Compatible Host with Specific Storage Class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc mv` with the :mc-cmd-option:`~mc mv storage-class` option to set
+Use :mc:`mc mv` with the :mc-cmd:`~mc mv storage-class` option to set
 the storage class on the destination S3-compatible host.
 
 .. code-block:: shell
@@ -312,7 +312,7 @@ the storage class on the destination S3-compatible host.
 
 - Replace :mc-cmd:`PATH <mc mv TARGET>` with the destination bucket.
 
-- Replace :mc-cmd:`ATTRIBUTES <mc mv attr>` with one or more comma-separated
+- Replace :mc-cmd:`ATTRIBUTES <mc mv --attr>` with one or more comma-separated
   key-value pairs ``KEY=VALUE``. Each pair represents one attribute key and
   value.
 
@@ -325,19 +325,19 @@ Behavior
 Object Names on Move
 ~~~~~~~~~~~~~~~~~~~~
 
-MinIO uses the :mc-cmd-option:`~mc mv SOURCE` object name when moving
-the object to the :mc-cmd-option:`~mc mv TARGET` if no explicit target
+MinIO uses the :mc-cmd:`~mc mv SOURCE` object name when moving
+the object to the :mc-cmd:`~mc mv TARGET` if no explicit target
 object name is specified.
 
 You can specify a different object name for the
-:mc-cmd-option:`~mc mv TARGET` with the same object path to "rename"
+:mc-cmd:`~mc mv TARGET` with the same object path to "rename"
 an object. For example:
 
 .. code-block:: shell
 
    mc mv play/mybucket/object.txt play/mybucket/myobject.txt
 
-For recursive move operations (:mc-cmd-option:`mc mv recursive`), MinIO
+For recursive move operations (:mc-cmd:`mc mv --recursive`), MinIO
 treats the ``TARGET`` path as a prefix for objects on the ``SOURCE``. 
 
 Checksum Verification
@@ -349,7 +349,7 @@ checksums.
 Resume Move Operations
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd-option:`mc mv continue` to resume an interrupted or failed
+Use :mc-cmd:`mc mv --continue` to resume an interrupted or failed
 move operation from the point of failure. 
 
 MinIO Trims Empty Prefixes on Object Removal

--- a/source/reference/minio-mc/mc-policy-links.rst
+++ b/source/reference/minio-mc/mc-policy-links.rst
@@ -69,8 +69,8 @@ Parameters
             
       mc links public [FLAGS] play/mybucket
 
-.. mc-cmd:: recursive
-   :option:
+.. mc-cmd:: --recursive
+   
 
    *Optional* Retrieve the HTTP links recursively.
 

--- a/source/reference/minio-mc/mc-rb.rst
+++ b/source/reference/minio-mc/mc-rb.rst
@@ -76,7 +76,7 @@ Parameters
 
    Omit the bucket path to perform a site-wide removal of buckets on the MinIO
    deployment. This operation *requires* specifying 
-   :mc-cmd-option:`~mc rb dangerous` to explicitly acknowledge the permanent
+   :mc-cmd:`~mc rb --dangerous` to explicitly acknowledge the permanent
    removal of *all* data on the deployment. For example:
 
    .. code-block:: none
@@ -85,7 +85,7 @@ Parameters
 
    For removing a directory and its contents on a local filesystem, specify
    the full path to that directory. The 
-   :mc-cmd-option:`~mc rb force` flag is ignored if specified. For example:
+   :mc-cmd:`~mc rb --force` flag is ignored if specified. For example:
 
    .. code-block:: none
 
@@ -99,13 +99,13 @@ Parameters
 
       mc rb --force myminio/mydata ~/data/myolddata
 
-.. mc-cmd:: force
-   :option:
+.. mc-cmd:: --force
+   
 
    *Required* Safety flag to confirm removal of the bucket contents.
 
-.. mc-cmd:: dangerous
-   :option:
+.. mc-cmd:: --dangerous
+   
 
    *Optional* Directs :mc:`mc rb` to perform a site-wide removal of all
    buckets on each specified :mc-cmd:`~mc rb ALIAS` (e.g. ``myminio/``).
@@ -116,7 +116,7 @@ Parameters
 
    .. warning::
 
-      Running :mc-cmd-option:`mc rb dangerous` is irreversible. Exercise all
+      Running :mc-cmd:`mc rb --dangerous` is irreversible. Exercise all
       possible due diligence in ensuring the command applies to only the 
       desired ``ALIAS`` targets prior to execution.
 

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -85,8 +85,8 @@ Parameters
       mc replicate add --remote-bucket "arn:minio:replica::UUID" play/mybucket
 
 
-.. mc-cmd:: remote-bucket
-   :option:
+.. mc-cmd:: --remote-bucket
+   
 
    *Required* Specify the ARN for the destination deployment and bucket. You
    can retrieve the ARN using :mc-cmd:`mc admin bucket remote`:
@@ -97,8 +97,8 @@ Parameters
    - Use the :mc-cmd:`mc admin bucket remote add` to create a replication ARN
      for the bucket on the destination deployment. 
 
-.. mc-cmd:: disable
-   :option:
+.. mc-cmd:: --disable
+   
 
    *Optional* Creates the replication rule in the "disabled" state. MinIO does
    not begin replicating objects using the rule until it is enabled using
@@ -109,18 +109,18 @@ Parameters
    You must explicitly enable replication of existing
    objects by including ``"existing-objects"`` to the list of
    replication features specified to 
-   :mc-cmd-option:`mc replicate edit replicate`. See
+   :mc-cmd:`mc replicate edit --replicate`. See
    :ref:`minio-replication-behavior-existing-objects` for more
    information.
 
-.. mc-cmd:: id
-   :option:
+.. mc-cmd:: --id
+   
 
    *Optional* Specify a unique ID for the replication rule. MinIO automatically
    generates an ID if one is not specified.
 
-.. mc-cmd:: replicate
-   :option:
+.. mc-cmd:: --replicate
+   
 
    *Optional* Specify a comma-separated list of the following values to enable
    extended replication features. 
@@ -134,16 +134,16 @@ Parameters
    - ``existing-objects`` - Directs MinIO to replicate objects created
      before replication was enabled *or* while replication was suspended.
 
-.. mc-cmd:: storage-class
-   :option:
+.. mc-cmd:: --storage-class
+   
 
    *Optional*
 
    Specify the MinIO :ref:`storage class <minio-ec-storage-class>` to 
    apply to replicated objects. 
 
-.. mc-cmd:: tags
-   :option:
+.. mc-cmd:: --tags
+   
 
    *Optional* Specify one or more ampersand ``&`` separated key-value pair tags
    which MinIO uses for filtering objects to replicate. For example:
@@ -155,8 +155,8 @@ Parameters
    MinIO applies the replication rule to any object whose tag set
    contains the specified replication tags.
 
-.. mc-cmd:: priority
-   :option:
+.. mc-cmd:: --priority
+   
 
    *Optional* Specify the integer priority of the replication rule. The value
    *must* be unique among all other rules on the source bucket. Higher values
@@ -191,11 +191,11 @@ operations, and delete markers to the remote target:
 - Replace ``myminio/mybucket`` with the :mc-cmd:`~mc replicate add ALIAS` and
   full bucket path for which to create the replication configuration.
 
-- Replace the :mc-cmd-option:`~mc replicate add remote-bucket` value with the 
+- Replace the :mc-cmd:`~mc replicate add --remote-bucket` value with the 
   ARN of the remote target. Use :mc-cmd:`mc admin bucket remote ls` to list
   all configured remote replication targets.
 
-- The :mc-cmd-option:`~mc replicate add replicate` flag directs MinIO to
+- The :mc-cmd:`~mc replicate add --replicate` flag directs MinIO to
   replicate all delete operations, delete markers, and existing objects to the
   remote. See :ref:`minio-replication-behavior-delete` and
   :ref:`minio-replication-behavior-existing-objects` for more information on
@@ -218,11 +218,11 @@ to the remote target:
 - Replace ``myminio/mybucket`` with the :mc-cmd:`~mc replicate add ALIAS` and
   full bucket path for which to create the replication configuration.
 
-- Replace the :mc-cmd-option:`~mc replicate add remote-bucket` value with the 
+- Replace the :mc-cmd:`~mc replicate add --remote-bucket` value with the 
   ARN of the remote target. Use :mc-cmd:`mc admin bucket remote ls` to list
   all configured remote replication targets.
 
-- The :mc-cmd-option:`~mc replicate add replicate` flag directs MinIO to
+- The :mc-cmd:`~mc replicate add --replicate` flag directs MinIO to
   replicate all existing objects to the remote. See
   :ref:`minio-replication-behavior-existing-objects` for more information on
   replication behavior.
@@ -339,11 +339,11 @@ without the overhead of contacting technical support.
 
 - To enable replication of existing objects when creating a new replication
   rule, include ``"existing-objects"`` to the list of replication features 
-  specified to :mc-cmd-option:`mc replicate add replicate`.
+  specified to :mc-cmd:`mc replicate add --replicate`.
 
 - To enable replication of existing objects for an existing replication rule,
   add ``"existing-objects"`` to the list of existing replication features using
-  :mc-cmd-option:`mc replicate add replicate`. You must specify *all*
+  :mc-cmd:`mc replicate add --replicate`. You must specify *all*
   desired replication features when editing the replication rule. 
 
 See :ref:`minio-replication-behavior-existing-objects` for more complete
@@ -369,7 +369,7 @@ metadata-only update to an object with the ``REPLICA`` status, MinIO marks the
 object as ``PENDING`` and eligible for replication.
 
 To disable metadata synchronization, use the 
-:mc-cmd-option:`mc replicate edit replicate` command and omit 
+:mc-cmd:`mc replicate edit --replicate` command and omit 
 ``replica-metadata-sync`` from the replication feature list. 
 
 Replication of Delete Operations
@@ -392,7 +392,7 @@ MinIO does *not* replicate objects deleted due to
 client-driven delete operations.
 
 MinIO requires explicitly enabling replication of delete operations using the
-:mc-cmd-option:`mc replicate add replicate` flag. This procedure includes the
+:mc-cmd:`mc replicate add --replicate` flag. This procedure includes the
 required flags for enabling replication of delete operations and delete markers.
 See :ref:`minio-replication-behavior-delete` for more complete documentation
 on this behavior.

--- a/source/reference/minio-mc/mc-replicate-edit.rst
+++ b/source/reference/minio-mc/mc-replicate-edit.rst
@@ -80,22 +80,22 @@ Parameters
 
       mc replicate edit --id "c75nrap4b0talo3ipthg" [FLAGS]
 
-.. mc-cmd:: id
-   :option:
+.. mc-cmd:: --id
+   
 
    *Required* Specify the unique ID for a configured replication rule. 
    Use the :mc-cmd:`mc replicate ls` command to list the replication rules
    for a bucket.
 
-.. mc-cmd:: priority
-   :option:
+.. mc-cmd:: --priority
+   
 
    *Optional* Specify the integer priority of the replication rule. The value
    *must* be unique among all other rules on the source bucket. Higher values
    imply a *higher* priority than all other rules.
 
-.. mc-cmd:: remote-bucket
-   :option:
+.. mc-cmd:: --remote-bucket
+   
 
     *Optional* Specify the ARN for the destination deployment and bucket. You
     can retrieve the ARN using :mc-cmd:`mc admin bucket remote`:
@@ -106,8 +106,8 @@ Parameters
     - Use the :mc-cmd:`mc admin bucket remote add` to create a replication ARN
       for the bucket on the destination deployment. 
 
-.. mc-cmd:: replicate
-   :option:
+.. mc-cmd:: --replicate
+   
 
    *Optional* Specify a comma-separated list of the following values to enable
    extended replication features:
@@ -134,8 +134,8 @@ Parameters
      See :ref:`minio-replication-behavior-existing-objects` for more
      information.
 
-.. mc-cmd:: state
-   :option:
+.. mc-cmd:: --state
+   
 
    *Optional* Enables or disables the replication rule. Specify one of the
    following values:
@@ -148,17 +148,17 @@ Parameters
    for replication after enabling the rule. You must explicitly enable
    replication of existing objects by including ``"existing-objects"`` to the
    list of replication features specified to 
-   :mc-cmd-option:`mc replicate edit replicate`. See
+   :mc-cmd:`mc replicate edit --replicate`. See
    :ref:`minio-replication-behavior-existing-objects` for more information.
 
-.. mc-cmd:: storage-class
-   :option:
+.. mc-cmd:: --storage-class
+   
 
    *Optional*  Specify the MinIO :ref:`storage class <minio-ec-storage-class>`
    to apply to replicated objects. 
 
-.. mc-cmd:: tags
-   :option:
+.. mc-cmd:: --tags
+   
 
    *Optional* Specify one or more ampersand ``&`` separated key-value pair tags
    which MinIO uses for filtering objects to replicate. For example:
@@ -198,14 +198,14 @@ Use :mc-cmd:`mc replicate edit` to modify an existing replication rule.
 - Replace :mc-cmd:`PATH <mc replicate edit ALIAS>` with the path to the 
   bucket or bucket prefix on which the rule exists.
 
-- Replace :mc-cmd:`ID <mc replicate edit id>` with the unique identifier for the
+- Replace :mc-cmd:`ID <mc replicate edit --id>` with the unique identifier for the
   rule to modify. Use :mc-cmd:`mc replicate ls` to retrieve the list of 
   replication rules on the bucket and their corresponding identifiers.
 
 .. note::
 
    Modifying a replication configuration rule does not effect already replicated
-   objects. For example, modifying the :mc-cmd-option:`~mc replicate edit tags`
+   objects. For example, modifying the :mc-cmd:`~mc replicate edit --tags`
    filter does not result in the removal of replicated objects which do not
    meet the filter.
 
@@ -213,7 +213,7 @@ Disable or Enable an Existing Replication Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc-cmd:`mc replicate edit` with the
-:mc-cmd-option:`~mc replicate edit state` flag to disable or enable a 
+:mc-cmd:`~mc replicate edit --state` flag to disable or enable a 
 replication rule.
 
 .. code-block:: shell
@@ -229,12 +229,12 @@ replication rule.
 - Replace :mc-cmd:`PATH <mc replicate edit ALIAS>` with the path to the 
   bucket or bucket prefix on which the rule exists.
 
-- Replace :mc-cmd:`ID <mc replicate edit id>` with the unique identifier for the
+- Replace :mc-cmd:`ID <mc replicate edit --id>` with the unique identifier for the
   rule to modify. Use :mc-cmd:`mc replicate ls` to retrieve the list of 
   replication rules on the bucket and their corresponding identifiers.
 
 - Specify either ``"disabled"`` or ``"enabled"`` to the 
-  :mc-cmd:`~mc replicate edit state` flag to disable or enable the replication
+  :mc-cmd:`~mc replicate edit --state` flag to disable or enable the replication
   rule.
 
 .. note::

--- a/source/reference/minio-mc/mc-replicate-ls.rst
+++ b/source/reference/minio-mc/mc-replicate-ls.rst
@@ -64,8 +64,8 @@ Parameters
       mc replicate ls myminio/mybucket
 
 
-.. mc-cmd:: status
-   :option:
+.. mc-cmd:: --status
+   
 
    *Optional*  Filter replication rules on the bucket based on their status.
    Specify one of the following values:

--- a/source/reference/minio-mc/mc-replicate-resync.rst
+++ b/source/reference/minio-mc/mc-replicate-resync.rst
@@ -79,8 +79,8 @@ Parameters
 
       mc replicate resync myminio/mybucket
 
-.. mc-cmd:: remote-bucket
-   :option:
+.. mc-cmd:: --remote-bucket
+   
 
    *Required* Specify the ARN for the destination deployment and bucket. You
    can retrieve the ARN using :mc-cmd:`mc admin bucket remote`:
@@ -121,7 +121,7 @@ replication status:
 - Replace ``myminio/mybucket`` with the :mc-cmd:`~mc replicate add ALIAS` and
   full bucket path for which to create the replication configuration.
 
-- Replace the :mc-cmd-option:`~mc replicate add remote-bucket` value with the 
+- Replace the :mc-cmd:`~mc replicate add --remote-bucket` value with the 
   ARN of the remote target. Use :mc-cmd:`mc admin bucket remote ls` to list
   all configured remote replication targets.
 

--- a/source/reference/minio-mc/mc-replicate-rm.rst
+++ b/source/reference/minio-mc/mc-replicate-rm.rst
@@ -69,23 +69,23 @@ Parameters
       mc replicate rm --id "ID" myminio/mybucket
 
 
-.. mc-cmd:: id
-   :option:
+.. mc-cmd:: --id
+   
 
    *Required* Specify the unique ID for a configured replication rule.
 
-   You can omit this option if specifying :mc-cmd-option:`~mc replicate rm all`
+   You can omit this option if specifying :mc-cmd:`~mc replicate rm --all`
 
-.. mc-cmd:: all
-   :option:
+.. mc-cmd:: --all
+   
 
    *Optional* Removes all replication rules on the specified bucket. Requires
-   specifying the :mc-cmd-option:`~mc replicate rm force` flag.
+   specifying the :mc-cmd:`~mc replicate rm --force` flag.
 
-.. mc-cmd:: force
-   :option:
+.. mc-cmd:: --force
+   
 
-   *Optional* Required if specifying :mc-cmd-option:`~mc replicate rm all` .
+   *Optional* Required if specifying :mc-cmd:`~mc replicate rm --all` .
 
 
 Global Flags
@@ -108,7 +108,7 @@ Use :mc-cmd:`mc replicate rm` to remote a bucket replication rule:
 
    mc replicate rm --id "ID" ALIAS/PATH
 
-- Replace :mc-cmd-option:`ID <mc replicate rm id>` with the unique ID of the
+- Replace :mc-cmd:`ID <mc replicate rm --id>` with the unique ID of the
   replication rule to remove. Use :mc-cmd:`mc replicate ls` to list all
   replication rules for the bucket.
 

--- a/source/reference/minio-mc/mc-retention-clear.rst
+++ b/source/reference/minio-mc/mc-retention-clear.rst
@@ -11,10 +11,10 @@
 .. mc:: mc retention clear
 
 .. |command| replace:: :mc-cmd:`mc retention clear`
-.. |rewind| replace:: :mc-cmd-option:`~mc retention clear rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc retention clear version-id`
-.. |versions| replace:: :mc-cmd-option:`~mc retention clear versions`
-.. |alias| replace:: :mc-cmd-option:`~mc retention clear ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc retention clear --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc retention clear version-id`
+.. |versions| replace:: :mc-cmd:`~mc retention clear --versions`
+.. |alias| replace:: :mc-cmd:`~mc retention clear ALIAS`
 
 Syntax
 ------
@@ -63,7 +63,7 @@ To change the retention status of an object under
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
-      :mc-cmd-option:`mc retention clear version-id` is mutually exclusive with
+      :mc-cmd:`mc retention clear version-id` is mutually exclusive with
       multiple other parameters. See the reference documentation for more
       information.
 
@@ -82,41 +82,41 @@ Parameters
       mc retention clear play/mybucket/object.txt
 
    - If the ``ALIAS`` specifies a bucket or bucket prefix, include
-      :mc-cmd-option:`~mc retention clear recursive` to clear the object lock
+      :mc-cmd:`~mc retention clear --recursive` to clear the object lock
       settings to the bucket contents.
 
    - If the ``ALIAS`` bucket has versioning enabled,
       :mc-cmd:`mc retention clear` by default applies to only the latest
-      object version. Use :mc-cmd-option:`~mc retention clear version-id` or
-      :mc-cmd-option:`~mc retention clear versions` to clear the object lock
+      object version. Use :mc-cmd:`~mc retention clear version-id` or
+      :mc-cmd:`~mc retention clear --versions` to clear the object lock
       settings for a specific version or for all versions of the object.
 
-.. mc-cmd:: default
-   :option:
+.. mc-cmd:: --default
+   
 
    *Optional* Clears the default object lock settings for the bucket specified
    to :mc-cmd:`~mc retention clear ALIAS`.
    
-   If specifying :mc-cmd-option:`~mc retention clear default`, 
+   If specifying :mc-cmd:`~mc retention clear --default`, 
    :mc-cmd:`mc retention clear` ignores all other flags.
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    *Optional* Recursively clears the object lock settings for all objects in the
    specified :mc-cmd:`~mc retention clear ALIAS` path.
 
-   Mutually exclusive with :mc-cmd-option:`~mc retention clear version-id`.
+   Mutually exclusive with :mc-cmd:`~mc retention clear version-id`.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -124,19 +124,19 @@ Parameters
 
    Mutually exclusive with any of the following flags:
    
-   - :mc-cmd-option:`~mc retention clear versions`
-   - :mc-cmd-option:`~mc retention clear rewind`
-   - :mc-cmd-option:`~mc retention clear recursive`
+   - :mc-cmd:`~mc retention clear --versions`
+   - :mc-cmd:`~mc retention clear --rewind`
+   - :mc-cmd:`~mc retention clear --recursive`
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc retention clear versions` and
-   :mc-cmd-option:`~mc retention clear rewind` together to remove the
+   Use :mc-cmd:`~mc retention clear --versions` and
+   :mc-cmd:`~mc retention clear --rewind` together to remove the
    retention settings from all object versions that existed at a
    specific point-in-time.
 
@@ -172,7 +172,7 @@ Clear Object Lock Settings for an Object or Object(s)
    .. tab-item:: Multiple Objects
 
       Use :mc-cmd:`mc retention clear` with
-      :mc-cmd-option:`~mc retention clear recursive` to clear the retention
+      :mc-cmd:`~mc retention clear --recursive` to clear the retention
       settings from all objects in a bucket:
 
       .. code-block:: shell

--- a/source/reference/minio-mc/mc-retention-info.rst
+++ b/source/reference/minio-mc/mc-retention-info.rst
@@ -11,10 +11,10 @@
 .. mc:: mc retention info
 
 .. |command| replace:: :mc-cmd:`mc retention info`
-.. |rewind| replace:: :mc-cmd-option:`~mc retention info rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc retention info version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc retention info ALIAS`
-.. |versions| replace:: :mc-cmd-option:`~mc retention info versions`
+.. |rewind| replace:: :mc-cmd:`~mc retention info --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc retention info version-id`
+.. |alias| replace:: :mc-cmd:`~mc retention info ALIAS`
+.. |versions| replace:: :mc-cmd:`~mc retention info --versions`
 
 Syntax
 ------
@@ -33,7 +33,7 @@ use :mc:`mc legalhold`.
 
 :mc:`mc retention info` *requires* that the specified bucket has object locking
 enabled. You can **only** enable object locking at bucket creation. See
-:mc-cmd-option:`mc mb with-lock` for documentation on creating buckets with
+:mc-cmd:`mc mb with-lock` for documentation on creating buckets with
 object locking enabled. 
 
 .. tab-set::
@@ -67,7 +67,7 @@ object locking enabled.
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
-      :mc-cmd-option:`mc retention info version-id` is mutually exclusive with
+      :mc-cmd:`mc retention info version-id` is mutually exclusive with
       multiple other parameters. See the reference documentation for more
       information.
 
@@ -88,42 +88,42 @@ Parameters
       mc retention info play/mybucket/object.txt
 
    - If the ``ALIAS`` specifies a bucket or bucket prefix, include 
-      :mc-cmd-option:`~mc retention info recursive` to return the object
+      :mc-cmd:`~mc retention info --recursive` to return the object
       lock settings for all objects in the bucket or bucket prefix.
 
    - If the ``ALIAS`` bucket has versioning enabled, 
       :mc-cmd:`mc retention info` by default applies to only the latest object
-      version. Use :mc-cmd-option:`~mc retention info version-id` or
-      :mc-cmd-option:`~mc retention info versions` to return the object lock
+      version. Use :mc-cmd:`~mc retention info version-id` or
+      :mc-cmd:`~mc retention info --versions` to return the object lock
       settings for a specific version or for all versions of the object.
 
 
-.. mc-cmd:: default
-   :option:
+.. mc-cmd:: --default
+   
 
    *Optional* Returns the default object lock settings for the bucket specified
    to :mc-cmd:`~mc retention info ALIAS`.
 
-   If specifying :mc-cmd-option:`~mc retention info default`, 
+   If specifying :mc-cmd:`~mc retention info --default`, 
    :mc-cmd:`mc retention info` ignores all other flags.
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    *Optional* Recursively returns the object lock settings for all objects in the
    specified :mc-cmd:`~mc retention info ALIAS` path.
 
-   Mutually exclusive with :mc-cmd-option:`~mc retention info version-id`.
+   Mutually exclusive with :mc-cmd:`~mc retention info version-id`.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -131,19 +131,19 @@ Parameters
 
    Mutually exclusive with any of the following flags:
    
-   - :mc-cmd-option:`~mc retention info versions`
-   - :mc-cmd-option:`~mc retention info rewind`
-   - :mc-cmd-option:`~mc retention info recursive`
+   - :mc-cmd:`~mc retention info --versions`
+   - :mc-cmd:`~mc retention info --rewind`
+   - :mc-cmd:`~mc retention info --recursive`
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc retention info versions` and
-   :mc-cmd-option:`~mc retention info rewind` together to retrieve the
+   Use :mc-cmd:`~mc retention info --versions` and
+   :mc-cmd:`~mc retention info --rewind` together to retrieve the
    retention settings for all object versions that existed at a
    specific point-in-time.
 
@@ -178,7 +178,7 @@ Retrieve Object Lock Settings for an Object or Object(s)
    .. tab-item:: Multiple Objects
 
       Use :mc-cmd:`mc retention info` with
-      :mc-cmd-option:`~mc retention info recursive` to retrieve the retention
+      :mc-cmd:`~mc retention info --recursive` to retrieve the retention
       settings for all objects in a bucket:
 
       .. code-block:: shell
@@ -200,7 +200,7 @@ Retrieve Default Object Lock Settings for a Bucket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc-cmd:`mc retention info` with 
-:mc-cmd-option:`~mc retention info default` to retrieve the default 
+:mc-cmd:`~mc retention info --default` to retrieve the default 
 object lock settings for a bucket:
 
 .. code-block:: shell

--- a/source/reference/minio-mc/mc-retention-set.rst
+++ b/source/reference/minio-mc/mc-retention-set.rst
@@ -16,10 +16,10 @@
 .. replacements for mc retention set
 
 .. |command| replace:: :mc-cmd:`mc retention set`
-.. |rewind| replace:: :mc-cmd-option:`~mc retention set rewind`
-.. |versionid| replace:: :mc-cmd-option:`~mc retention set version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc retention set ALIAS`
-.. |versions| replace:: :mc-cmd-option:`~mc retention set versions`
+.. |rewind| replace:: :mc-cmd:`~mc retention set --rewind`
+.. |versionid| replace:: :mc-cmd:`~mc retention set --version-id`
+.. |alias| replace:: :mc-cmd:`~mc retention set ALIAS`
+.. |versions| replace:: :mc-cmd:`~mc retention set --versions`
 
 Syntax
 ------
@@ -39,7 +39,7 @@ use :mc:`mc legalhold`.
 
 :mc:`mc retention set` *requires* that the specified bucket has object locking
 enabled. You can **only** enable object locking at bucket creation. See
-:mc-cmd-option:`mc mb with-lock` for documentation on creating buckets with
+:mc-cmd:`mc mb with-lock` for documentation on creating buckets with
 object locking enabled. 
 
 .. tab-set::
@@ -77,7 +77,7 @@ object locking enabled.
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
-      :mc-cmd-option:`mc retention set version-id` is mutually exclusive with
+      :mc-cmd:`mc retention set --version-id` is mutually exclusive with
       multiple other parameters. See the reference documentation for more
       information.
 
@@ -123,24 +123,24 @@ Parameters
       mc retention set play/mybucket/object.txt MODE VALIDITY
 
    - If the ``ALIAS`` specifies a bucket or bucket prefix, include
-     :mc-cmd-option:`~mc retention set recursive` to apply the object lock
+     :mc-cmd:`~mc retention set --recursive` to apply the object lock
      settings to the bucket contents.
 
    - :mc-cmd:`mc retention set` by default applies to only the latest object
-     version. Use :mc-cmd-option:`~mc retention set version-id` or
-     :mc-cmd-option:`~mc retention set versions` to apply the object lock
+     version. Use :mc-cmd:`~mc retention set --version-id` or
+     :mc-cmd:`~mc retention set --versions` to apply the object lock
      settings to a specific version or to all versions of the object
      respectively.
 
-.. mc-cmd:: bypass
-   :option:
+.. mc-cmd:: --bypass
+   
 
    *Optional* Allows a user with the ``s3:BypassGovernanceRetention`` permission
    to modify the object. Requires the ``governance`` retention 
    :mc-cmd:`~mc retention set MODE`
 
-.. mc-cmd:: default
-   :option:
+.. mc-cmd:: --default
+   
 
    *Optional* Sets the default object lock settings for the bucket specified to
    :mc-cmd:`~mc retention set ALIAS` using the
@@ -148,26 +148,29 @@ Parameters
    Any objects created in the bucket inherit the default object lock settings
    unless explicitly overriden using :mc-cmd:`mc retention set`.
    
-   If specifying :mc-cmd-option:`~mc retention set default`, 
+   If specifying :mc-cmd:`~mc retention set --default`, 
    :mc-cmd:`mc retention set` ignores all other flags.
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive
+   :optional:
+   :alias: --r
 
-   *Optional* Recursively applies the object lock settings to all objects in the
+   Recursively applies the object lock settings to all objects in the
    specified :mc-cmd:`~mc retention set ALIAS` path.
 
-   Mutually exclusive with :mc-cmd-option:`~mc retention set version-id`.
+   Mutually exclusive with :mc-cmd:`~mc retention set --version-id`.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
-.. mc-cmd:: version-id, vid
-   :option:
+.. mc-cmd:: --version-id
+   :optional:
+   :alias: --vid
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -175,19 +178,19 @@ Parameters
 
    Mutually exclusive with any of the following flags:
    
-   - :mc-cmd-option:`~mc retention set versions`
-   - :mc-cmd-option:`~mc retention set rewind`
-   - :mc-cmd-option:`~mc retention set recursive`
+   - :mc-cmd:`~mc retention set --versions`
+   - :mc-cmd:`~mc retention set --rewind`
+   - :mc-cmd:`~mc retention set --recursive`
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc retention set versions` and
-   :mc-cmd-option:`~mc retention set rewind` together to apply the
+   Use :mc-cmd:`~mc retention set --versions` and
+   :mc-cmd:`~mc retention set --rewind` together to apply the
    retention settings to all object versions that existed at a
    specific point-in-time.
 
@@ -205,8 +208,8 @@ Set Default Bucket Retention Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc-cmd:`mc retention set` with the
-:mc-cmd-option:`~mc retention set recursive` and
-:mc-cmd-option:`~mc retention set default` to set the default bucket
+:mc-cmd:`~mc retention set --recursive` and
+:mc-cmd:`~mc retention set --default` to set the default bucket
 retention settings.
 
 .. code-block:: shell
@@ -239,7 +242,7 @@ Set Object Lock Configuration for Versioned Object
    .. tab-item:: Specific Version
 
       Use :mc-cmd:`mc retention set` with
-      :mc-cmd-option:`~mc retention set version-id` to apply the retention
+      :mc-cmd:`~mc retention set --version-id` to apply the retention
       settings to a specific object version:
 
       .. code-block:: shell
@@ -247,7 +250,7 @@ Set Object Lock Configuration for Versioned Object
 
          mc retention set --version-id VERSION MODE DURATION ALIAS/PATH
 
-      - Replace :mc-cmd:`VERSION <mc retention set version-id>` with the version
+      - Replace :mc-cmd:`VERSION <mc retention set --version-id>` with the version
         of the object.
 
       - Replace :mc-cmd:`MODE <mc retention set MODE>` with the retention mode
@@ -267,7 +270,7 @@ Set Object Lock Configuration for Versioned Object
    .. tab-item:: All Versions
 
       Use :mc-cmd:`mc retention set` with
-      :mc-cmd-option:`~mc retention set versions` to apply the retention
+      :mc-cmd:`~mc retention set --versions` to apply the retention
       settings to a specific object version:
 
       .. code-block:: shell
@@ -314,18 +317,18 @@ all versions of an object:
       To direct :mc:`mc retention set` to operate on a specific version of an
       object, include the ``--version-id`` argument:
       
-      - :mc-cmd-option:`mc retention set version-id`
-      - :mc-cmd-option:`mc retention set version-id`
-      - :mc-cmd-option:`mc retention set version-id`
+      - :mc-cmd:`mc retention set --version-id`
+      - :mc-cmd:`mc retention set --version-id`
+      - :mc-cmd:`mc retention set --version-id`
 
    .. tab-item:: All Object Versions
 
       To direct :mc:`mc retention set` to operate on *all* versions of an object, 
       include the ``--versions`` argument:
 
-      - :mc-cmd-option:`mc retention set versions`
-      - :mc-cmd-option:`mc retention set versions`
-      - :mc-cmd-option:`mc retention set versions`
+      - :mc-cmd:`mc retention set --versions`
+      - :mc-cmd:`mc retention set --versions`
+      - :mc-cmd:`mc retention set --versions`
 
 Interaction with Legal Holds
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-rm.rst
+++ b/source/reference/minio-mc/mc-rm.rst
@@ -11,10 +11,10 @@
 .. mc:: mc rm
 
 .. |command| replace:: :mc-cmd:`mc rm`
-.. |rewind| replace:: :mc-cmd-option:`~mc rm rewind`
-.. |versions| replace:: :mc-cmd-option:`~mc rm versions`
-.. |versionid| replace:: :mc-cmd-option:`~mc rm version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc rm ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc rm --rewind`
+.. |versions| replace:: :mc-cmd:`~mc rm --versions`
+.. |versionid| replace:: :mc-cmd:`~mc rm version-id`
+.. |alias| replace:: :mc-cmd:`~mc rm ALIAS`
 
 Syntax
 ------
@@ -32,7 +32,7 @@ results to the ``rm`` commandline tool.
 .. important::
 
    :mc:`mc rm` supports removing multiple objects *or* files in a single
-   command. Consider using the :mc-cmd-option:`~mc rm fake`
+   command. Consider using the :mc-cmd:`~mc rm --fake`
    option to validate that the operation targets only the desired objects/files.
 
 .. tab-set::
@@ -74,8 +74,8 @@ results to the ``rm`` commandline tool.
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
-      :mc-cmd-option:`mc rm force` is required by multiple parameters.
-      :mc-cmd-option:`mc rm version-id` is mutually exclusive with multiple
+      :mc-cmd:`mc rm --force` is required by multiple parameters.
+      :mc-cmd:`mc rm version-id` is mutually exclusive with multiple
       parameters. See the reference documentation for more information.
 
 Parameters
@@ -98,8 +98,8 @@ Parameters
       mc rm play/mybucket/object.txt play/mybucket/otherobject.txt
 
    If specifying the path to a bucket or bucket prefix, you **must** also
-   specify the :mc-cmd-option:`~mc rm recursive` and 
-   :mc-cmd-option:`~mc rm force` arguments. For example:
+   specify the :mc-cmd:`~mc rm --recursive` and 
+   :mc-cmd:`~mc rm --force` arguments. For example:
 
    .. code-block:: shell
 
@@ -108,7 +108,7 @@ Parameters
       mc rm --recursive --force play/mybucket/myprefix/
 
    Consider first running the command with the
-   :mc-cmd-option:`~mc rm fake` flag to validate the scope of the
+   :mc-cmd:`~mc rm --fake` flag to validate the scope of the
    recursive delete operation.
 
    For removing a file from a local filesystem, specify the full path to that
@@ -118,34 +118,34 @@ Parameters
 
       mc rm ~/data/myoldobject.txt
 
-.. mc-cmd:: bypass
-   :option:
+.. mc-cmd:: --bypass
+   
    
    *Optional* Allows removing an object held under 
    :ref:`GOVERNANCE <minio-object-locking-governance>` object locking. 
 
-.. mc-cmd:: dangerous
-   :option:
+.. mc-cmd:: --dangerous
+   
    
    *Optional* Allows running :mc:`mc rm` when the :mc-cmd:`~mc rm ALIAS`
    specifies the root (all buckets) on the MinIO deployment.
 
-   When combined with :mc-cmd-option:`~mc rm versions`, this flag
+   When combined with :mc-cmd:`~mc rm --versions`, this flag
    directs :mc-cmd:`mc rm` to permanently remove all objects *and* versions from
    the ``ALIAS`` target.
 
-   Consider first running the command with the :mc-cmd-option:`~mc rm fake` to
+   Consider first running the command with the :mc-cmd:`~mc rm --fake` to
    validate the scope of the site-wide delete operation.
 
    .. warning::
 
-      Running :mc-cmd-option:`mc rm dangerous` with the
-      :mc-cmd-option:`~mc rm versions` flag is irreversible. Exercise all 
+      Running :mc-cmd:`mc rm --dangerous` with the
+      :mc-cmd:`~mc rm --versions` flag is irreversible. Exercise all 
       possible due diligence in ensuring the command applies to only the desired
       ``ALIAS`` targets prior to execution.
 
-.. mc-cmd:: encrypt-key
-   :option:
+.. mc-cmd:: --encrypt-key
+   
 
    *Optional* The encryption key to use for performing Server-Side Encryption
    with Client Keys (SSE-C). Specify comma seperated key-value pairs as
@@ -159,45 +159,45 @@ Parameters
    - For ``VALUE``, specify the data key to use for encryption object(s) in
      the bucket or bucket prefix specified to ``KEY``.
 
-   :mc-cmd-option:`~mc rm encrypt-key` can use the ``MC_ENCRYPT_KEY``
+   :mc-cmd:`~mc rm --encrypt-key` can use the ``MC_ENCRYPT_KEY``
    environment variable for populating the list of encryption key-value
    pairs as an alternative to specifying them on the command line.
 
-.. mc-cmd:: fake
-   :option:
+.. mc-cmd:: --fake
+   
 
    *Optional* Perform a fake remove operation. Use this operation to perform 
    validate that the :mc:`mc rm` operation will only
    remove the desired objects or buckets.
 
-.. mc-cmd:: force
-   :option:
+.. mc-cmd:: --force
+   
 
    *Optional* Allows running :mc:`mc rm` with any of the following arguments:
    
-   - :mc-cmd-option:`~mc rm recursive`
-   - :mc-cmd-option:`~mc rm versions`
-   - :mc-cmd-option:`~mc rm stdin`
+   - :mc-cmd:`~mc rm --recursive`
+   - :mc-cmd:`~mc rm --versions`
+   - :mc-cmd:`~mc rm --stdin`
 
-.. mc-cmd:: incomplete, I
-   :option:
+.. mc-cmd:: --incomplete, I
+   
 
    *Optional* Remove incomplete uploads for the specified object.
 
-   If any :mc-cmd-option:`~mc rm ALIAS` specifies a bucket, 
-   you **must** also specify :mc-cmd-option:`~mc rm recursive`
-   and :mc-cmd-option:`~mc rm force`.
+   If any :mc-cmd:`~mc rm ALIAS` specifies a bucket, 
+   you **must** also specify :mc-cmd:`~mc rm --recursive`
+   and :mc-cmd:`~mc rm --force`.
 
-.. mc-cmd:: newer-than
-   :option:
+.. mc-cmd:: --newer-than
+   
 
    *Optional* Remove object(s) newer than the specified number of days. Specify
    a string in ``#d#hh#mm#ss`` format. For example: ``--newer-than 1d2hh3mm4ss``
 
    Defaults to ``0`` (all objects).
 
-.. mc-cmd:: non-current
-   :option:
+.. mc-cmd:: --non-current
+   
 
    *Optional* Removes all :ref:`non-current <minio-bucket-versioning-delete>`
    object versions from the specified :mc-cmd:`~mc rm ALIAS`.
@@ -205,8 +205,8 @@ Parameters
    This option has on effect on buckets without 
    :ref:`versioning <minio-bucket-versioning>` enabled.
 
-.. mc-cmd:: older-than
-   :option:
+.. mc-cmd:: --older-than
+   
 
    *Optional* Remove object(s) older than the specified time limit. Specify a
    string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``.
@@ -214,51 +214,51 @@ Parameters
       
    Defaults to ``0`` (all objects).
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
    
    *Optional* Recursively remove the contents of each :mc-cmd:`~mc rm ALIAS`
    bucket or bucket prefix.
 
-   If specifying :mc-cmd-option:`~mc rm recursive`, you **must** also
-   specify :mc-cmd-option:`~mc rm force`.
+   If specifying :mc-cmd:`~mc rm --recursive`, you **must** also
+   specify :mc-cmd:`~mc rm --force`.
 
    For buckets with :ref:`versioning <minio-bucket-versioning>` enabled,
    this option by default produces a delete marker for each removed object.
-   Include the :mc-cmd-option:`~mc rm versions` flag to recursively remove
+   Include the :mc-cmd:`~mc rm --versions` flag to recursively remove
    all objects *and* object versions from the bucket.
 
    Consider first running the command with the 
-   :mc-cmd-option:`~mc rm fake` flag to validate the scope of the
+   :mc-cmd:`~mc rm --fake` flag to validate the scope of the
    recursive delete operation.
 
-   Mutually exclusive with :mc-cmd-option:`mc rm version-id`
+   Mutually exclusive with :mc-cmd:`mc rm version-id`
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
-.. mc-cmd:: stdin
-   :option:
+.. mc-cmd:: --stdin
+   
 
    *Optional* Read object names or buckets from ``STDIN``.
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc rm versions` and 
-   :mc-cmd-option:`~mc rm rewind` together to remove all object
+   Use :mc-cmd:`~mc rm --versions` and 
+   :mc-cmd:`~mc rm --rewind` together to remove all object
    versions which existed at a specific point in time.
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -266,9 +266,9 @@ Parameters
 
    Mutually exclusive with any of the following flags:
    
-   - :mc-cmd-option:`~mc rm versions`
-   - :mc-cmd-option:`~mc rm rewind`
-   - :mc-cmd-option:`~mc rm recursive`
+   - :mc-cmd:`~mc rm --versions`
+   - :mc-cmd:`~mc rm --rewind`
+   - :mc-cmd:`~mc rm --recursive`
 
 Global Flags
 ~~~~~~~~~~~~
@@ -298,7 +298,7 @@ Recursively Remove a Bucket's Contents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use :mc:`mc rm` with the
-:mc-cmd-option:`~mc rm recursive` and :mc-cmd-option:`~mc rm force` options
+:mc-cmd:`~mc rm --recursive` and :mc-cmd:`~mc rm --force` options
 to recursively remove a bucket's contents.
 
 .. code-block:: shell
@@ -317,7 +317,7 @@ bucket along with all contents and associated configurations.
 Remove All Incomplete Upload Files for an Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc rm` with the :mc-cmd-option:`~mc rm incomplete` option to remove
+Use :mc:`mc rm` with the :mc-cmd:`~mc rm --incomplete` option to remove
 incomplete upload files for an object. 
 
 .. code-block:: shell
@@ -331,13 +331,13 @@ incomplete upload files for an object.
 - Replace :mc-cmd:`PATH <mc rm ALIAS>` with the path to the object.
 
 Removing incomplete upload files prevents resuming the upload using the
-:mc-cmd-option:`mc mv continue` or :mc-cmd-option:`mc cp continue` commands.
+:mc-cmd:`mc mv --continue` or :mc-cmd:`mc cp --continue` commands.
 
 Roll Object Back To Previous Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc rm` with :mc-cmd-option:`~mc rm versions` and 
-:mc-cmd-option:`~mc rm newer-than` to
+Use :mc:`mc rm` with :mc-cmd:`~mc rm --versions` and 
+:mc-cmd:`~mc rm --newer-than` to
 remove all object versions newer than the specified duration of time. This
 effectively "rolls back" the object to its state at that time.
 
@@ -357,7 +357,7 @@ effectively "rolls back" the object to its state at that time.
 - Replace :mc-cmd:`PATH <mc rm ALIAS>` with the path to the object. For 
   example, ``/mybucket/myobject``.
 
-- Replace :mc-cmd:`DURATION <mc rm newer-than>` with the number of days in the
+- Replace :mc-cmd:`DURATION <mc rm --newer-than>` with the number of days in the
   past from the current host time from which the operation begins removing
   versions of the object. For example, to remove all versions of the object
   created in the last 30 days, specify ``"30d"``.
@@ -370,7 +370,7 @@ Deleting Bucket Contents
 
 Using :mc:`mc rm` to remove all contents in a bucket does not delete the bucket
 itself. Any configurations associated to the bucket remain in place, such as
-:mc-cmd-option:`default object lock settings <mc retention set default>`.
+:mc-cmd:`default object lock settings <mc retention set --default>`.
 
 To completely remove a bucket, use :mc:`mc rb` instead of :mc:`mc rm`.
 
@@ -395,13 +395,13 @@ that marks an object as deleted while retaining all previous versions of that
 object.
 
 - To remove a specific object version from a bucket, use
-  :mc-cmd-option:`mc rm version-id`
+  :mc-cmd:`mc rm version-id`
 
 - To remove all versions of an object from a bucket, use
-  :mc-cmd-option:`mc rm versions`
+  :mc-cmd:`mc rm --versions`
 
 - To remove all non-current versions of an object from a bucket, use
-  :mc-cmd-option:`mc rm non-current`
+  :mc-cmd:`mc rm --non-current`
 
 
 S3 Compatibility

--- a/source/reference/minio-mc/mc-share-download.rst
+++ b/source/reference/minio-mc/mc-share-download.rst
@@ -11,8 +11,8 @@
 .. mc:: mc share download
 
 .. |command| replace:: :mc-cmd:`mc share download`
-.. |versionid| replace:: :mc-cmd-option:`~mc share download version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc share download ALIAS`
+.. |versionid| replace:: :mc-cmd:`~mc share download version-id`
+.. |alias| replace:: :mc-cmd:`~mc share download ALIAS`
 
 Syntax
 ------
@@ -82,7 +82,7 @@ Parameters
       mc share download play/mybucket/object.txt play/mybucket/otherobject.txt
 
    If specifying the path to a bucket or bucket prefix, you **must** also
-   specify the :mc-cmd-option:`~mc share download recursive` argument. For
+   specify the :mc-cmd:`~mc share download --recursive` argument. For
    example:
 
    .. code-block:: shell
@@ -91,8 +91,8 @@ Parameters
 
       mc share download --recursive play/mybucket/myprefix/
 
-.. mc-cmd:: expire, E
-   :option:
+.. mc-cmd:: --expire, E
+   
 
    *Optional* Set the expiration time limit for all generated URLs.
    
@@ -102,8 +102,8 @@ Parameters
 
    Defaults to ``168h`` or 168 hours (7 days).
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
    
    *Optional* Recursively generate URLs for all objects in a 
    :mc-cmd:`mc share download ALIAS` bucket or bucket prefix. 
@@ -111,7 +111,7 @@ Parameters
    Required if any ``ALIAS`` specifies a path to a bucket or bucket prefix.
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -148,14 +148,14 @@ Generate a URL to Download Object(s)
       - Replace :mc-cmd:`PATH <mc share download ALIAS>` with the path to the
         object on the MinIO deployment.
 
-      - Replace :mc-cmd:`DURATION <mc share download expire>` with the duration
+      - Replace :mc-cmd:`DURATION <mc share download --expire>` with the duration
         after which the URL expires. For example, to set a 30 day expiry, 
         specify ``30d``.
 
    .. tab-item:: Get Object(s) in a Bucket
 
       Use :mc-cmd:`mc share download` with the 
-      :mc-cmd-option:`~mc share download recursive` option to generate a URL for
+      :mc-cmd:`~mc share download --recursive` option to generate a URL for
       each object in a bucket. Each URL supports ``GET`` requests for its
       associated object:
 
@@ -170,7 +170,7 @@ Generate a URL to Download Object(s)
       - Replace :mc-cmd:`PATH <mc share download ALIAS>` with the path to the
         bucket or bucket prefix on the MinIO deployment.
 
-      - Replace :mc-cmd:`DURATION <mc share download expire>` with the duration
+      - Replace :mc-cmd:`DURATION <mc share download --expire>` with the duration
         after which the URL expires. For example, to set a 30 day expiry, 
         specify ``30d``.
 

--- a/source/reference/minio-mc/mc-share-list.rst
+++ b/source/reference/minio-mc/mc-share-list.rst
@@ -62,13 +62,13 @@ Parameters
 
    *Required* Lists all unexpired presigned download (``GET``) URLs.
 
-   Mutually exclusive with :mc-cmd-option:`mc share list upload`
+   Mutually exclusive with :mc-cmd:`mc share list upload`
 
 .. mc-cmd:: upload
 
    *Required* Lists all unexpired presigned upload (``PUT``) URLs.
 
-   Mutually exclusive with :mc-cmd-option:`mc share list download`
+   Mutually exclusive with :mc-cmd:`mc share list download`
 
 .. mc-cmd:: ALIAS
 

--- a/source/reference/minio-mc/mc-share-upload.rst
+++ b/source/reference/minio-mc/mc-share-upload.rst
@@ -75,7 +75,7 @@ Parameters
       mc share upload play/mybucket/object.txt play/mybucket/otherobject.txt
 
    If specifying the path to a bucket or bucket prefix, you **must** also
-   specify the :mc-cmd-option:`~mc share upload recursive` argument. For
+   specify the :mc-cmd:`~mc share upload --recursive` argument. For
    example:
 
    .. code-block:: shell
@@ -84,8 +84,8 @@ Parameters
 
       mc share upload --recursive play/mybucket/myprefix/
 
-.. mc-cmd:: expire, E
-   :option:
+.. mc-cmd:: --expire, E
+   
 
    *Optional* Set the expiration time limit for all generated URLs.
    
@@ -95,8 +95,8 @@ Parameters
 
    Defaults to ``168h`` or 168 hours (7 days).
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
    
    *Optional* Modifies the CURL URL to support uploading objects to a bucket or
    bucket prefix. Required if any ``ALIAS`` specifies a path to a bucket or
@@ -142,16 +142,17 @@ Generate a URL to Upload Object(s)
       - Replace :mc-cmd:`PATH <mc share upload ALIAS>` with the path to the
         object on the MinIO deployment.
 
-      - Replace :mc-cmd:`DURATION <mc share upload expire>` with the duration
+      - Replace :mc-cmd:`DURATION <mc share upload --expire>` with the duration
         after which the URL expires. For example, to set a 30 day expiry, 
         specify ``30d``.
 
    .. tab-item:: Upload Multiple Objects
 
-      Use :mc-cmd:`mc share upload` with the 
-      :mc-cmd-option:`~mc share upload recursive` option to generate a URL that
-      supports ``POST`` requests for uploading files to a bucket on a
-      MinIO deployment:
+      Use :mc-cmd:`mc share upload` with the
+      :mc-cmd:`~mc share upload --recursive` and
+      :mc-cmd:`~mc share upload --expire` options to generate a temporary URL
+      that supports ``POST`` requests for uploading files to a bucket on a MinIO
+      deployment:
 
       .. code-block:: shell
          :class: copyable
@@ -164,7 +165,7 @@ Generate a URL to Upload Object(s)
       - Replace :mc-cmd:`PATH <mc share upload ALIAS>` with the path to the
         bucket or bucket prefix on the MinIO deployment.
 
-      - Replace :mc-cmd:`DURATION <mc share upload expire>` with the duration
+      - Replace :mc-cmd:`DURATION <mc share upload --expire>` with the duration
         after which the URL expires. For example, to set a 30 day expiry, 
         specify ``30d``.
 

--- a/source/reference/minio-mc/mc-sql.rst
+++ b/source/reference/minio-mc/mc-sql.rst
@@ -72,8 +72,8 @@ Parameters
 
       mc sql [FLAGS] play/mybucket
 
-.. mc-cmd:: query, e
-   :option:
+.. mc-cmd:: --query, e
+   
 
    *Required* The SQL statement to execute on the specified 
    :mc-cmd:`~mc sql ALIAS` directory or object. Wrap the entire SQL query in 
@@ -81,15 +81,15 @@ Parameters
 
    Defaults to ``"select * from S3Object"``.
 
-.. mc-cmd:: csv-input
-   :option:
+.. mc-cmd:: --csv-input
+   
 
    *Optional* The data format for ``.csv`` input objects. Specify a string of
    comma-seperated ``key=value,...`` pairs. See :ref:`mc-sql-csv-format` for
    more information on valid keys.
 
-.. mc-cmd:: compression
-   :option:
+.. mc-cmd:: --compression
+   
 
    *Optional* The compression type of the input object. Specify one of the
    following supported values:
@@ -105,8 +105,8 @@ Parameters
    - ``S2`` `S2 <https://github.com/klauspost/compress/tree/master/s2#s2-compression>`__ framed stream
    - ``SNAPPY`` `Snappy <http://google.github.io/snappy/>`__ framed stream
 
-.. mc-cmd:: csv-output
-   :option:
+.. mc-cmd:: --csv-output
+   
 
    *Optional* The data format for ``.csv`` output. Specify a string of
    comma-seperated ``key=value,...`` pairs. See :ref:`mc-sql-csv-format` for
@@ -116,15 +116,15 @@ Parameters
    information.
 
 .. mc-cmd:: csv-output-header
-   :option:
+   
 
    *Optional* The header row of the ``.csv`` output file. Specify a string of
    comma-separated fields as ``field1,field2,...``.
 
    Omit to output a ``.csv`` with no header row.
 
-.. mc-cmd:: encrypt-key
-   :option:
+.. mc-cmd:: --encrypt-key
+   
 
    *Optional* The encryption key to use for performing Server-Side Encryption
    with Client Keys (SSE-C). Specify comma seperated key-value pairs as
@@ -138,12 +138,12 @@ Parameters
    - For ``VALUE``, specify the data key to use for encryption object(s) in
      the bucket or bucket prefix specified to ``KEY``.
 
-   :mc-cmd-option:`~mc sql encrypt-key` can use the ``MC_ENCRYPT_KEY``
+   :mc-cmd:`~mc sql --encrypt-key` can use the ``MC_ENCRYPT_KEY``
    environment variable for populating the list of encryption key-value
    pairs as an alternative to specifying them on the command line.
 
-.. mc-cmd:: json-input
-   :option:
+.. mc-cmd:: --json-input
+   
 
    *Optional* The data format for ``.json`` input objects. Specify the type of 
    the JSON contents as ``type=<VALUE>``. The value can be either:
@@ -154,8 +154,8 @@ Parameters
    See the S3 API :s3-api:`JSONInput <API_JSONInput.html>` for more
    information.
 
-.. mc-cmd:: json-output
-   :option:
+.. mc-cmd:: --json-output
+   
 
    *Optional* The data format for the ``.json`` output. Supports the 
    ``rd=value`` key, where ``rd`` is the ``RecordDelimiter`` for the JSON
@@ -166,11 +166,11 @@ Parameters
    See the S3 API :s3-api:`JSONOutput <API_JSONOutput.html>` for more
    information.
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    *Optional* Recursively searches the specified :mc-cmd:`~mc sql ALIAS`
-   directory using the :mc-cmd-option:`~mc sql query` SQL statement.
+   directory using the :mc-cmd:`~mc sql --query` SQL statement.
 
 Global Flags
 ~~~~~~~~~~~~
@@ -185,8 +185,8 @@ Examples
 Select all Columns in all Objects in a Bucket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc sql` with the :mc-cmd-option:`~mc sql recursive` and
-:mc-cmd-option:`~mc sql query` options to apply the query to all objects 
+Use :mc:`mc sql` with the :mc-cmd:`~mc sql --recursive` and
+:mc-cmd:`~mc sql --query` options to apply the query to all objects 
 in a bucket:
 
 .. code-block:: shell
@@ -203,7 +203,7 @@ in a bucket:
 Run an Aggregation Query on an Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc sql` with the :mc-cmd-option:`~mc sql query` option to query 
+Use :mc:`mc sql` with the :mc-cmd:`~mc sql --query` option to query 
 an object on an MinIO deployment:
 
 .. code-block:: shell
@@ -228,11 +228,11 @@ Input Formats
 - ``.json``
 - ``.parquet``
 
-For ``.csv`` file types, use :mc-cmd-option:`mc sql csv-input` to 
+For ``.csv`` file types, use :mc-cmd:`mc sql --csv-input` to 
 specify the CSV data format. See :ref:`mc-sql-csv-format` for more 
 information on CSV formatting fields.
 
-For ``.json`` file types, use :mc-cmd-option:`mc sql json-input` to specify
+For ``.json`` file types, use :mc-cmd:`mc sql --json-input` to specify
 the JSON data format.
 
 For ``.parquet`` file types, :mc-cmd:`mc sql` automatically interprets the
@@ -244,8 +244,8 @@ CSV Formatting Fields
 ~~~~~~~~~~~~~~~~~~~~~
 
 The following table lists valid key-value pairs for use with
-:mc-cmd-option:`mc sql csv-input` and :mc-cmd-option:`mc sql csv-output`. 
-Certain key pairs are only valid for :mc-cmd-option:`~mc sql csv-input`
+:mc-cmd:`mc sql --csv-input` and :mc-cmd:`mc sql --csv-output`. 
+Certain key pairs are only valid for :mc-cmd:`~mc sql --csv-input`
 See the documentation for S3 API :s3-api:`CSVInput <API_CSVInput.html>` for more 
 information on S3 CSV formatting.
 
@@ -297,11 +297,11 @@ information on S3 CSV formatting.
        - ``USE`` - The first line is a header.
 
        For ``NONE`` or ``IGNORE``, you must specify column positions
-       ``_#`` to identify a column in the :mc-cmd-option:`~mc sql query` 
+       ``_#`` to identify a column in the :mc-cmd:`~mc sql --query` 
        statement.
 
        For ``USE``, you can specify header values to identify a column in 
-       the :mc-cmd-option:`~mc sql query` statement.
+       the :mc-cmd:`~mc sql --query` statement.
 
        Corresponds to ``FieldHeaderInfo`` in the S3 API ``CSVInput``.
    

--- a/source/reference/minio-mc/mc-stat.rst
+++ b/source/reference/minio-mc/mc-stat.rst
@@ -11,10 +11,10 @@
 .. mc:: mc stat
 
 .. |command| replace:: :mc-cmd:`mc stat`
-.. |rewind| replace:: :mc-cmd-option:`~mc stat rewind`
-.. |versions| replace:: :mc-cmd-option:`~mc stat versions`
-.. |versionid| replace:: :mc-cmd-option:`~mc stat version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc stat ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc stat --rewind`
+.. |versions| replace:: :mc-cmd:`~mc stat --versions`
+.. |versionid| replace:: :mc-cmd:`~mc stat version-id`
+.. |alias| replace:: :mc-cmd:`~mc stat ALIAS`
 
 Syntax
 -----------
@@ -61,7 +61,7 @@ results to the ``stat`` commandline tool.
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
-      :mc-cmd-option:`mc stat version-id` is mutually exclusive with multiple
+      :mc-cmd:`mc stat version-id` is mutually exclusive with multiple
       parameters. See the reference documentation for more information.
 
 Parameters
@@ -83,7 +83,7 @@ Parameters
       mc stat play/mybucket/myobject.txt myminio/mybucket/myobject.txt
 
    If specifying the path to a bucket or bucket prefixy, you **must**
-   include the :mc-cmd-option:`mc stat recursive` flag:
+   include the :mc-cmd:`mc stat --recursive` flag:
 
    .. code-block:: shell
 
@@ -96,8 +96,8 @@ Parameters
 
       mc stat ~/data/myobject.txt
 
-.. mc-cmd:: encrypt-key
-   :option:
+.. mc-cmd:: --encrypt-key
+   
 
    *Optional* Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
@@ -107,38 +107,38 @@ Parameters
       object(s).
 
    Enclose the entire list of key-value pairs passed to 
-   :mc-cmd-option:`~mc stat encrypt-key` in double quotes ``"``.
+   :mc-cmd:`~mc stat --encrypt-key` in double quotes ``"``.
 
-   :mc-cmd-option:`~mc stat encrypt-key` can use the ``MC_ENCRYPT_KEY``
+   :mc-cmd:`~mc stat --encrypt-key` can use the ``MC_ENCRYPT_KEY``
    environment variable for retrieving a list of encryption key-value pairs
    as an alternative to specifying them on the command line.
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    *Optional* Recursively :mc:`mc stat` the contents of the MinIO bucket
    specified to :mc-cmd:`~mc stat ALIAS`.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc stat versions` and 
-   :mc-cmd-option:`~mc stat rewind` together to remove all object
+   Use :mc-cmd:`~mc stat --versions` and 
+   :mc-cmd:`~mc stat --rewind` together to remove all object
    versions which existed at a specific point in time.
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -146,9 +146,9 @@ Parameters
 
    Mutually exclusive with any of the following flags:
    
-   - :mc-cmd-option:`~mc stat versions`
-   - :mc-cmd-option:`~mc stat rewind`
-   - :mc-cmd-option:`~mc stat recursive`
+   - :mc-cmd:`~mc stat --versions`
+   - :mc-cmd:`~mc stat --rewind`
+   - :mc-cmd:`~mc stat --recursive`
 
 Examples
 --------
@@ -170,7 +170,7 @@ Examples
 
    .. tab-item:: Object(s) in Bucket
 
-      Use :mc:`mc stat` with the :mc-cmd-option:`~mc stat recursive` option
+      Use :mc:`mc stat` with the :mc-cmd:`~mc stat --recursive` option
       to apply the operation to all objects in the bucket:
 
       .. code-block:: shell

--- a/source/reference/minio-mc/mc-tag-list.rst
+++ b/source/reference/minio-mc/mc-tag-list.rst
@@ -13,10 +13,10 @@
 .. mc:: mc tag list
 
 .. |command| replace:: :mc-cmd:`mc tag list`
-.. |rewind| replace:: :mc-cmd-option:`~mc tag list rewind`
-.. |versions| replace:: :mc-cmd-option:`~mc tag list versions`
-.. |versionid| replace:: :mc-cmd-option:`~mc tag list version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc tag list ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc tag list --rewind`
+.. |versions| replace:: :mc-cmd:`~mc tag list --versions`
+.. |versionid| replace:: :mc-cmd:`~mc tag list version-id`
+.. |alias| replace:: :mc-cmd:`~mc tag list ALIAS`
 
 Syntax
 ------
@@ -56,7 +56,7 @@ The :mc:`mc tag list` command lists all tags from a bucket or object.
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
-      :mc-cmd-option:`mc tag list version-id` is mutually exclusive with
+      :mc-cmd:`mc tag list version-id` is mutually exclusive with
       multiple parameters. See the reference documentation for more information.
 
 Parameters
@@ -72,26 +72,26 @@ Parameters
 
       mc tag list myminio/mybucket/object.txt
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc tag list versions` and 
-   :mc-cmd-option:`~mc tag list rewind` together to list tags from all
+   Use :mc-cmd:`~mc tag list --versions` and 
+   :mc-cmd:`~mc tag list --rewind` together to list tags from all
    object versions which existed at a specific point in time.
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -99,8 +99,8 @@ Parameters
 
    Mutually exclusive with the following parameters:
 
-   - :mc-cmd-option:`~mc tag list rewind`
-   - :mc-cmd-option:`~mc tag list versions`
+   - :mc-cmd:`~mc tag list --rewind`
+   - :mc-cmd:`~mc tag list --versions`
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-tag-remove.rst
+++ b/source/reference/minio-mc/mc-tag-remove.rst
@@ -13,10 +13,10 @@
 .. mc:: mc tag remove
 
 .. |command| replace:: :mc-cmd:`mc tag remove`
-.. |rewind| replace:: :mc-cmd-option:`~mc tag remove rewind`
-.. |versions| replace:: :mc-cmd-option:`~mc tag remove versions`
-.. |versionid| replace:: :mc-cmd-option:`~mc tag remove version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc tag remove ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc tag remove --rewind`
+.. |versions| replace:: :mc-cmd:`~mc tag remove --versions`
+.. |versionid| replace:: :mc-cmd:`~mc tag remove version-id`
+.. |alias| replace:: :mc-cmd:`~mc tag remove ALIAS`
 
 Syntax
 ------
@@ -55,7 +55,7 @@ The :mc:`mc tag remove` command removes all tags from a bucket or object.
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
-      :mc-cmd-option:`mc tag remove version-id` is mutually exclusive with
+      :mc-cmd:`mc tag remove version-id` is mutually exclusive with
       multiple parameters. See the reference documentation for more information.
 
 Parameters
@@ -71,26 +71,26 @@ Parameters
 
       mc tag remove myminio/mybucket/object.txt
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc tag remove versions` and 
-   :mc-cmd-option:`~mc tag remove rewind` together to remove tags from all
+   Use :mc-cmd:`~mc tag remove --versions` and 
+   :mc-cmd:`~mc tag remove --rewind` together to remove tags from all
    object versions which existed at a specific point in time.
 
 .. mc-cmd:: version-id, vid
-   :option:
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -98,8 +98,8 @@ Parameters
 
    Mutually exclusive with the following parameters:
 
-   - :mc-cmd-option:`~mc tag remove rewind`
-   - :mc-cmd-option:`~mc tag remove versions`
+   - :mc-cmd:`~mc tag remove --rewind`
+   - :mc-cmd:`~mc tag remove --versions`
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-tag-set.rst
+++ b/source/reference/minio-mc/mc-tag-set.rst
@@ -14,10 +14,10 @@
 .. mc:: mc tag set
 
 .. |command| replace:: :mc-cmd:`mc tag set`
-.. |rewind| replace:: :mc-cmd-option:`~mc tag set rewind`
-.. |versions| replace:: :mc-cmd-option:`~mc tag set versions`
-.. |versionid| replace:: :mc-cmd-option:`~mc tag set version-id`
-.. |alias| replace:: :mc-cmd-option:`~mc tag set ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc tag set --rewind`
+.. |versions| replace:: :mc-cmd:`~mc tag set --versions`
+.. |versionid| replace:: :mc-cmd:`~mc tag set --version-id`
+.. |alias| replace:: :mc-cmd:`~mc tag set ALIAS`
 
 Syntax
 ------
@@ -58,7 +58,7 @@ The :mc:`mc tag set` command sets one or more tags to a bucket or object.
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
-      :mc-cmd-option:`mc tag set version-id` is mutually exclusive with
+      :mc-cmd:`mc tag set --version-id` is mutually exclusive with
       multiple parameters. See the reference documentation for more information.
 
 
@@ -85,26 +85,26 @@ Parameters
 
       mc tag set myminio/mybucket/object.txt "key1=value1&key2=value2"
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
-.. mc-cmd:: versions
-   :option:
+.. mc-cmd:: --versions
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-versions-desc
       :end-before: end-versions-desc
 
-   Use :mc-cmd-option:`~mc tag set versions` and 
-   :mc-cmd-option:`~mc tag set rewind` together to apply the tag all object
+   Use :mc-cmd:`~mc tag set --versions` and 
+   :mc-cmd:`~mc tag set --rewind` together to apply the tag all object
    versions which existed at a specific point in time.
 
-.. mc-cmd:: version-id, vid
-   :option:
+.. mc-cmd:: --version-id, --vid
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -112,8 +112,8 @@ Parameters
 
    Mutually exclusive with the following parameters:
 
-   - :mc-cmd-option:`~mc tag set rewind`
-   - :mc-cmd-option:`~mc tag set versions`
+   - :mc-cmd:`~mc tag set --rewind`
+   - :mc-cmd:`~mc tag set --versions`
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-tree.rst
+++ b/source/reference/minio-mc/mc-tree.rst
@@ -11,8 +11,8 @@
 .. mc:: mc tree
 
 .. |command| replace:: :mc-cmd:`mc tree`
-.. |rewind| replace:: :mc-cmd-option:`~mc tree rewind`
-.. |alias| replace:: :mc-cmd-option:`~mc tree ALIAS`
+.. |rewind| replace:: :mc-cmd:`~mc tree --rewind`
+.. |alias| replace:: :mc-cmd:`~mc tree ALIAS`
 
 Syntax
 ------
@@ -82,21 +82,21 @@ Parameters
 
       mc tree ~/minio/mydata/
 
-.. mc-cmd:: depth, d
-   :option:
+.. mc-cmd:: --depth, d
+   
 
    *Optional* Limit the tree depth to the specified integer value. 
    
    Defaults to ``-1`` or unlimited depth.
 
-.. mc-cmd:: files, f
-   :option:
+.. mc-cmd:: --files, f
+   
 
    *Optional* Includes files in the object or directory in the :mc:`mc tree`
    output.
 
-.. mc-cmd:: rewind
-   :option:
+.. mc-cmd:: --rewind
+   
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-rewind-desc

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -175,7 +175,7 @@ a versioning ID to any unversioned object.
 Disabling bucket versioning on a bucket with existing versioned data does
 *not* remove any versioned objects. Applications can continue to access
 versioned data after disabling bucket versioning. Use 
-:mc-cmd:`mc rm --versions ALIAS/BUCKET/OBJECT <mc rm versions>` to delete an 
+:mc-cmd:`mc rm --versions ALIAS/BUCKET/OBJECT <mc rm --versions>` to delete an 
 object *and* all its versions.
 
 S3 Compatibility

--- a/source/reference/minio-mc/mc-watch.rst
+++ b/source/reference/minio-mc/mc-watch.rst
@@ -68,38 +68,38 @@ Parameters
 
       mc tree myminio/mybucket
 
-.. mc-cmd:: event
-   :option:
+.. mc-cmd:: --event
+   
 
    The event(s) to watch for. Specify multiple events using a comma ``,``
    delimiter. See :ref:`mc-event-supported-events` for supported events.
 
    Defaults to ``put,delete, get``.
       
-.. mc-cmd:: prefix
-   :option:
+.. mc-cmd:: --prefix
+   
 
    The bucket prefix in which to watch for the specified 
-   :mc-cmd-option:`~mc watch event`.
+   :mc-cmd:`~mc watch --event`.
 
    For example, given a :mc-cmd:`~mc watch ALIAS` of ``play/mybucket`` and a 
-   :mc-cmd-option:`~mc watch prefix` of ``photos``, only events in 
+   :mc-cmd:`~mc watch --prefix` of ``photos``, only events in 
    ``play/mybucket/photos`` trigger bucket notifications.
 
-.. mc-cmd:: recursive, r
-   :option:
+.. mc-cmd:: --recursive, r
+   
 
    Recursively watch for events in the specified 
    :mc-cmd:`~mc watch ALIAS` bucket path or local directory.
 
-.. mc-cmd:: suffix
-   :option:
+.. mc-cmd:: --suffix
+   
 
    The bucket suffix in which to watch for the specified 
-   :mc-cmd-option:`~mc watch event`.
+   :mc-cmd:`~mc watch --event`.
 
    For example, given a :mc-cmd:`~mc watch ALIAS` of ``play/mybucket`` and a 
-   :mc-cmd-option:`~mc watch suffix` of ``.jpg``, only events in 
+   :mc-cmd:`~mc watch --suffix` of ``.jpg``, only events in 
    ``play/mybucket/*.jpg`` trigger bucket notifications.
 
 Global Flags

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -131,8 +131,8 @@ The command accepts the following arguments:
       of decreased reliability.
 
 
-.. mc-cmd:: address
-   :option:
+.. mc-cmd:: --address
+   
 
    *Optional* Binds the :mc:`minio <minio server>` server process to a
    specific network address and port number. Specify the address and port as
@@ -146,8 +146,8 @@ The command accepts the following arguments:
    If omitted, :mc:`minio <minio server>` binds to port ``9000`` on all
    configured IP addresses or hostnames on the host machine.
 
-.. mc-cmd:: console-address
-   :option:
+.. mc-cmd:: --console-address
+   
 
    *Optional*
 
@@ -157,7 +157,7 @@ The command accepts the following arguments:
    MinIO server outputs the port to the system log.
 
 .. mc-cmd:: certs-dir, -S
-   :option:
+   
 
    *Optional* Specifies the path to the folder containing certificates the
    :mc:`minio` process uses for configuring TLS/SSL connectivity.
@@ -169,18 +169,18 @@ The command accepts the following arguments:
 
    See :ref:`minio-TLS` for more information on TLS/SSL connectivity.
 
-.. mc-cmd:: quiet
-   :option:
+.. mc-cmd:: --quiet
+   
 
    *Optional* Disables startup information.
 
-.. mc-cmd:: anonymous
-   :option:
+.. mc-cmd:: --anonymous
+   
 
    *Optional* Hides sensitive information from logging.
 
-.. mc-cmd:: json
-   :option:
+.. mc-cmd:: --json
+   
 
    *Optional* Outputs server logs and startup information in ``JSON``
    format.

--- a/source/replication/enable-server-side-multi-site-bucket-replication.rst
+++ b/source/replication/enable-server-side-multi-site-bucket-replication.rst
@@ -49,8 +49,8 @@ MinIO multi-site replication requires MinIO server
    - Use the :mc-cmd:`mc replicate edit` command to modify an existing
      replication rule.
 
-   - Use the :mc-cmd-option:`mc replicate edit` command with the
-     :mc-cmd-option:`--state "disable" <mc replicate edit state>` flag to
+   - Use the :mc-cmd:`mc replicate edit` command with the
+     :mc-cmd:`--state "disable" <mc replicate edit --state>` flag to
      disable an existing replication rule.
 
    - Use the :mc-cmd:`mc replicate rm` command to remove an existing replication
@@ -208,8 +208,8 @@ Starting with :mc:`mc` :minio-git:`RELEASE.2021-06-13T17-48-22Z
 replicating existing objects in a bucket.
 
 MinIO requires explicitly enabling replication of existing objects using the
-:mc-cmd-option:`mc replicate add replicate` or
-:mc-cmd-option:`mc replicate edit replicate` and including the 
+:mc-cmd:`mc replicate add --replicate` or
+:mc-cmd:`mc replicate edit --replicate` and including the 
 ``existing-objects`` replication feature flag. This procedure includes the
 required flags for enabling replication of existing objects.
 
@@ -228,8 +228,8 @@ of specific versioned objects:
   MinIO replication also deletes those versions on the target bucket.
 
 MinIO requires explicitly enabling replication of delete operations using the
-:mc-cmd-option:`mc replicate add replicate` or 
-:mc-cmd-option:`mc replicate edit replicate`. This procedure includes the
+:mc-cmd:`mc replicate add --replicate` or 
+:mc-cmd:`mc replicate edit --replicate`. This procedure includes the
 required flags for enabling replication of delete operations and delete markers.
 
 MinIO does *not* replicate delete operations resulting from the application of
@@ -383,10 +383,10 @@ configuration.
 
 - Replace ``HOSTNAME`` with the URL of the remote MinIO deployment
 
-- (Optional) Specify the :mc-cmd-option:`~mc admin bucket remote add sync`
+- (Optional) Specify the :mc-cmd:`~mc admin bucket remote add sync`
   option to enable synchronous replication. Omit the option to use the default
   of asynchronous replication. See the reference documentation for
-  :mc-cmd-option:`~mc admin bucket remote add sync` for more information on
+  :mc-cmd:`~mc admin bucket remote add sync` for more information on
   synchronous vs asynchronous replication.
 
 The command returns an ARN similar to the following. Copy this ARN for use in
@@ -420,7 +420,7 @@ the remote as a target:
   - :ref:`Replication of Deletes <minio-replication-behavior-delete>` 
   - :ref:`Replication of Existing Objects <minio-replication-behavior-existing-objects>`
   
-  See :mc-cmd-option:`mc replicate add replicate` for more complete
+  See :mc-cmd:`mc replicate add --replicate` for more complete
   documentation. Omit these fields to disable replication of delete operations
   or replication of existing objects respectively.
 

--- a/source/replication/enable-server-side-one-way-bucket-replication.rst
+++ b/source/replication/enable-server-side-one-way-bucket-replication.rst
@@ -33,8 +33,8 @@ one-way synchronization of objects between MinIO buckets.
    - Use the :mc-cmd:`mc replicate edit` command to modify an existing
      replication rule.
 
-   - Use the :mc-cmd-option:`mc replicate edit` command with the
-     :mc-cmd-option:`--state "disable" <mc replicate edit state>` flag to
+   - Use the :mc-cmd:`mc replicate edit` command with the
+     :mc-cmd:`--state "disable" <mc replicate edit --state>` flag to
      disable an existing replication rule.
 
    - Use the :mc-cmd:`mc replicate rm` command to remove an existing replication
@@ -173,8 +173,8 @@ Starting with :mc:`mc` :minio-git:`RELEASE.2021-06-13T17-48-22Z
 replicating existing objects in a bucket.
 
 MinIO requires explicitly enabling replication of existing objects using the
-:mc-cmd-option:`mc replicate add replicate` or
-:mc-cmd-option:`mc replicate edit replicate` and including the 
+:mc-cmd:`mc replicate add --replicate` or
+:mc-cmd:`mc replicate edit --replicate` and including the 
 ``existing-objects`` replication feature flag. This procedure includes the
 required flags for enabling replication of existing objects.
 
@@ -193,8 +193,8 @@ of specific versioned objects:
   MinIO replication also deletes those versions on the target bucket.
 
 MinIO requires explicitly enabling replication of delete operations using the
-:mc-cmd-option:`mc replicate add replicate` or 
-:mc-cmd-option:`mc replicate edit replicate`. This procedure includes the
+:mc-cmd:`mc replicate add --replicate` or 
+:mc-cmd:`mc replicate edit --replicate`. This procedure includes the
 required flags for enabling replication of delete operations and delete markers.
 
 MinIO does *not* replicate delete operations resulting from the 
@@ -335,10 +335,10 @@ bucket.
 - Replace ``DESTINATIONBUCKET`` with the name of the target bucket on the
   ``Baker`` cluster.
 
-- Specify the :mc-cmd-option:`~mc admin bucket remote add sync` option to
+- Specify the :mc-cmd:`~mc admin bucket remote add sync` option to
   enable synchronous replication. Omit the option to use the default of 
   asynchronous replication. See the reference documentation for 
-  :mc-cmd-option:`~mc admin bucket remote add sync` for more information
+  :mc-cmd:`~mc admin bucket remote add sync` for more information
   on synchronous vs asynchronous replication.
 
 The command returns an ARN similar to the following:
@@ -377,7 +377,7 @@ replication rule to the source MinIO cluster.
   - :ref:`Replication of Deletes <minio-replication-behavior-delete>` 
   - :ref:`Replication of existing Objects <minio-replication-behavior-existing-objects>`
   
-  See :mc-cmd-option:`mc replicate add replicate` for more complete
+  See :mc-cmd:`mc replicate add --replicate` for more complete
   documentation. Omit these fields to disable replication of delete operations
   or replication of existing objects respectively.
 
@@ -402,5 +402,5 @@ Use :mc-cmd:`mc ls` to verify the object exists on the destination bucket:
    mc ls Baker/DESTINATIONBUCKET
 
 If the remote target was configured *without* the 
-:mc-cmd-option:`~mc admin bucket remote add sync` option, the destination
+:mc-cmd:`~mc admin bucket remote add sync` option, the destination
 bucket may have some delay before it receives the new object.

--- a/source/replication/enable-server-side-two-way-bucket-replication.rst
+++ b/source/replication/enable-server-side-two-way-bucket-replication.rst
@@ -38,8 +38,8 @@ or more MinIO clusters, see :ref:`minio-bucket-replication-serverside-multi`
    - Use the :mc-cmd:`mc replicate edit` command to modify an existing
      replication rule.
 
-   - Use the :mc-cmd-option:`mc replicate edit` command with the
-     :mc-cmd-option:`--state "disable" <mc replicate edit state>` flag to
+   - Use the :mc-cmd:`mc replicate edit` command with the
+     :mc-cmd:`--state "disable" <mc replicate edit --state>` flag to
      disable an existing replication rule.
 
    - Use the :mc-cmd:`mc replicate rm` command to remove an existing replication
@@ -195,8 +195,8 @@ Starting with :mc:`mc` :minio-git:`RELEASE.2021-06-13T17-48-22Z
 replicating existing objects in a bucket.
 
 MinIO requires explicitly enabling replication of existing objects using the
-:mc-cmd-option:`mc replicate add replicate` or
-:mc-cmd-option:`mc replicate edit replicate` and including the 
+:mc-cmd:`mc replicate add --replicate` or
+:mc-cmd:`mc replicate edit --replicate` and including the 
 ``existing-objects`` replication feature flag. This procedure includes the
 required flags for enabling replication of existing objects.
 
@@ -215,8 +215,8 @@ of specific versioned objects:
   MinIO replication also deletes those versions on the target bucket.
 
 MinIO requires explicitly enabling replication of delete operations using the
-:mc-cmd-option:`mc replicate add replicate` or 
-:mc-cmd-option:`mc replicate edit replicate`. This procedure includes the
+:mc-cmd:`mc replicate add --replicate` or 
+:mc-cmd:`mc replicate edit --replicate`. This procedure includes the
 required flags for enabling replication of delete operations and delete markers.
 
 MinIO does *not* replicate delete operations resulting from the 
@@ -371,10 +371,10 @@ A\) Create a Replication Target for Alpha -> Baker
    - Replace ``DESTINATIONBUCKET`` with the name of the target bucket on the
      ``Baker`` cluster.
 
-   - Specify the :mc-cmd-option:`~mc admin bucket remote add sync` option to
+   - Specify the :mc-cmd:`~mc admin bucket remote add sync` option to
      enable synchronous replication. Omit the option to use the default of 
      asynchronous replication. See the reference documentation for 
-     :mc-cmd-option:`~mc admin bucket remote add sync` for more information
+     :mc-cmd:`~mc admin bucket remote add sync` for more information
      on synchronous vs asynchronous replication.
 
    The command returns an ARN similar to the following. Copy this ARN for use in
@@ -405,10 +405,10 @@ B\) Create a Replication Target for Baker -> Alpha
    - Replace ``DESTINATIONBUCKET`` with the name of the remote replication 
      target on the ``Alpha`` cluster.
 
-   - Specify the :mc-cmd-option:`~mc admin bucket remote add sync` option to
+   - Specify the :mc-cmd:`~mc admin bucket remote add sync` option to
      enable synchronous replication. Omit the option to use the default of 
      asynchronous replication. See the reference documentation for 
-     :mc-cmd-option:`~mc admin bucket remote add sync` for more information
+     :mc-cmd:`~mc admin bucket remote add sync` for more information
      on synchronous vs asynchronous replication.
 
    The command returns an ARN similar to the following. Copy this ARN for use in
@@ -456,7 +456,7 @@ A\) Create Replication Rule on Alpha
      - :ref:`Replication of Deletes <minio-replication-behavior-delete>` 
      - :ref:`Replication of existing Objects <minio-replication-behavior-existing-objects>`
       
-     See :mc-cmd-option:`mc replicate add replicate` for more complete
+     See :mc-cmd:`mc replicate add --replicate` for more complete
      documentation. Omit these fields to disable replication of delete operations
      or replication of existing objects respectively.
 
@@ -491,7 +491,7 @@ B\) Create Replication Rule on Baker
      - :ref:`Replication of Deletes <minio-replication-behavior-delete>` 
      - :ref:`Replication of existing Objects <minio-replication-behavior-existing-objects>`
       
-     See :mc-cmd-option:`mc replicate add replicate` for more complete
+     See :mc-cmd:`mc replicate add --replicate` for more complete
      documentation. Omit these fields to disable replication of delete operations
      or replication fof existing objects respectively.
 
@@ -530,5 +530,5 @@ Use :mc-cmd:`mc ls` to verify the object exists on the destination bucket:
    mc ls Alpha/DESTINATIONBUCKET
 
 If the remote target was configured *without* the 
-:mc-cmd-option:`~mc admin bucket remote add sync` option, the destination
+:mc-cmd:`~mc admin bucket remote add sync` option, the destination
 bucket may have some delay before it receives the new object.

--- a/source/replication/replication-overview.rst
+++ b/source/replication/replication-overview.rst
@@ -111,7 +111,7 @@ replication uses the same :ref:`replication process <minio-replication-process>`
 as all other replication operations. 
 
 MinIO requires explicitly enabling versioned deletes and delete marker
-replication . Use the :mc-cmd-option:`mc replicate add replicate` field to
+replication . Use the :mc-cmd:`mc replicate add --replicate` field to
 specify both or either ``delete`` and ``delete-marker`` to enable versioned
 deletes and delete marker replication respectively. To enable both, specify both
 strings using a comma separator ``delete,delete-marker``.
@@ -194,11 +194,11 @@ replication. You can enable existing object replication while configuring
 or modifying a replication rule:
 
 - For new replication rules, include ``"existing-objects"`` to the list of
-  replication features specified to :mc-cmd-option:`mc replicate add replicate`.
+  replication features specified to :mc-cmd:`mc replicate add --replicate`.
 
 - For existing replication rules, add ``"existing-objects"`` to the list of
   existing replication features using 
-  :mc-cmd-option:`mc replicate edit replicate`. You must specify *all* desired
+  :mc-cmd:`mc replicate edit --replicate`. You must specify *all* desired
   replication features when editing the replication rule. 
 
 Enabling existing object replication does not increase the priority of objects
@@ -242,7 +242,7 @@ it may also increase the time of each write operation due to replication load.
 
 You must explicitly enable synchronous replication when configuring the remote
 target target using the :mc-cmd:`mc admin bucket remote add` command with the
-:mc-cmd-option:`~mc admin bucket remote add sync` flag.
+:mc-cmd:`~mc admin bucket remote add sync` flag.
 
 Replication Internals
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/security/ad-ldap-external-identity-management/configure-ad-ldap-external-identity-management.rst
+++ b/source/security/ad-ldap-external-identity-management/configure-ad-ldap-external-identity-management.rst
@@ -169,7 +169,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 3) Use the MinIO Console to Log In with AD/LDAP Credentials

--- a/source/security/network-encryption/minio-tls.rst
+++ b/source/security/network-encryption/minio-tls.rst
@@ -40,7 +40,7 @@ appropriate TLS certificate for that hostname.
 
 MinIO by default searches an OS-specific directory for TLS keys and
 certificates. For deployments started with a custom TLS directory
-:mc-cmd-option:`minio server certs-dir`, use that directory instead of the
+:mc-cmd:`minio server certs-dir`, use that directory instead of the
 defaults.
 
 .. tab-set::
@@ -234,7 +234,7 @@ necessary CA key for MinIO to explicitly trust:
 
 MinIO by default searches an OS-specific directory for Certificate Authority
 certificates. For deployments started with a custom TLS directory
-:mc-cmd-option:`minio server certs-dir`, use that directory instead of the
+:mc-cmd:`minio server certs-dir`, use that directory instead of the
 defaults.
 
 .. tab-set::

--- a/source/security/openid-external-identity-management/configure-openid-external-identity-management.rst
+++ b/source/security/openid-external-identity-management/configure-openid-external-identity-management.rst
@@ -160,7 +160,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 3) Use the MinIO Console to Log In with OIDC Credentials

--- a/source/security/server-side-encryption/server-side-encryption-sse-kms.rst
+++ b/source/security/server-side-encryption/server-side-encryption-sse-kms.rst
@@ -213,7 +213,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 4) Configure Automatic Bucket Encryption

--- a/source/security/server-side-encryption/server-side-encryption-sse-s3.rst
+++ b/source/security/server-side-encryption/server-side-encryption-sse-s3.rst
@@ -209,7 +209,7 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :mc:`alias <mc-alias>` of the deployment to 
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
 restart.
 
 4) Configure Automatic Bucket Encryption

--- a/sphinxext/minio.py
+++ b/sphinxext/minio.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Iterator, List, Tuple
 from typing import cast
 
 from docutils import nodes
-from docutils.nodes import Element, Node
+from docutils.nodes import Element, Node, Text, emphasis
 from docutils.parsers.rst import directives
 
 from sphinx import addnodes
@@ -53,7 +53,7 @@ class MinioMCCommand(SphinxDirective):
 
    has_content = False
    required_arguments = 1
-   optional_arguments = 1 #for mc admin?
+   optional_arguments = 0 #for mc admin?
    final_argument_whitespace = True
    option_spec = {
       'noindex': directives.flag # in case we do not want to create an index entry. 
@@ -61,20 +61,17 @@ class MinioMCCommand(SphinxDirective):
 
    def run(self) -> List[Node]:
       command = self.arguments[0].strip()
-      if (len(self.arguments) > 1):
-         command += "-" + self.arguments[1].strip().replace(" ","-")
-      
       self.env.ref_context['minio:mc'] = command
       noindex = 'noindex' in self.options
       ret = []
       if not noindex:
          domain = cast(MinIODomain, self.env.get_domain('minio'))
 
-         node_id = make_id(self.env, self.state.document, 'command', command)
-         domain.note_module(command, node_id)
+         node_id = make_id(self.env, self.state.document, 'command', command.replace(" ","."))
+         domain.note_module(command.replace(" ","."), node_id)
          # Make a duplicate entry in 'objects' to facilitate searching for
          # the module in JavaScriptDomain.find_obj()
-         domain.note_object(command, 'mc', node_id,
+         domain.note_object(command.replace(" ","."), 'mc', node_id,
                               location=(self.env.docname, self.lineno))
 
          target = nodes.target('', '', ids=[node_id], ismod=True)
@@ -101,8 +98,10 @@ class MinioMCObject(ObjectDescription):
        'noindex': directives.flag,
        'noindexentry': directives.flag,
        'fullpath': directives.flag,
-       'option': directives.flag,
+       'optional': directives.flag,
+       'required': directives.flag,
        'notext': directives.flag,
+       'alias': directives.unchanged,
     }
 
     def handle_signature(self, sig: str, signode: desc_signature) -> Tuple[str, str]:
@@ -118,58 +117,47 @@ class MinioMCObject(ObjectDescription):
            member, alias = sig.split(',', 1)
            member = member.strip()
            alias = alias.strip()
-        elif ' ' in sig:
-           # For subcommands with spaces
-           # Need to find a better way of specifying aliases, this is very hacky
-           member = sig.replace(' ', '-')
-           alias = None
         else:
             member = sig
             alias = None
-        # If construct is nested, prefix the current prefix
+        # If construct is nested, prefix the current parent
         prefix = self.env.ref_context.get('minio:object', None)
 
+
+        # Using this while transitioning away from comma-based argument list
+        if ('alias' in self.options):
+            alias = self.options.get('alias')
+
         #Grab the top-level command name.
-        command_name = self.env.ref_context.get('minio:mc').replace("-"," ")
+        command_name = self.env.ref_context.get('minio:mc', None)
         name = member
-        format_name = member
-        format_alias = alias
         if prefix:
-            fullname = '-'.join([prefix, name])
+            fullname = '.'.join([prefix, name])
         else:
             fullname = name
 
-        if 'option' in self.options:
-           format_name = "--" + name
-        
-        if 'option' in self.options and alias != None:
-           format_alias = "--" + alias
+        #print("Signature: " + " | command: " + str(command_name) + " | object: " + str(prefix) + " | name: " + str(fullname))
 
 
         signode['command'] = command_name
         signode['object'] = prefix
         signode['fullname'] = fullname
 
-        if prefix:
-           signode += addnodes.desc_addname(prefix + '-', ' ')
-        elif command_name and ('fullpath' in self.options):
-           signode += addnodes.desc_addname(command_name + '-', command_name + ' ')
-        elif command_name:
-           signode += addnodes.desc_addname(command_name + '-', ' ')
-        
-        if (alias != None):
-           signode += addnodes.desc_name(name + ', ' + alias, format_name + ', ' + format_alias)
-        elif 'notext' in self.options:
-           signode += addnodes.desc_name(name, '')
+        signode += addnodes.desc_addname(str(prefix) + "." + command_name + ".")
+
+        if (alias):
+            signode += addnodes.desc_name(name + ", " + alias, name + ", " + alias)
         else:
-           signode += addnodes.desc_name(name, format_name)
-        
+            signode += addnodes.desc_name(name,name)
+
+       
         return fullname, prefix
 
     def add_target_and_index(self, name_obj: Tuple[str, str], sig: str,
                              signode: desc_signature) -> None:
-        mod_name = self.env.ref_context.get('minio:mc')
-        fullname = (mod_name + '-' if mod_name else '') + name_obj[0]
+        mod_name = self.env.ref_context.get('minio:mc').replace(" ", ".")
+        #print("Linking: " + "| modname: " + str(mod_name) + " | name_obj0: " + str(name_obj[0]) + " | name_obj1: " + str(name_obj[1]))
+        fullname = (mod_name + '.' if mod_name else '') + name_obj[0]
         node_id = make_id(self.env, self.state.document, '', fullname)
         signode['ids'].append(node_id)
 
@@ -228,6 +216,13 @@ class MinioMCObject(ObjectDescription):
             if self.allow_nesting:
                 objects = self.env.ref_context.setdefault('minio:objects', [])
                 objects.append(prefix)
+
+    def transform_content(self, contentnode: addnodes.desc_content) -> None:
+        if ('optional' in self.options):
+            contentnode.children = [emphasis(None,Text("Optional"))] + contentnode.children
+        elif ('required' in self.options):
+            contentnode.children = [emphasis(None,Text("Required"))] + contentnode.children
+        pass
 
     def after_content(self) -> None:
         """Handle object de-nesting after content
@@ -415,33 +410,6 @@ class MinioObject(ObjectDescription):
         """
         return fullname.replace('$', '_S_')
 
-class MinioCMDOptionXRefRole(XRefRole):
-    def process_link(self, env: BuildEnvironment, refnode: Element,
-                     has_explicit_title: bool, title: str, target: str) -> Tuple[str, str]:
-        # basically what sphinx.domains.python.PyXRefRole does
-        refnode['minio:object'] = env.ref_context.get('minio:object')
-        refnode['minio:module'] = env.ref_context.get('minio:module')
-        refnode['minio:mc'] = env.ref_context.get('minio:mc')
-        if not has_explicit_title:
-            title = title.lstrip('.')
-            target = target.lstrip('~')
-            if title[0:1] == '~':
-                title = title[1:]
-                # Handle stripping lead path from commands.
-                space = title.rfind(' ')
-                if space != -1:
-                   title = title[space + 1:]
-                title = "--" + title
-            else:
-               #full command, so need to insert the `--`
-               title = title[:title.rfind(" ")] + " --" + title[title.rfind(" ")+1:]
-        if target[0:1] == '.':
-            target = target[1:]
-            refnode['refspecific'] = True
-        target = target.replace(" ","-")
-
-        return title, target
-
 class MinioXRefRole(XRefRole):
     def process_link(self, env: BuildEnvironment, refnode: Element,
                      has_explicit_title: bool, title: str, target: str) -> Tuple[str, str]:
@@ -467,8 +435,8 @@ class MinioXRefRole(XRefRole):
             target = target[1:]
             refnode['refspecific'] = True
 
-        if (self.reftype == "mc" or self.reftype == "mc-cmd" or self.reftype == "mc-cmd-option"):
-          target = target.replace(" ","-")
+        if (self.reftype == "mc" or self.reftype == "mc-cmd"):
+          target = target.replace(" ",".")
           return title, target
         
         target = self.reftype + "." + target
@@ -513,7 +481,6 @@ class MinIODomain(Domain):
         'flag':             MinioXRefRole(),
         'mc':               MinioXRefRole(),
         'mc-cmd':           MinioXRefRole(),
-        'mc-cmd-option':    MinioCMDOptionXRefRole(),
         'policy-action':    MinioXRefRole(),
         'envvar':           MinioXRefRole(),
         'mc-conf':          MinioXRefRole(),


### PR DESCRIPTION
# Summary

The original minio.py extension was pretty hacky and made a lot of assumptions on structure.

As we progress on a unified multi-platform repo, those assumptions go away. There's a lot of restructuring to do here and general clean-ups as well.

This is required to merge *before* the multi-platform work, as it should resolve some linking errors produced by intersphinx from detaching the client-SDK docs.

Do not merge yet - needs further review and testing.

# Goals

- [x] - Remove cruft from minio.py that is no longer necessary
- [x] - Update all mc refs to use new linking structure

# Non-Goals
- [ ] - Redo mc admin syntax (To do later)
