### PR TITLE
Correcting subnet replacement to fix link rendering issue

### DIFF
--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -143,6 +143,6 @@ rst_prolog = """
 .. |minio-latest| replace:: MINIOLATEST
 .. |minio-rpm| replace:: RPMURL
 .. |minio-deb| replace:: DEBURL
-.. |subnet| replace:: `MinIO SUBNET <https://min.io/pricing?jmp=docs>`
+.. |subnet| replace:: `MinIO SUBNET <https://min.io/pricing?jmp=docs>`__
 
 """


### PR DESCRIPTION
`|subnet|` replacement is not rendering correctly.
This adds missing `__` at the end of the replacement link in conf.py and default-conf.py.