### PR TITLE
Match terms with MinIO Console

### DIFF
--- a/source/console/minio-console.rst
+++ b/source/console/minio-console.rst
@@ -30,8 +30,8 @@ standalone MinIO Console using the instructions in the
 You can explore the Console using https://play.min.io:9443. Log in with
 the following credentials:
 
-- Access Key: ``Q3AM3UQ867SPQQA43P2F``
-- Secret Key: ``zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG``
+- Username: ``Q3AM3UQ867SPQQA43P2F``
+- Password: ``zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG``
 
 The Play Console connects to the MinIO Play deployment at https://play.min.io.
 You can also access this deployment using :mc:`mc` and using the ``play``


### PR DESCRIPTION
This PR updates terms to match MinIO Console.
- Relevant page:
[https://docs.min.io/minio/baremetal/console/minio-console.html](https://docs.min.io/minio/baremetal/console/minio-console.html#:~:text=You%20can%20explore,Key%3A%20zuf%2BtfteSlswRu7BJ86wekitnifILbZam1KYY3TG)

- Why:
The document uses `Access/Secret Key`
But MinIO console uses `Username` and `Password`.<br>
Maybe this PR could make the document even more intuitive.
![image](https://user-images.githubusercontent.com/33207565/169488910-cdbfc640-b4d3-4706-a942-29cc66894426.png)
