### PR TITLE
Remove additional backticks from container quickstart

### DIFF
--- a/source/quickstart/container.rst
+++ b/source/quickstart/container.rst
@@ -44,7 +44,7 @@ Procedure
                   -p 9000:9000 \
                   -p 9090:9090 \
                   -v ~/minio/data:/data \
-                  -e "MINIO_ROOT_USER=ROOTNAME`" \
+                  -e "MINIO_ROOT_USER=ROOTNAME" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
                   quay.io/minio/minio server /data --console-address ":9090"
    
@@ -69,7 +69,7 @@ Procedure
                   -p 9000:9000 \
                   -p 9090:9090 \
                   -v D:\data:/data \
-                  -e "MINIO_ROOT_USER=ROOTNAME`" \
+                  -e "MINIO_ROOT_USER=ROOTNAME" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
                   quay.io/minio/minio server /data --console-address ":9090"
    
@@ -101,7 +101,7 @@ Procedure
                   -p 9090:9090 \
                   --name minio \
                   -v ~/minio/data:/data \
-                  -e "MINIO_ROOT_USER=ROOTNAME`" \
+                  -e "MINIO_ROOT_USER=ROOTNAME" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
                   quay.io/minio/minio server /data --console-address ":9090"
          


### PR DESCRIPTION
Remove additional backticks from container quickstart
https://docs.min.io/minio/baremetal/quickstart/container.html#quickstart-container
![image](https://user-images.githubusercontent.com/33207565/168570607-e0700737-3e54-4721-9d65-797e68971a4d.png)