### PR TITLE
Remove incorrect references to downtime on restart

### DIFF
--- a/source/includes/common-admonitions.rst
+++ b/source/includes/common-admonitions.rst
@@ -1,23 +1,6 @@
 .. Used in the following pages:
    - /monitoring/bucket-notifications/publish-events-to-amqp.rst
 
-.. start-restart-downtime
-
-.. important::
-
-   This procedure *requires* restarting all :mc:`minio server` processes
-   associated to the deployment at the same time. There is typically a brief
-   period of time during which API operations are interrupted or may fail.
-
-   Applications using an S3-compatible SDK with built-in retry logic *or* which
-   implement manual retry logic typically experience no notable interruption in
-   services. For applications which cannot use retry-logic, consider scheduling
-   a maintenance period to minimize interruption of services while performing
-   this procedure.
-
-.. end-restart-downtime
-
-
 .. Used in the following pages:
 
    /reference/minio-cli/minio-mc/mc-rm.rst

--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -49,6 +49,57 @@ recommends using RPM or DEB installation routes.
 
 .. end-install-minio-binary-desc
 
+.. start-upgrade-minio-binary-desc
+
+The following tabs provide examples of updating MinIO onto 64-bit Linux
+operating systems using RPM, DEB, or binary:
+
+.. tab-set::
+
+   .. tab-item:: RPM (RHEL)
+      :sync: rpm
+
+      Use the following commands to download the latest stable MinIO RPM and
+      update the existing installation.
+
+      .. code-block:: shell
+         :class: copyable
+         :substitutions:
+
+         wget |minio-rpm| -O minio.deb
+         sudo dnf update minio.rpm
+
+   .. tab-item:: DEB (Debian/Ubuntu)
+      :sync: deb
+
+      Use the following commands to download the latest stable MinIO DEB and
+      upgrade the existing installation:
+
+      .. code-block:: shell
+         :class: copyable
+         :substitutions:
+
+         wget |minio-deb| -O minio.deb
+         sudo dpkg -i minio.deb
+
+   .. tab-item:: Binary
+      :sync: binary
+
+      Use the following commands to download the latest stable MinIO binary and
+      overwrite the existing binary:
+
+      .. code-block:: shell
+         :class: copyable
+
+         wget https://dl.min.io/server/minio/release/linux-amd64/minio
+         chmod +x minio
+         sudo mv minio /usr/local/bin/
+
+      Replace ``/usr/local/bin`` with the location of the existing MinIO
+      binary. Run ``which minio`` to identify the path if not already known.
+
+.. end-upgrade-minio-binary-desc
+
 .. start-install-minio-tls-desc
 
 MinIO enables :ref:`Transport Layer Security (TLS) <minio-tls>` 1.2+ 
@@ -174,6 +225,27 @@ transient and should resolve as the deployment comes online.
 
 .. end-install-minio-start-service-desc
 
+.. start-install-minio-restart-service-desc
+
+.. code-block:: shell
+   :class: copyable
+
+   sudo systemctl restart minio.service
+
+Use the following commands to confirm the service is online and functional:
+
+.. code-block:: shell
+   :class: copyable
+
+   sudo systemctl status minio.service
+   journalctl -f -u minio.service
+
+MinIO may log an increased number of non-critical warnings while the 
+server processes connect and synchronize. These warnings are typically 
+transient and should resolve as the deployment comes online.
+
+.. end-install-minio-restart-service-desc
+
 .. start-install-minio-console-desc
 
 Open your browser and access any of the MinIO hostnames at port ``:9001`` to
@@ -250,3 +322,13 @@ data to a new mount position, whether intentional or as the result of OS-level
 behavior.
 
 .. end-local-jbod-desc
+
+.. start-nondisruptive-upgrade-desc
+
+MinIO strongly recommends restarting all nodes simultaneously. MinIO operations
+are atomic and strictly consistent. As such the restart procedure is
+non-disruptive to applications and ongoing operations.
+
+Do **not** perform "rolling" (e.g. one node at a time) restarts.
+
+.. end-nondisruptive-upgrade-desc

--- a/source/installation/decommission-pool.rst
+++ b/source/installation/decommission-pool.rst
@@ -152,14 +152,15 @@ resumes only after you manually re-initiate the decommissioning operation.
 The pool remains in the decommissioning state *regardless* of the interruption.
 A pool can *never* return to active status after decommissioning begins.
 
-Decommissioning Requires Downtime
+Decommissioning is Non-Disruptive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Removing a decommissioned server pool requires restarting *all* MinIO
-nodes in the deployment at around the same time. This results in a 
-brief period of downtime. S3 SDKs typically include retry logic, such that
-application impact should be minimal. You can plan for a maintenance period
-during which you perform this procedure to provide additional buffer.
+nodes in the deployment at around the same time.
+
+.. include:: /includes/common-installation.rst
+   :start-after: start-nondisruptive-upgrade-desc
+   :end-before: end-nondisruptive-upgrade-desc
 
 .. _minio-decommissioning-server-pool:
 
@@ -328,25 +329,16 @@ out of scope for this procedure.
 6) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Stop the MinIO server nodes in the decommissioned pool at the same time.
+Issue the following commands on each node **simultaneously** in the deployment
+to restart the MinIO service:
 
-.. code-block:: shell
-   :class: copyable
+.. include:: /includes/common-installation.rst
+   :start-after: start-install-minio-restart-service-desc
+   :end-before: end-install-minio-restart-service-desc
 
-   sudo systemctl stop minio
-
-Restart the remaining MinIO server nodes in the deployment at the same time:
-
-.. code-block:: shell
-   :class: copyable
-
-   sudo systemctl restart minio
-
-The :mc-cmd:`mc admin service restart` command does not reload variables
-from the environment file and is insufficient for this step.
-
-Use ``systemctl status``, ``journalctl -f -u minio``, and 
-:mc-cmd:`mc admin console` to monitor the deployment startup.
+.. include:: /includes/common-installation.rst
+   :start-after: start-nondisruptive-upgrade-desc
+   :end-before: end-nondisruptive-upgrade-desc
 
 Once the deployment is online, use :mc-cmd:`mc admin info` to confirm the
 uptime of all remaining servers in the deployment.

--- a/source/installation/expand-minio-distributed.rst
+++ b/source/installation/expand-minio-distributed.rst
@@ -157,14 +157,15 @@ for simplified cluster management and more predictable performance across pools.
 See :ref:`deploy-minio-distributed-recommendations` for more guidance on
 selecting hardware for MinIO deployments.
 
-Expansion Requires Downtime
+Expansion is Non-Disruptive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Adding a new server pool requires restarting *all* MinIO nodes in the
-deployment at around same time. This results in a brief period of downtime.
-S3 SDKs typically include retry logic, such that application impact should be
-minimal. You can plan for a maintenance period during which you perform this
-procedure to provide additional buffer 
+deployment at around same time. 
+
+.. include:: /includes/common-installation.rst
+   :start-after: start-nondisruptive-upgrade-desc
+   :end-before: end-nondisruptive-upgrade-desc
 
 Capacity-Based Planning
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -353,44 +354,21 @@ You may specify other :ref:`environment variables
 by your deployment. All MinIO nodes in the deployment should include the same
 environment variables with the matching values.
 
-5) Stop the MinIO Deployment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. important::
-
-   This step *requires* stopping the MinIO deployment and results in
-   immediate downtime of the object storage API. This downtime period is
-   typically as short as necessary for running terminal commands on multiple
-   hosts simultaneously.
-
-   Applications using standard S3 SDKs (e.g. from AWS or MinIO) retry operations
-   automatically, such that downtime is typically not observed from the
-   application side. Planning expansion procedures during a maintenance or
-   low-traffic period may mitigate any potential delay or interruption of
-   services.
-
-MinIO does **not** support rolling restarts and requires stopping
-and starting the entire deployment at once.
-
-Issue the following command on each host machine running a MinIO server in the
-deployment:
-
-.. code-block:: shell
-   :class: copyable
-
-   sudo systemctl stop minio.service
-
-6) Restart the MinIO Deployment with Expanded Configuration
+5) Restart the MinIO Deployment with Expanded Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Issue the following commands on each node in the deployment to start the
-MinIO service:
+Issue the following commands on each node **simultaneously** in the deployment
+to restart the MinIO service:
 
 .. include:: /includes/common-installation.rst
-   :start-after: start-install-minio-start-service-desc
-   :end-before: end-install-minio-start-service-desc
+   :start-after: start-install-minio-restart-service-desc
+   :end-before: end-install-minio-restart-service-desc
 
-7) Next Steps
+.. include:: /includes/common-installation.rst
+   :start-after: start-nondisruptive-upgrade-desc
+   :end-before: end-nondisruptive-upgrade-desc
+
+6) Next Steps
 ~~~~~~~~~~~~~
 
 - Update any load balancers, reverse proxies, or other network control planes

--- a/source/installation/upgrade-minio.rst
+++ b/source/installation/upgrade-minio.rst
@@ -27,30 +27,98 @@ Upgrade a MinIO Deployment
    `MinIO SUBNET <https://min.io/pricing?ref=docs>`__ for additional support
    and guidance during the upgrade procedure.
 
-Use the :mc-cmd:`mc admin update` command to update a :ref:`Standalone
-<deploy-minio-standalone>` or :ref:`Distributed <deploy-minio-distributed>`
-MinIO deployment to the latest stable :minio-git:`release <minio/releases>`.
+Upgrade Checklist
+-----------------
+
+Review all items on the following checklist before performing an upgrade on
+your MinIO deployments:
+
+.. list-table::
+   :stub-columns: 1
+   :widths: 25 75
+   :width: 100%
+
+   * - Test in Lower Environments
+     - Test all upgrades in a lower environment such as a dedicated 
+       testing, development, or QA deployment.
+
+       **Never** perform blind upgrades on production deployments.
+
+   * - Upgrade Only When Necessary
+     - MinIO follows a rapid development model where there may be multiple
+       releases in a week. There is no requirement to follow these updates
+       if your deployment is otherwise stable and functional.
+
+       Upgrade only if there is a specific feature, bug fix, or other
+       requirement necessary for your workload. Review the 
+       :minio-git:`Release Notes <minio/releases>` for each Server release
+       between your current MinIO version and the target version.
+
+   * - Upgrades require Simultaneous Restart 
+     - Ensure your preferred method of node management supports operating on 
+       all nodes simultaneously.
+     
+       .. include:: /includes/common-installation.rst
+          :start-after: start-nondisruptive-upgrade-desc
+          :end-before: end-nondisruptive-upgrade-desc
+
+.. _minio-upgrade-systemctl:
+
+Update ``systemctl``-Managed MinIO Deployments
+----------------------------------------------
+
+Deployments managed using ``systemctl``, such as those created
+using the MinIO :ref:`DEB/RPM packages <deploy-minio-distributed-baremetal>`,
+require manual update and simultaneous restart of all nodes in the
+MinIO deployment.
+
+1. **Update the MinIO Binary on Each Node**
+
+   .. include:: /includes/common-installation.rst
+      :start-after: start-upgrade-minio-binary-desc
+      :end-before: end-upgrade-minio-binary-desc
+
+2. **Restart the Deployment**
+
+   Run ``systemctl restart minio`` simultaneously across all nodes in the
+   deployment. Utilize your preferred method for coordinated execution of
+   terminal/shell commands.
+
+   .. include:: /includes/common-installation.rst
+      :start-after: start-nondisruptive-upgrade-desc
+      :end-before: end-nondisruptive-upgrade-desc
+
+.. _minio-upgrade-mc-admin-update:
+
+Update MinIO Deployments using ``mc admin update``
+--------------------------------------------------
+
+.. include:: /includes/common-installation.rst
+   :start-after: start-nondisruptive-upgrade-desc
+   :end-before: end-nondisruptive-upgrade-desc
+
+The :mc-cmd:`mc admin update` command updates all MinIO server binaries in 
+the target MinIO deployment before restarting all nodes simultaneously.
+
+:mc-cmd:`mc admin update` is intended for baremetal (non-orchestrated)
+deployments using manual management of server binaries.
+
+- For deployments managed using ``systemctl``, see
+  :ref:`minio-upgrade-systemctl`.
+
+- For Kubernetes or other containerized environments, defer to the native 
+  mechanisms for updating container images across a deployment.
+
+:mc-cmd:`mc admin update` requires write access to the directory in which
+the MinIO binary is saved (e.g. ``/usr/local/bin``).
+
+The following command updates a MinIO deployment with the specified
+:ref:`alias <alias>` to the latest stable release:
 
 .. code-block:: shell
    :class: copyable
 
    mc admin update ALIAS
-
-Replace :mc-cmd:`ALIAS <mc admin update ALIAS>` with the
-:mc-cmd:`alias <mc alias>` of the MinIO deployment.
-
-:mc-cmd:`mc admin update` affects *all* MinIO servers in the target deployment
-at the same time. The update procedure interrupts in-progress API operations on
-the MinIO deployment. Exercise caution before issuing an update command on
-production environments.
-
-You can specify a custom URL for updating the MinIO deployment using a specific
-MinIO server binary:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc admin update ALIAS https://minio-mirror.example.com/minio
 
 You should upgrade your :mc:`mc` binary to match or closely follow the
 MinIO server release. You can use the :mc:`mc update` command to update the
@@ -60,3 +128,60 @@ binary to the latest stable release:
    :class: copyable
 
    mc update
+
+You can specify a URL resolving to a specific MinIO server binary version.
+Airgapped or internet-isolated deployments may utilize this feature for updating
+from an internally-accessible server:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin update ALIAS https://minio-mirror.example.com/minio
+
+Update MinIO Manually
+---------------------
+
+The following steps manually download the MinIO binary and restart the
+deployment. These steps are intended for fully manual baremetal deployments
+without ``systemctl`` or similar process management. These steps may also
+apply to airgapped or similarly internet-isolated deployments which 
+cannot use :mc-cmd:`mc admin update` to retrieve the binary over the network.
+
+1. **Add the MinIO Binary to each node in the deployment**
+
+   Follow your organizations preferred procedure for adding a new binary
+   to the node. The following command downloads the latest stable MinIO
+   binary:
+
+   .. code-block:: shell
+      :class: copyable
+
+      wget https://dl.min.io/server/minio/release/linux-amd64/minio
+
+2. **Overwrite the existing MinIO binary with the newer version**
+
+   The following command sets the binary to executable and copies it to
+   ``/usr/local/bin``. Replace this path with the location of the existing
+   MinIO binary:
+
+   .. code-block:: shell
+      :class: copyable
+
+      chmod +x minio
+      sudo mv minio /usr/local/bin/
+   
+3. **Restart the deployment**
+
+   Once all nodes have the updated binary, restart all nodes simultaneously
+   using the :mc-cmd:`mc admin service` command:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc admin service ALIAS
+
+   Replace ``ALIAS`` with the :ref:`alias <alias>` for the target deployment.
+
+   .. include:: /includes/common-installation.rst
+      :start-after: start-nondisruptive-upgrade-desc
+      :end-before: end-nondisruptive-upgrade-desc

--- a/source/monitoring/bucket-notifications/publish-events-to-amqp.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-amqp.rst
@@ -27,10 +27,6 @@ The following procedure adds a new AMQP service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~~
 
@@ -168,15 +164,6 @@ You can configure a new AMQP service endpoint using either environment variables
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -247,10 +234,6 @@ Update an AMQP Endpoint in a MinIO Deployment
 The following procedure updates an existing AMQP service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
-
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
 
 Prerequisites
 ~~~~~~~~~~~~~~
@@ -338,15 +321,6 @@ for a complete list of AMQP configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-elasticsearch.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-elasticsearch.rst
@@ -25,10 +25,6 @@ The following procedure adds a new Elasticsearch service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -159,15 +155,6 @@ You can configure a new Elasticsearch service endpoint using either environment 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -236,10 +223,6 @@ Update an Elasticsearch Endpoint in a MinIO Deployment
 The following procedure updates an existing Elasticsearch service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
-
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
 
 Prerequisites
 ~~~~~~~~~~~~~~
@@ -318,15 +301,6 @@ of Elasticsearch configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-kafka.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-kafka.rst
@@ -26,10 +26,6 @@ The following procedure adds a new Kafka service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -166,15 +162,6 @@ You can configure a new Kafka service endpoint using either environment variable
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -243,10 +230,6 @@ Update a Kafka Endpoint in a MinIO Deployment
 The following procedure updates an existing Kafka service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
-
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
 
 Prerequisites
 ~~~~~~~~~~~~~~
@@ -331,15 +314,6 @@ Kafka configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-mqtt.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-mqtt.rst
@@ -21,10 +21,6 @@ The following procedure adds a new MQTT service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~~
 
@@ -171,15 +167,6 @@ You can configure a new MQTT service endpoint using either environment variables
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -248,10 +235,6 @@ Update an MQTT Endpoint in a MinIO Deployment
 The following procedure updates an existing MQTT service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
-
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
 
 Prerequisites
 ~~~~~~~~~~~~~~
@@ -345,15 +328,6 @@ configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-mysql.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-mysql.rst
@@ -21,10 +21,6 @@ The following procedure adds a new MySQL service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -158,15 +154,6 @@ You can configure a new MySQL service endpoint using either environment variable
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -235,10 +222,6 @@ Update a MySQL Endpoint in a MinIO Deployment
 The following procedure updates an existing MySQL service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
-
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
 
 Prerequisites
 ~~~~~~~~~~~~~~
@@ -318,15 +301,6 @@ MySQL configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-nats.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-nats.rst
@@ -21,10 +21,6 @@ The following procedure adds a new NATS service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -158,15 +154,6 @@ You can configure a new NATS service endpoint using either environment variables
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -235,10 +222,6 @@ Update an NATS Endpoint in a MinIO Deployment
 The following procedure updates an existing NATS service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
-
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
 
 Prerequisites
 ~~~~~~~~~~~~~~
@@ -318,15 +301,6 @@ for a complete list of NATS configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-nsq.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-nsq.rst
@@ -21,10 +21,6 @@ The following procedure adds a new NSQ service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -139,15 +135,6 @@ You can configure a new NSQ service endpoint using either environment variables
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -217,10 +204,6 @@ The following procedure updates an existing NSQ service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~~
 
@@ -289,15 +272,6 @@ configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-postgresql.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-postgresql.rst
@@ -24,10 +24,6 @@ The following procedure adds a new PostgreSQL service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -161,15 +157,6 @@ variables *or* by setting runtime configuration settings.
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -238,10 +225,6 @@ Update a PostgreSQL Endpoint in a MinIO Deployment
 The following procedure updates an existing PostgreSQL service endpoint for
 supporting :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
-
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -323,15 +306,6 @@ PostgreSQL configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-redis.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-redis.rst
@@ -21,10 +21,6 @@ The following procedure adds a new Redis service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -141,15 +137,6 @@ You can configure a new Redis service endpoint using either environment variable
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -219,10 +206,6 @@ The following procedure updates an existing Redis service endpoint for
 supporting :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~~
 
@@ -291,15 +274,6 @@ Redis configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-webhook.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-webhook.rst
@@ -21,10 +21,6 @@ The following procedure adds a new Webhook service endpoint for supporting
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~
 
@@ -139,15 +135,6 @@ variables *or* by setting runtime configuration settings.
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 
@@ -217,10 +204,6 @@ The following procedure updates an existing Webhook service endpoint for support
 :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
 deployment.
 
-.. include:: /includes/common-admonitions.rst
-   :start-after: start-restart-downtime
-   :end-before: end-restart-downtime
-
 Prerequisites
 ~~~~~~~~~~~~~~
 
@@ -289,15 +272,6 @@ Webhook configuration settings.
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable

--- a/source/reference/minio-mc-admin/mc-admin-update.rst
+++ b/source/reference/minio-mc-admin/mc-admin-update.rst
@@ -21,17 +21,27 @@ environments where the deployment does not have public internet access.
 
 .. end-mc-admin-update-desc
 
-:mc-cmd:`mc admin update` affects *all* MinIO servers in the target deployment
-at the same time. The update procedure interrupts in-progress API operations on
-the MinIO deployment. Exercise caution before issuing an update command on
-production environments.
-
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only
    :class: note
 
    .. include:: /includes/facts-mc-admin.rst
       :start-after: start-minio-only
       :end-before: end-minio-only
+
+
+Considerations
+--------------
+
+Updates are Non-Disruptive
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:mc-cmd:`mc admin update` updates the binary and restarts all MinIO servers in
+the deployment simultaneously. MinIO operations are atomic and strictly
+consistent and as such the restart process is non-disruptive to applications.
+
+MinIO strongly recommends only performing simultaneous upgrade-and-restart
+procedures. Do not perform "rolling" (e.g one node at a time) upgrade 
+procedures.
 
 Examples
 --------
@@ -65,8 +75,7 @@ Syntax
 
    If the specified ``ALIAS`` corresponds to a distributed MinIO
    deployment, :mc-cmd:`mc admin update` updates *all* MinIO servers
-   in the deployment at the same time. The command does not perform a 
-   rolling upgrade or similar zero or near-zero downtime upgrade procedure.
+   in the deployment at the same time. 
 
    Use :mc-cmd:`mc alias list` to review the configured aliases and their
    corresponding MinIO deployment endpoints.

--- a/source/security/ad-ldap-external-identity-management/configure-ad-ldap-external-identity-management.rst
+++ b/source/security/ad-ldap-external-identity-management/configure-ad-ldap-external-identity-management.rst
@@ -155,15 +155,6 @@ environment variables and configuration settings respectively:
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 

--- a/source/security/openid-external-identity-management/configure-openid-external-identity-management.rst
+++ b/source/security/openid-external-identity-management/configure-openid-external-identity-management.rst
@@ -146,15 +146,6 @@ environment variables and configuration settings respectively:
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 

--- a/source/security/server-side-encryption/server-side-encryption-sse-kms.rst
+++ b/source/security/server-side-encryption/server-side-encryption-sse-kms.rst
@@ -199,15 +199,6 @@ MinIO server host in the deployment:
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
-
 .. code-block:: shell
    :class: copyable
 

--- a/source/security/server-side-encryption/server-side-encryption-sse-s3.rst
+++ b/source/security/server-side-encryption/server-side-encryption-sse-s3.rst
@@ -189,20 +189,11 @@ MinIO server host in the deployment:
        the configured Key Management System (KMS). Specify the name of the
        key created in the previous step. 
 
-1) Restart the MinIO Deployment to Enable SSE-S3
+3) Restart the MinIO Deployment to Enable SSE-S3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 
 Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
-
-.. important::
-
-   MinIO restarts *all* :mc:`minio server` processes associated to the 
-   deployment at the same time. Applications may experience a brief period of 
-   downtime during the restart process. 
-
-   Consider scheduling the restart during a maintenance period to minimize
-   interruption of services.
 
 .. code-block:: shell
    :class: copyable


### PR DESCRIPTION
# Summary

When  I first wrote these docs I made some assumptions around the consequences of a restart.

After discussion with engineering, these sections are largely incorrect or misleading.

MinIO restarts are very fast - a few seconds long at most even for large clusters. Operations are atomic and strictly consistent. And S3 SDKs typically retry transparently. This means applications should not be aware at all of a restart assuming the admin is following best practices - namely simultaneous restart of all nodes/processes, *no rolling restarts*

# Goals

- [] Better describe how restarts effect ongoing operations
- [] Remove incorrect warnings around downtime
- [] Create checklist for upgrades to better frame the optimal setup

# Build Instructions

Create a Python `venv` using 3.9 + and activate it

Run `make stage`

```
python -m venv venv
source venv bin activate
pip install -r requirements.txt
make stage
```