### PR TITLE
Removing group creation from last graph of access control

### DIFF
--- a/source/security/ad-ldap-external-identity-management/external-authentication-with-ad-ldap-identity-provider.rst
+++ b/source/security/ad-ldap-external-identity-management/external-authentication-with-ad-ldap-identity-provider.rst
@@ -217,8 +217,6 @@ group-inherited policies cannot access any resource on the MinIO deployment.
 
 MinIO provides :ref:`built-in policies <minio-policy-built-in>` for basic access
 control. You can create new policies using the :mc:`mc admin policy` command.
-You can create new groups using the :mc:`mc admin group` command and assign
-policies to that group using :mc-cmd:`mc admin policy set`.
 
 .. _minio-external-identity-management-ad-ldap-access-control-group-lookup:
 


### PR DESCRIPTION
Closes #427 

Removes an inaccurate sentence about creating groups from the last paragraph of the access control section.

I did not stage this change, as it is just deletion.