### PR TITLE
Hide navigation links when the docs pages are loaded inside iframe

### DIFF
--- a/source/_static/js/main.js
+++ b/source/_static/js/main.js
@@ -1,4 +1,11 @@
 window.addEventListener("DOMContentLoaded", (event) => {
+   // Detect parent iframe.
+   // This is required to hide the navigation links when viewed via PathFactory for analytics purposes
+   if (window.location !== window.parent.location) {
+      document.body.classList.add('inside-iframe');
+   }
+   
+   // Table of contents
 	var topic = document.getElementById("table-of-contents");
 	if (topic != null) {
 		document

--- a/source/_static/scss/includes/_layout.scss
+++ b/source/_static/scss/includes/_layout.scss
@@ -43,3 +43,20 @@
     top: 0;
     overflow: scroll;
 }
+
+// Keep only the main content when the page is loaded inside an iframe.
+// Currently we load certain pages inside iframes for PathFactory analytics.
+.inside-iframe {
+    .header,
+    .sidebar {
+        display: none;
+    }
+
+    .content {
+        height: 100vh;
+    }
+
+    .content__main {
+        padding-left: $content-padding;
+    }
+}


### PR DESCRIPTION
We use some of the docs pages in [PathFactory](https://pathfactory.com/) for analytics purposes. These pages are loaded via iframes with a different reading experience, thus it is required to hide the header, footer, and navigation links in order to keep the reading experience minimal and cleaner.