### PR TITLE
Fixing The Command command with references to intended command

### DIFF
--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -154,7 +154,7 @@ The following table lists :mc-cmd:`mc` commands:
    * - | :mc:`mc alias set`
        | :mc:`mc alias remove`
        | :mc:`mc alias list`
-     - The command command provides a convenient interface for
+     - The ``mc alias`` commands provide a convenient interface for
        managing the list of S3-compatible hosts that :mc-cmd:`mc` can connect to
        and run operations against.
 

--- a/source/reference/minio-mc/mc-cat.rst
+++ b/source/reference/minio-mc/mc-cat.rst
@@ -45,7 +45,7 @@ display the contents of the specified file or object to ``STDOUT``.
 
    .. tab-item:: SYNTAX
 
-      The command command has the following syntax:
+      The :mc:`mc cat` command has the following syntax:
 
       .. code-block:: shell
          :class: copyable

--- a/source/reference/minio-mc/mc-cp.rst
+++ b/source/reference/minio-mc/mc-cp.rst
@@ -44,7 +44,7 @@ similar results to the ``cp`` commandline tool.
 
    .. tab-item:: SYNTAX
 
-      The command command has the following syntax:
+      The :mc:`mc cp` command has the following syntax:
 
       .. code-block:: shell
          :class: copyable

--- a/source/reference/minio-mc/mc-diff.rst
+++ b/source/reference/minio-mc/mc-diff.rst
@@ -39,7 +39,7 @@ objects.
 
    .. tab-item:: SYNTAX
 
-      The command command has the following syntax:
+      The :mc:`mc diff` command has the following syntax:
 
       .. code-block:: shell
          :class: copyable

--- a/source/reference/minio-mc/mc-tree.rst
+++ b/source/reference/minio-mc/mc-tree.rst
@@ -68,7 +68,7 @@ Parameters
 
       mc tree myminio/mybucket
 
-   You can specify multiple targets to The command command. For
+   You can specify multiple targets to the :mc:`mc tree` command. For
    example:
 
    .. code-block:: shell


### PR DESCRIPTION
Fixes #453 

Corrected five instances of `The Command command` in the docs.

One instance remains in the replication overview doc, but that instance is addressed in the site replication PR #469 .