### PR TITLE
#346 Adding info for parsing JSON for srsARN value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ main.min.css
 main.css
 objects.inv
 output.log
+.DS_Store

--- a/source/includes/common-bucket-notifications.rst
+++ b/source/includes/common-bucket-notifications.rst
@@ -1,0 +1,36 @@
+.. start-bucket-notification-find-arn
+
+.. admonition:: Identifying the ARN for your bucket notifications
+   :class: note
+
+   You defined the ``<IDENTIFIER>`` to assign to the target ARN for your bucket notifications when creating the endpoint previously.
+   The steps below return the ARNs configured on the deployment.
+   Identify the ARN created previously by looking for the ``<IDENTIFIER>`` you specified.
+   
+   **Review the JSON output**
+   
+   #. Copy and run the following command, replacing ``ALIAS`` with the :ref:`alias <alias>` of the deployment.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin info --json ALIAS
+
+   #. In the JSON output, look for the key ``info.sqsARN``.
+   
+      The ARN you need is the value of that key that matches the ``<IDENTIFIER>`` you specified.
+      
+      For example, |ARN|.
+   **Use jq to parse the JSON for the value**
+    
+   #. `Install jq <https://stedolan.github.io/jq/>`_
+   #. Copy and run the following command, replacing ``ALIAS`` with the :ref:`alias <alias>` of the deployment.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin info --json ALIAS | jq  .info.sqsARN
+
+      This returns the ARN to use for notifications, such as |ARN|
+
+.. end-bucket-notification-find-arn

--- a/source/monitoring/bucket-notifications/bucket-notifications.rst
+++ b/source/monitoring/bucket-notifications/bucket-notifications.rst
@@ -10,9 +10,8 @@ Bucket Notifications
    :local:
    :depth: 2
 
-MinIO bucket notifications allow administrators to send notifications to 
-supported external services on certain object or bucket events. MinIO 
-supports bucket and object-level S3 events similar to the 
+MinIO bucket notifications allow administrators to send notifications to supported external services on certain object or bucket events. 
+MinIO supports bucket and object-level S3 events similar to the 
 :s3-docs:`Amazon S3 Event Notifications <NotificationHowTo.html>`.
 
 Supported Notification Targets
@@ -35,8 +34,7 @@ MinIO supports publishing event notifications to the following targets:
        See :ref:`minio-bucket-notifications-publish-amqp` for a tutorial.
 
    * - :guilabel:`MQTT`
-     - Publish notifications to an `MQTT <https://www.mqtt.org/>`__  
-       service.
+     - Publish notifications to an `MQTT <https://www.mqtt.org/>`__ service.
 
        See :ref:`minio-bucket-notifications-publish-mqtt` for a tutorial.
 
@@ -50,13 +48,10 @@ MinIO supports publishing event notifications to the following targets:
 
        See :ref:`minio-bucket-notifications-publish-nsq` for a tutorial
 
-
    * - :guilabel:`Elasticsearch`
-     - Publish notifications to a `Elasticsearch <https://www.elastic.co/>`__ 
-       service.
+     - Publish notifications to a `Elasticsearch <https://www.elastic.co/>`__ service.
 
-       See :ref:`minio-bucket-notifications-publish-elasticsearch` for a
-       tutorial.
+       See :ref:`minio-bucket-notifications-publish-elasticsearch` for a tutorial.
 
    * - :guilabel:`Kafka`
      - Publish notifications to a `Kafka <https://kafka.apache.org/>`__ service.
@@ -69,8 +64,7 @@ MinIO supports publishing event notifications to the following targets:
        See :ref:`minio-bucket-notifications-publish-mysql` for a tutorial.
 
    * - :guilabel:`PostgreSQL`
-     - Publish notifications to a `PostgreSQL <https://www.postgresql.org/>`__
-       service.
+     - Publish notifications to a `PostgreSQL <https://www.postgresql.org/>`__ service.
 
        See :ref:`minio-bucket-notifications-publish-postgresql` for a tutorial.
 
@@ -91,9 +85,8 @@ MinIO supports publishing event notifications to the following targets:
 Supported S3 Event Types
 ------------------------
 
-MinIO bucket notifications are compatible with 
-:s3-docs:`Amazon S3 Event Notifications <NotificationHowTo.html>`. This 
-section lists all supported events.
+MinIO bucket notifications are compatible with :s3-docs:`Amazon S3 Event Notifications <NotificationHowTo.html>`. 
+This section lists all supported events.
 
 Object Events
 ~~~~~~~~~~~~~
@@ -132,8 +125,7 @@ Specify the wildcard ``*`` character to select all events related to a prefix:
 Replication Events
 ~~~~~~~~~~~~~~~~~~
 
-MinIO supports triggering notifications on the following S3 replication 
-events:
+MinIO supports triggering notifications on the following S3 replication events:
 
 .. data:: s3:Replication:OperationCompletedReplication
 .. data:: s3:Replication:OperationFailedReplication
@@ -148,8 +140,7 @@ Specify the wildcard ``*`` character to select all ``s3:Replication`` events:
 ILM Transition Events
 ~~~~~~~~~~~~~~~~~~~~~
 
-MinIO supports triggering notifications on the following S3 ILM transition
-events:
+MinIO supports triggering notifications on the following S3 ILM transition events:
 
 .. data:: s3:ObjectRestore:Post
 .. data:: s3:ObjectRestore:Completed
@@ -170,8 +161,7 @@ Global Events
 ~~~~~~~~~~~~~
 
 MinIO supports triggering notifications on the following global events. 
-You can only listen to these events through the :legacy:`ListenNotification 
-<golang-client-api-reference.html#ListenNotification>` API:
+You can only listen to these events through the :legacy:`ListenNotification <golang-client-api-reference.html#ListenNotification>` API:
 
 .. data:: s3:BucketCreated
 .. data:: s3:BucketRemoved

--- a/source/monitoring/bucket-notifications/publish-events-to-amqp.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-amqp.rst
@@ -6,6 +6,8 @@ Publish Events to AMQP (RabbitMQ)
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:amqp``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -182,6 +184,10 @@ target similar to the following:
 You must specify the ARN resource when configuring bucket notifications with
 the associated AMQP deployment as a target.
 
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
+
 3) Configure Bucket Notifications using the AMQP Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -337,7 +343,7 @@ target similar to the following:
 
    SQS ARNs: arn:minio:sqs::primary:amqp
 
-3) Validate the Changes
+4) Validate the Changes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Perform an action on a bucket which has an event configuration using the updated

--- a/source/monitoring/bucket-notifications/publish-events-to-elasticsearch.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-elasticsearch.rst
@@ -6,6 +6,8 @@ Publish Events to Elasticsearch
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:elasticsearch``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -173,6 +175,11 @@ target similar to the following:
 You must specify the ARN resource when configuring bucket notifications with
 the associated Elasticsearch deployment as a target.
 
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
+
+
 3) Configure Bucket Notifications using the Elasticsearch Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -197,7 +204,7 @@ a given notification target:
 .. code-block:: shell
    :class: copyable
 
-   mc event list ALIAS/BUCKET arn:minio:sqs::primary:Elasticsearch
+   mc event list ALIAS/BUCKET arn:minio:sqs::primary:elasticsearch
 
 4) Validate the Configured Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -317,7 +324,7 @@ Elasticsearch target similar to the following:
 
    SQS ARNs: arn:minio:sqs::primary:elasticsearch
 
-3) Validate the Changes
+4) Validate the Changes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Perform an action on a bucket which has an event configuration using the updated

--- a/source/monitoring/bucket-notifications/publish-events-to-kafka.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-kafka.rst
@@ -6,6 +6,8 @@ Publish Events to Kafka
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:kafka``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -179,6 +181,11 @@ Kafka target similar to the following:
 
 You must specify the ARN resource when configuring bucket notifications with
 the associated Kafka deployment as a target.
+
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
+
 
 3) Configure Bucket Notifications using the Kafka Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/monitoring/bucket-notifications/publish-events-to-mqtt.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-mqtt.rst
@@ -6,6 +6,8 @@ Publish Events to MQTT
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:mqtt``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -185,7 +187,11 @@ target similar to the following:
 You must specify the ARN resource when configuring bucket notifications with
 the associated MQTT deployment as a target.
 
-3) Configure Bucket Notifications using the MQTT Endpoint as a Target
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
+
+1) Configure Bucket Notifications using the MQTT Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use the :mc-cmd:`mc event add` command to add a new bucket notification 

--- a/source/monitoring/bucket-notifications/publish-events-to-mysql.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-mysql.rst
@@ -6,6 +6,8 @@ Publish Events to MySQL
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:mysql``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -172,6 +174,10 @@ target similar to the following:
 You must specify the ARN resource when configuring bucket notifications with
 the associated MySQL deployment as a target.
 
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
+
 3) Configure Bucket Notifications using the MySQL Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -317,7 +323,7 @@ target similar to the following:
 
    SQS ARNs: arn:minio:sqs::primary:mysql
 
-3) Validate the Changes
+4) Validate the Changes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Perform an action on a bucket which has an event configuration using the updated

--- a/source/monitoring/bucket-notifications/publish-events-to-nats.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-nats.rst
@@ -6,6 +6,8 @@ Publish Events to NATS
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:nats``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -171,6 +173,10 @@ target similar to the following:
 
 You must specify the ARN resource when configuring bucket notifications with
 the associated NATS deployment as a target.
+
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
 
 3) Configure Bucket Notifications using the NATS Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/monitoring/bucket-notifications/publish-events-to-nsq.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-nsq.rst
@@ -6,6 +6,8 @@ Publish Events to NSQ
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:nsq``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -148,16 +150,18 @@ target similar to the following:
 
 .. code-block:: shell
 
-   SQS ARNs: arn:minio:sqs::primary:nsq
+   SQS ARNs: |ARN|
 
-You must specify the ARN resource when configuring bucket notifications with
-the associated NSQ deployment as a target.
+You must specify the ARN resource when configuring bucket notifications with the associated NSQ deployment as a target.
+
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
 
 3) Configure Bucket Notifications using the NSQ Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc-cmd:`mc event add` command to add a new bucket notification 
-event with the configured NSQ service as a target:
+Use the :mc-cmd:`mc event add` command to add a new bucket notification event with the configured NSQ service as a target:
 
 .. code-block:: shell
    :class: copyable
@@ -166,13 +170,11 @@ event with the configured NSQ service as a target:
      --event EVENTS
 
 - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
-- Replace ``BUCKET`` with the name of the bucket in which to configure the 
-  event.
+- Replace ``BUCKET`` with the name of the bucket in which to configure the event.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
   <mc-event-supported-events>` for which MinIO triggers notifications.
 
-Use :mc-cmd:`mc event list` to view all configured bucket events for 
-a given notification target:
+Use :mc-cmd:`mc event list` to view all configured bucket events for a given notification target:
 
 .. code-block:: shell
    :class: copyable
@@ -182,15 +184,10 @@ a given notification target:
 4) Validate the Configured Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Perform an action on the bucket for which you configured the new event and 
-check the NSQ service for the notification data. The action required
-depends on which :mc-cmd:`events <mc event add --event>` were specified
-when configuring the bucket notification.
+Perform an action on the bucket for which you configured the new event and check the NSQ service for the notification data. 
+The action required depends on which :mc-cmd:`events <mc event add --event>` were specified when configuring the bucket notification.
 
-For example, if the bucket notification configuration includes the 
-``s3:ObjectCreated:Put`` event, you can use the 
-:mc-cmd:`mc cp` command to create a new object in the bucket and trigger 
-a notification.
+For example, if the bucket notification configuration includes the ``s3:ObjectCreated:Put`` event, you can use the :mc-cmd:`mc cp` command to create a new object in the bucket and trigger a notification.
 
 .. code-block:: shell
    :class: copyable
@@ -200,9 +197,7 @@ a notification.
 Update an NSQ Endpoint in a MinIO Deployment
 --------------------------------------------
 
-The following procedure updates an existing NSQ service endpoint for supporting
-:ref:`bucket notifications <minio-bucket-notifications>` in a MinIO
-deployment.
+The following procedure updates an existing NSQ service endpoint for supporting :ref:`bucket notifications <minio-bucket-notifications>` in a MinIO deployment.
 
 Prerequisites
 ~~~~~~~~~~~~~~
@@ -217,8 +212,7 @@ See the ``mc`` :ref:`Quickstart <mc-install>` for installation instructions.
 1) List Configured NSQ Endpoints In The Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc-cmd:`mc admin config get` command to list the currently
-configured NSQ service endpoints in the deployment:
+Use the :mc-cmd:`mc admin config get` command to list the currently configured NSQ service endpoints in the deployment:
 
 .. code-block:: shell
    :class: copyable
@@ -234,20 +228,16 @@ The command output resembles the following:
    notify_nsq:primary nsqd_address="https://nsq.example.com" queue_dir="" queue_limit="0"  tls="off" tls_skip_verify="off" topic=""
    notify_nsq:secondary nsqd_address="https://nsq.example.com" queue_dir="" queue_limit="0"  tls="off" tls_skip_verify="off" topic=""
 
-The :mc-conf:`notify_nsq` key is the top-level configuration key for an
-:ref:`minio-server-config-bucket-notification-nsq`. The :mc-conf:`nsqd_address
-<notify_nsq.nsqd_address>` key specifies the NSQ service endpoint for the given
-`notify_nsq` key. The ``notify_nsq:<IDENTIFIER>`` suffix describes the unique
-identifier for that NSQ service endpoint.
+The :mc-conf:`notify_nsq` key is the top-level configuration key for an :ref:`minio-server-config-bucket-notification-nsq`. 
+The :mc-conf:`nsqd_address <notify_nsq.nsqd_address>` key specifies the NSQ service endpoint for the given `notify_nsq` key. 
+The ``notify_nsq:<IDENTIFIER>`` suffix describes the unique identifier for that NSQ service endpoint.
 
-Note the identifier for the NSQ service endpoint you want to update for
-the next step. 
+Note the identifier for the NSQ service endpoint you want to update for the next step. 
 
 2) Update the NSQ Endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc-cmd:`mc admin config set` command to set the new configuration
-for the NSQ service endpoint:
+Use the :mc-cmd:`mc admin config set` command to set the new configuration for the NSQ service endpoint:
 
 .. code-block:: shell
    :class: copyable
@@ -261,11 +251,9 @@ for the NSQ service endpoint:
       queue_limit="<string>" \
       comment="<string>"
 
-The :mc-conf:`notify_nsq nsqd_address <notify_nsq.nsqd_address>` configuration
-setting is the *minimum* required for an NSQ service endpoint. All other
-configuration settings are *optional*. See
-:ref:`minio-server-config-bucket-notification-nsq` for a complete list of NSQ
-configuration settings.
+The :mc-conf:`notify_nsq nsqd_address <notify_nsq.nsqd_address>` configuration setting is the *minimum* required for an NSQ service endpoint. 
+All other configuration settings are *optional*. 
+See :ref:`minio-server-config-bucket-notification-nsq` for a complete list of NSQ configuration settings.
 
 3) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -278,28 +266,21 @@ Use the :mc-cmd:`mc admin service restart` command to restart the deployment.
 
    mc admin service restart ALIAS
 
-Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to 
-restart.
+Replace ``ALIAS`` with the :ref:`alias <alias>` of the deployment to restart.
 
-The :mc:`minio server` process prints a line on startup for each configured NSQ
-target similar to the following:
+The :mc:`minio server` process prints a line on startup for each configured NSQ target similar to the following:
 
 .. code-block:: shell
 
    SQS ARNs: arn:minio:sqs::primary:NSQ
 
-3) Validate the Changes
+4) Validate the Changes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Perform an action on a bucket which has an event configuration using the updated
-NSQ service endpoint and check the NSQ service for the notification data. The
-action required depends on which :mc-cmd:`events <mc event add --event>` were
-specified when configuring the bucket notification.
+Perform an action on a bucket which has an event configuration using the updated NSQ service endpoint and check the NSQ service for the notification data. 
+The action required depends on which :mc-cmd:`events <mc event add --event>` were specified when configuring the bucket notification.
 
-For example, if the bucket notification configuration includes the 
-``s3:ObjectCreated:Put`` event, you can use the 
-:mc-cmd:`mc cp` command to create a new object in the bucket and trigger 
-a notification.
+For example, if the bucket notification configuration includes the ``s3:ObjectCreated:Put`` event, you can use the :mc-cmd:`mc cp` command to create a new object in the bucket and trigger a notification.
 
 .. code-block:: shell
    :class: copyable

--- a/source/monitoring/bucket-notifications/publish-events-to-postgresql.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-postgresql.rst
@@ -6,6 +6,8 @@ Publish Events to PostgreSQL
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:postgresql``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -175,6 +177,10 @@ target similar to the following:
 You must specify the ARN resource when configuring bucket notifications with
 the associated PostgreSQL deployment as a target.
 
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
+
 3) Configure Bucket Notifications using the PostgreSQL Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -188,8 +194,7 @@ event with the configured PostgreSQL service as a target:
      --event EVENTS
 
 - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment.
-- Replace ``BUCKET`` with the name of the bucket in which to configure the 
-  event.
+- Replace ``BUCKET`` with the name of the bucket in which to configure the ßevent.
 - Replace ``EVENTS`` with a comma-separated list of :ref:`events 
   <mc-event-supported-events>` for which MinIO triggers notifications.
 
@@ -322,7 +327,7 @@ target similar to the following:
 
    SQS ARNs: arn:minio:sqs::primary:postgresql
 
-3) Validate the Changes
+4) Validate the Changes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Perform an action on a bucket which has an event configuration using the updated

--- a/source/monitoring/bucket-notifications/publish-events-to-redis.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-redis.rst
@@ -6,6 +6,8 @@ Publish Events to Redis
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:redis``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -155,6 +157,10 @@ target similar to the following:
 You must specify the ARN resource when configuring bucket notifications with
 the associated Redis deployment as a target.
 
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
+
 3) Configure Bucket Notifications using the Redis Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -290,7 +296,7 @@ target similar to the following:
 
    SQS ARNs: arn:minio:sqs::primary:redis
 
-3) Validate the Changes
+4) Validate the Changes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Perform an action on a bucket which has an event configuration using the updated

--- a/source/monitoring/bucket-notifications/publish-events-to-webhook.rst
+++ b/source/monitoring/bucket-notifications/publish-events-to-webhook.rst
@@ -6,6 +6,8 @@ Publish Events to Webhook
 
 .. default-domain:: minio
 
+.. |ARN| replace:: ``arn:minio:sqs::primary:webhook``
+
 .. contents:: Table of Contents
    :local:
    :depth: 1
@@ -153,6 +155,10 @@ Webhook target similar to the following:
 You must specify the ARN resource when configuring bucket notifications with
 the associated Webhook deployment as a target.
 
+.. include:: /includes/common-bucket-notifications.rst
+   :start-after: start-bucket-notification-find-arn
+   :end-before: end-bucket-notification-find-arn
+
 3) Configure Bucket Notifications using the Webhook Endpoint as a Target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -288,7 +294,7 @@ target similar to the following:
 
    SQS ARNs: arn:minio:sqs::primary:webhook
 
-3) Validate the Changes
+4) Validate the Changes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Perform an action on a bucket which has an event configuration using the updated

--- a/source/reference/minio-mc/mc-event-add.rst
+++ b/source/reference/minio-mc/mc-event-add.rst
@@ -191,7 +191,7 @@ corresponding :ref:`S3 events <minio-bucket-notifications-event-types>`:
    :widths: 30 70
    :width: 100%
 
-   * - Supported Vluae
+   * - Supported Value
      - Corresponding S3 Events
 
    * - ``put``


### PR DESCRIPTION
Closes #346

Adds a new include file for bucket notification ARN identification.
Modifies each `publish` file under `monitoring/bucket-notifications` to add include file and a substitution directive.