### PR TITLE
Adding pre-existing data sections

### DIFF
--- a/source/installation/deploy-minio-distributed.rst
+++ b/source/installation/deploy-minio-distributed.rst
@@ -205,6 +205,15 @@ Support for running MinIO in distributed mode on Windows hosts is
 **experimental**. Contact MinIO at hello@min.io if your infrastructure requires
 deployment onto Windows hosts.
 
+Pre-Existing Data
+~~~~~~~~~~~~~~~~~
+
+When starting a new MinIO server, the storage devices may have existing data.
+MinIO adds this data as buckets and objects in the MinIO deployment.
+
+Once you start the MinIO server, all interactions with the data must be done through the S3 API.
+Use the :ref:`MinIO Client <minio-client>`, the :ref:`MinIO Console <minio-console>`, or one of the MinIO :ref:`Software Development Kits <minio-drivers>` to work with the buckets and objects.
+
 .. _deploy-minio-distributed-baremetal:
 
 Deploy Distributed MinIO

--- a/source/installation/deploy-minio-distributed.rst
+++ b/source/installation/deploy-minio-distributed.rst
@@ -208,11 +208,14 @@ deployment onto Windows hosts.
 Pre-Existing Data
 ~~~~~~~~~~~~~~~~~
 
-When starting a new MinIO server, the storage devices may have existing data.
-MinIO adds this data as buckets and objects in the MinIO deployment.
+When starting a new MinIO server in a distributed environment, the storage devices must not have existing data.
 
 Once you start the MinIO server, all interactions with the data must be done through the S3 API.
 Use the :ref:`MinIO Client <minio-client>`, the :ref:`MinIO Console <minio-console>`, or one of the MinIO :ref:`Software Development Kits <minio-drivers>` to work with the buckets and objects.
+
+.. warning:: 
+   
+   Modifying files on the backend drives can result in data corruption or data loss.
 
 .. _deploy-minio-distributed-baremetal:
 

--- a/source/installation/deploy-minio-standalone.rst
+++ b/source/installation/deploy-minio-standalone.rst
@@ -19,6 +19,35 @@ For extended development or production environments, *or* to access
 in :guilabel:`Distributed Mode`. See :ref:`deploy-minio-distributed` for more
 information.
 
+Pre-Existing Data
+-----------------
+
+When starting a new standalone MinIO server, the storage path may have existing data already grouped into directories.
+MinIO displays this data as buckets and objects in the MinIO deployment.
+Files at the root of the storage path do not display in MinIO. 
+To see them in MinIO, move the file(s) into a folder that becomes a MinIO bucket before deploying the server.
+
+Consider a starting path with the following structure:
+
+.. code-block:: 
+   
+   /data
+      file.txt
+      /foo
+         file2.txt
+      /bar
+         file3.txt
+
+When you deploy the server with a starting path of ``/data``, MinIO creates two buckets: ``foo`` and ``bar``.
+``file2.txt`` displays in the ``foo`` bucket and ``file3.txt`` displays in the ``bar`` bucket.
+
+``file.txt`` does not display in MinIO anywhere.
+
+On a standalone deployment with a single drive, you can create and delete files directly in the starting path folders.
+Top-level folders become MinIO buckets.
+Files in folders within the starting path become objects within the MinIO buckets.
+Files in the top-level starting path do not display in MinIO.
+
 .. _deploy-minio-standalone:
 
 Deploy Standalone MinIO on Baremetal
@@ -40,16 +69,6 @@ deployments are best suited for evaluation and initial development environments.
    For deployments that *require* using network-attached storage, use
    NFSv4 for best results.
 
-Pre-Existing Data
-~~~~~~~~~~~~~~~~~
-
-When starting a new MinIO server, the storage devices may have existing data.
-MinIO adds this data as buckets and objects in the MinIO deployment.
-
-Once you start the MinIO server, all interactions with the data must be done through the S3 API.
-Use the :ref:`MinIO Client <minio-client>`, the :ref:`MinIO Console <minio-console>`, or one of the MinIO :ref:`Software Development Kits <minio-drivers>` to work with the buckets and objects.
-
-For example, if you navigate to the storage device through a file explorer program and change the data on the device directly, MinIO may not pick up the changes as long as the server is running.
 
 1) Download and Run MinIO Server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/installation/deploy-minio-standalone.rst
+++ b/source/installation/deploy-minio-standalone.rst
@@ -24,8 +24,10 @@ Pre-Existing Data
 
 When starting a new standalone MinIO server, the storage path may have existing data already grouped into directories.
 MinIO displays this data as buckets and objects in the MinIO deployment.
-Files at the root of the storage path do not display in MinIO. 
-To see them in MinIO, move the file(s) into a folder that becomes a MinIO bucket before deploying the server.
+
+- Top-level folders at the starting path become MinIO buckets.
+- Files in folders within the starting path become objects within the MinIO buckets.
+- Files in the top-level starting path do not display in MinIO.
 
 Consider a starting path with the following structure:
 
@@ -38,15 +40,15 @@ Consider a starting path with the following structure:
       /bar
          file3.txt
 
-When you deploy the server with a starting path of ``/data``, MinIO creates two buckets: ``foo`` and ``bar``.
-``file2.txt`` displays in the ``foo`` bucket and ``file3.txt`` displays in the ``bar`` bucket.
+When you deploy the server with a starting path of ``/data``, MinIO displays the data as follows:
 
-``file.txt`` does not display in MinIO anywhere.
+- Two buckets, ``foo`` and ``bar``
+- ``file2.txt`` displays in the ``foo`` bucket 
+- ``file3.txt`` displays in the ``bar`` bucket
+- ``file.txt`` does not display in MinIO anywhere, but remains available through the file system
 
-On a standalone deployment with a single drive, you can create and delete files directly in the starting path folders.
-Top-level folders become MinIO buckets.
-Files in folders within the starting path become objects within the MinIO buckets.
-Files in the top-level starting path do not display in MinIO.
+On a standalone deployment with a single drive, you can manage buckets and objects with the :ref:`Console <minio-console>`, :ref:`command line client <minio-client>`, or create and delete files and folders directly in the starting path folders.
+
 
 .. _deploy-minio-standalone:
 

--- a/source/installation/deploy-minio-standalone.rst
+++ b/source/installation/deploy-minio-standalone.rst
@@ -40,6 +40,17 @@ deployments are best suited for evaluation and initial development environments.
    For deployments that *require* using network-attached storage, use
    NFSv4 for best results.
 
+Pre-Existing Data
+~~~~~~~~~~~~~~~~~
+
+When starting a new MinIO server, the storage devices may have existing data.
+MinIO adds this data as buckets and objects in the MinIO deployment.
+
+Once you start the MinIO server, all interactions with the data must be done through the S3 API.
+Use the :ref:`MinIO Client <minio-client>`, the :ref:`MinIO Console <minio-console>`, or one of the MinIO :ref:`Software Development Kits <minio-drivers>` to work with the buckets and objects.
+
+For example, if you navigate to the storage device through a file explorer program and change the data on the device directly, MinIO may not pick up the changes as long as the server is running.
+
 1) Download and Run MinIO Server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/installation/deployment-and-management.rst
+++ b/source/installation/deployment-and-management.rst
@@ -114,7 +114,7 @@ hello@min.io for additional support and guidance. You can build MinIO from
 for your platform and architecture combo. MinIO generally does not recommend
 source-based installations in production environments.
 
-.. _minio-preexisting-data::
+.. _minio-preexisting-data:
 
 Pre-Existing Data
 -----------------

--- a/source/installation/deployment-and-management.rst
+++ b/source/installation/deployment-and-management.rst
@@ -119,15 +119,31 @@ source-based installations in production environments.
 Pre-Existing Data
 -----------------
 
-When deploying a new MinIO server instance, you can choose a storage location that contains existing data.
-MinIO adds the existing data as buckets and objects as part of starting the server.
+Standalone Deployments
+~~~~~~~~~~~~~~~~~~~~~~
 
-Once you start the server, MinIO does not support manipulating the data directly on the storage location outside of the S3 API.
+When deploying a new MinIO server instance, you can choose a storage location that contains existing data only for standlone deployments.
+For standalone deployments, MinIO adds the existing data as buckets and objects as part of starting the server.
+
+.. important::
+   
+   Files at the root of the starting path do not display in MinIO.
+   Existing data must be in folders in the starting path.
+   Top level folders become MinIO buckets.
+
+Distributed Deployments
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Once you start a standalone server, you can create or delete buckets and objects either with :ref:`MinIO Console <minio-console>`, the :ref:`mc client <minio-client>`, or directly in the file system.
+
+For a distributed MinIO deployment, the starting path must be empty.
+
+Once you start a distributed server, MinIO does not support manipulating the data directly on the storage location outside of the S3 API.
+Manipulating files directly on the storage locations can result in data corruption or data loss.
 
 For example, you cannot navigate to the storage location using a file explorer program and add or remove files.
-If you do manipulate the data outside of the S3 API, you cannot expect MinIO to recognize the changes.
 
-Instead, use the :ref:`MinIO Client <minio-client>`, the :ref:`MinIO Console <minio-console>`, or one of the MinIO :ref:`Software Development Kits <minio-drivers>` to work with the buckets and objects instead.
+Instead, use the :ref:`MinIO Client <minio-client>`, the :ref:`MinIO Console <minio-console>`, or one of the MinIO :ref:`Software Development Kits <minio-drivers>` to work with the buckets and objects for distributed deployments.
 
 
 .. toctree::

--- a/source/installation/deployment-and-management.rst
+++ b/source/installation/deployment-and-management.rst
@@ -114,6 +114,22 @@ hello@min.io for additional support and guidance. You can build MinIO from
 for your platform and architecture combo. MinIO generally does not recommend
 source-based installations in production environments.
 
+.. _minio-preexisting-data::
+
+Pre-Existing Data
+-----------------
+
+When deploying a new MinIO server instance, you can choose a storage location that contains existing data.
+MinIO adds the existing data as buckets and objects as part of starting the server.
+
+Once you start the server, MinIO does not support manipulating the data directly on the storage location outside of the S3 API.
+
+For example, you cannot navigate to the storage location using a file explorer program and add or remove files.
+If you do manipulate the data outside of the S3 API, you cannot expect MinIO to recognize the changes.
+
+Instead, use the :ref:`MinIO Client <minio-client>`, the :ref:`MinIO Console <minio-console>`, or one of the MinIO :ref:`Software Development Kits <minio-drivers>` to work with the buckets and objects instead.
+
+
 .. toctree::
    :titlesonly:
    :hidden:


### PR DESCRIPTION
Closes #418 

Adds sections to the docs describing what happens with pre-existing data when starting up a MinIO server.
Also states that all interactions with data on a storage device must go through an S3 API after the server starts.