### PR TITLE
Add Sphinx Glossary

### DIFF
--- a/source/_static/scss/includes/_base.scss
+++ b/source/_static/scss/includes/_base.scss
@@ -195,7 +195,7 @@ button.toggle-button {
 }
 
 .xref {
-    color: $theme-red;
+    color: $link-color;
 }
 
 .content__main {

--- a/source/administration/identity-access-management/minio-identity-management.rst
+++ b/source/administration/identity-access-management/minio-identity-management.rst
@@ -35,7 +35,7 @@ user's authorized actions and resources *or* assign the user to :ref:`groups
 :ref:`minio-access-management` for more information.
 
 .. admonition:: External Identity Management
-   :class: dropdown, note
+   :class: note
 
    MinIO supports external management of identities using either an
    OpenID Connect (OIDC) or Active Directory/LDAP IDentity Provider (IDP).

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -200,13 +200,13 @@ Glossary
      These types of certificates do not expire or require periodic review, and they cannot be revoked.
 
    server logs
-     Records the :mc:`minio server` operations logged to the system console.
+     Records the ``minio server`` operations logged to the system console.
      :ref:`Server logs <minio-logging>` support general monitoring and troubleshooting of operations.
 
      For more detailed logging information, see :term:`audit logs`.
 
    server pool
-     A set of `minio server` nodes which combine their drives and resources to support object storage and retrieval requests.
+     A set of ``minio server`` nodes which combine their drives and resources to support object storage and retrieval requests.
 
    service account
      A MinIO deployment or tenant user account with limited account typically used with API calls.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -206,7 +206,7 @@ Glossary
      For more detailed logging information, see :term:`audit logs`.
 
    server pool
-     A set of :mc:`minio server` nodes which combine their drives and resources to support object storage and retrieval requests.
+     A set of `minio server` nodes which combine their drives and resources to support object storage and retrieval requests.
 
    service account
      A MinIO deployment or tenant user account with limited account typically used with API calls.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -1,0 +1,82 @@
+========
+Glossary
+========
+
+.. glossary::
+   :sorted:
+
+   bucket
+   buckets
+     A grouping of :term:`objects`.
+
+   Console
+   MinIO Console
+     Graphical User Interface (GUI) used to interact with a MinIO deployment or :term:`tenant`.
+
+   decommission
+     Process of removing a pool of drives from a :term:`distributed` deployment.
+     When initiated, the objects on the decommission pool drain by moving to other pools on the deployment.
+     The process is not reversible.
+   
+   deployment
+     A specific instance of MinIO containing a set of :term:`buckets` and :term:`objects`.
+
+   erasure coding
+     A technology that splits :term:`objects` into multiple shards and writes the shards to separate multiple disks.
+     Depending on the :term:`topology` used, erasure coding allows for loss of drives or nodes within a MinIO deployment without losing read or write access.
+
+   lifecycle management
+   ILM
+     Rules to determine when :term:`objects` should move or expire.
+
+   locking
+     A rule that prevents removal or deletion of an object until an authorized agent removes the rule or it expires.
+
+   multi-node multi-drive
+   MNMD
+   distributed
+     A system :term:`topology` that uses more than one server and more than one drive per server to host a MinIO instance.
+     MinIO recommends Kubernetes for distributed deployments.
+
+   object
+   objects
+     An item of data MinIO interacts with using an S3-compatible API.
+     Objects can be grouped into :term:`buckets`.
+
+   Operator
+   Operator Console
+     The Graphical User Interface (GUI) to deploy and manage the MinIO :term:`tenants` in a distributed deployment environment.
+   
+   replication
+     The duplication of a :ref:`bucket <minio-bucket-replication>` or entire :ref:`site <minio-site-replication-overview>` to another location.
+   
+   service account
+     A MinIO deployment or tenant account with limited account typically used with API calls.
+
+   single-node multi-drive
+   SNMD
+     A system :term:`topology` that deploys MinIO on one compute resource with more than one attached volume.
+
+   single-node single-drive
+   SNSD
+   filesystem
+     A system :term:`topology` that deploys MinIo on a single compute resource with a single drive.
+     This adds S3-type functionality to an otherwise standard filesystem mode. 
+   
+   SUBNET
+     MinIO's Subscription Network tracks support tickets and providers 24 hour direct-to-engineer access for subscribed accounts.
+
+   tenant
+     In a :term:`distributed` mode, a specific MinIO deployment.
+     One instance of the MinIO Operator may have multiple tenants.
+
+   topology
+     The hardware configuration used for a deployment.
+     MinIO works with three topologies:
+     
+     - :term:`multi-node multi-drive`
+     - :term:`single-node multi-drive`
+     - :term:`signle-node signle-drive`
+
+   versioning
+     The retention of multiple iterations of an object as it changes over time.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -5,13 +5,48 @@ Glossary
 .. glossary::
    :sorted:
 
+   active-active
+     A method of :term:`replication` that provides bidirectional mirroring of data.
+     With active-active configuration, changing the data at at any storage location also changes the data at the other storage location(s).
+     See also: :term:`active-passive`.
+
+   active-passive
+     A method of :term:`replication` that provides one-way mirroring of data.
+     With the active-passive configuration, changing data at the originating location also changes the data at the destination.
+     However, changing data at the destination does not affect the data on the origin.
+     See also: :term:`active-active`.
+
+   bitrot 
+     Data corruption that occurrs without the user’s knowledge. 
+     Some common reasons for bitrot include:
+     
+     - ageing drives
+     - current spikes
+     - bugs in disk firmware
+     - phantom writes
+     - misdirected reads/writes
+     - driver errors
+     - accidental overwrites
+     
+     MinIO combats bitrot with :term:`hashing` and :term:`erasure coding`.
+
+   bitrot healing
+     Objects corrupted due to bitrot automatically restore to a healed state at time of read.
+     MinIO captures and heals corrupted objects on the fly with its :term:`hashing` implementation.
+
    bucket
    buckets
-     A grouping of :term:`objects`.
+     A grouping of :term:`objects` and associated configurations.
 
    Console
    MinIO Console
      Graphical User Interface (GUI) used to interact with a MinIO deployment or :term:`tenant`.
+
+   data
+     One of the two types of blocks MinIO writes when doing :term:`erasure coding`.
+     Data blocks contain the contents of a file.
+     :term:`parity` blocks support data reconstruction should data blocks become corrupt or go missing.
+
 
    decommission
      Process of removing a pool of drives from a :term:`distributed` deployment.
@@ -21,11 +56,33 @@ Glossary
    deployment
      A specific instance of MinIO containing a set of :term:`buckets` and :term:`objects`.
 
+   encryption at rest
+     A method of encryption that stores an object in an encrypted state.
+     The object remains encrypted while not moving from one location to another.
+
+   encryption in transit
+     A method of encryption that encrypts an object when moving it from one location to another, such as during a GET request.
+     The object may or may not be encrypted on the origin or destination storage devices.
+   
    erasure coding
      A technology that splits :term:`objects` into multiple shards and writes the shards to separate multiple disks.
      Depending on the :term:`topology` used, erasure coding allows for loss of drives or nodes within a MinIO deployment without losing read or write access.
 
+   erasure set
+     A group of drives within MinIO that support :term:`erasure coding`. 
+     MinIO divides the number of drives in a deployment's server pool into groups of 4 to 16 drives that make up each _erasure set_.
+     When writing objects, :term:`data` and :term:`parity` blocks write randomly to the drives in the erasure set.
+
+   JBOD 
+     Initialism for "Just A Bunch of Disks".
+     JBOD is a storage device enclosure that holds many hard drives.
+     These drives can combine into one logical drive unit.
+     See also: :term:`RAID`
+
    lifecycle management
+   Data Lifecycle Management
+   Object Lifecycle Management
+   Information Lifecycle Management
    ILM
      Rules to determine when :term:`objects` should move or expire.
 
@@ -46,7 +103,22 @@ Glossary
    Operator
    Operator Console
      The Graphical User Interface (GUI) to deploy and manage the MinIO :term:`tenants` in a distributed deployment environment.
-   
+
+   parity
+     The portion of blocks written for an object by MinIO to support data reconstruction due to missing or corrupt data blocks.
+     The number of parity blocks indicates the number of drives in the :term:`erasure set` that a deployment can lose while still retaining read and write operations.
+
+   prefix
+     Prefixes organize the :term:`objects` in a :term:`bucket` by assigning the same string of characters to objects that should share a similar hierarchy or structure.
+     Use a delimiter character, typically a `/` to add layers to the hierarchy.
+     While prefixed objects may resemble a directory structure in some file systems, prefixes are not directories.
+
+   RAID
+     Initialism for "Redundant Array of Independent Disks".
+     The technology merges multiple separate physical disks into a single storage unit or array.
+     Some RAID levels provide data redundancy or fault tolerance by duplicating data, striping data, or mirroring data across physical disks.
+     See also: :term:`JBOD`.
+
    replication
      The duplication of a :ref:`bucket <minio-bucket-replication>` or entire :ref:`site <minio-site-replication-overview>` to another location.
    
@@ -79,4 +151,26 @@ Glossary
      - :term:`signle-node signle-drive`
 
    versioning
-     The retention of multiple iterations of an object as it changes over time.
+     The retention of multiple iterations of an :term:`object` as it changes over time.
+  
+
+..
+
+  To define:
+  
+   audit Logs
+   cluster registration 
+   disk encryption
+   hashing
+   HBA 
+   health diagnostics
+   IAM integration
+   monitoring
+   network encryption
+   scanner | MinIO Scanner
+   self signed certificates
+   server pool
+   SSE-C 
+   SSE-KMS
+   SSE-S3 
+   webhook

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -8,13 +8,21 @@ Glossary
    active-active
      A method of :term:`replication` that provides bidirectional mirroring of data.
      With active-active configuration, changing the data at at any storage location also changes the data at the other storage location(s).
+     
      See also: :term:`active-passive`.
 
    active-passive
      A method of :term:`replication` that provides one-way mirroring of data.
      With the active-passive configuration, changing data at the originating location also changes the data at the destination.
      However, changing data at the destination does not affect the data on the origin.
+     
      See also: :term:`active-active`.
+
+   audit logs
+     Granular descriptions of each operation on a MinIO deployment.
+     :ref:`Audit logs <minio-logging>` support security standards and regulations which require detailed tracking of operations.
+     
+     See also: :term:`server logs`.
 
    bitrot 
      Data corruption that occurrs without the user’s knowledge. 
@@ -38,34 +46,52 @@ Glossary
    buckets
      A grouping of :term:`objects` and associated configurations.
 
+   cluster
+     A group of drives and one or more MinIO server processes pooled into a single storage resource.
+     
+     See also: :term:`tenant`.
+
+   cluster registration
+     Cluster registration links a MinIO deployment to a :term:`SUBNET` :ref:`subscription <minio-docs-subnet>`.
+     An organization may have more than one MinIO clusters registered to the same SUBNET subscription.
+
    Console
    MinIO Console
-     Graphical User Interface (GUI) used to interact with a MinIO deployment or :term:`tenant`.
+     Graphical User Interface (GUI) for interacting with a MinIO deployment or :term:`tenant`.
 
    data
      One of the two types of blocks MinIO writes when doing :term:`erasure coding`.
      Data blocks contain the contents of a file.
-     :term:`parity` blocks support data reconstruction should data blocks become corrupt or go missing.
 
+     :term:`Parity` blocks support data reconstruction should data blocks become corrupt or go missing.
 
    decommission
      Process of removing a pool of drives from a :term:`distributed` deployment.
      When initiated, the objects on the decommission pool drain by moving to other pools on the deployment.
+     
      The process is not reversible.
    
    deployment
      A specific instance of MinIO containing a set of :term:`buckets` and :term:`objects`.
 
+   disk encryption
+     The conversion of all of the contents written to a disk to values that cannot be easily deciphered by an unauthorized entity.
+     Disk encryption can be used in conjuntion with other encryption technologies to create a robust data security system.
+
    encryption at rest
      A method of encryption that stores an object in an encrypted state.
      The object remains encrypted while not moving from one location to another.
 
+     Objects can be encrypted by the the server using one of key management methods:
+     :term:`SSE-KMS`, :term:`SSE-S3`, or :term:`SSE-C`.
+
    encryption in transit
-     A method of encryption that encrypts an object when moving it from one location to another, such as during a GET request.
+     A method of encryption that protects an object when moving it from one location to another, such as during a GET request.
      The object may or may not be encrypted on the origin or destination storage devices.
    
    erasure coding
-     A technology that splits :term:`objects` into multiple shards and writes the shards to separate multiple disks.
+     A technology that splits :term:`objects` into multiple shards and writes the shards to multiple, separate disks.
+     
      Depending on the :term:`topology` used, erasure coding allows for loss of drives or nodes within a MinIO deployment without losing read or write access.
 
    erasure set
@@ -73,27 +99,63 @@ Glossary
      MinIO divides the number of drives in a deployment's server pool into groups of 4 to 16 drives that make up each _erasure set_.
      When writing objects, :term:`data` and :term:`parity` blocks write randomly to the drives in the erasure set.
 
+   hashing
+     The use of an algorithm to create a unique, fixed-length string (a `value`) to identify a piece of data.
+   
+   healing
+     Restoration of data from partial loss due to bitrot, drive failure, or site failure.
+
+   health diagnostics
+     A suite of MinIO :ref:`API endpoints <minio-healthcheck-api>` available to check whether a server is
+     
+     - online 
+     - available for writing data
+     - available for reading data
+     - available for maintenance without affecting the cluster's read and write operations
+
+   host bus adapter
+   HBA 
+     A circuit board or integrated circuit adapter that connects a host system to a storage device.
+     The :abbr:`HBA (host bus adapter)` handles processing to reduce load on the host system's processor.
+
+   IAM integration
+     MinIO only allows access to data for authenticated users.
+     MinIO provides a built-in identity management solution to create authorized credentials.
+     Optionally, MinIO users can authenticate with credentials from a 3rd party identify provider (IDP), including either OpenID or LDAP providers.
+
    JBOD 
      Initialism for "Just A Bunch of Disks".
      JBOD is a storage device enclosure that holds many hard drives.
      These drives can combine into one logical drive unit.
+     
      See also: :term:`RAID`
 
    lifecycle management
-   Data Lifecycle Management
-   Object Lifecycle Management
-   Information Lifecycle Management
    ILM
      Rules to determine when :term:`objects` should move or expire.
 
    locking
      A rule that prevents removal or deletion of an object until an authorized agent removes the rule or it expires.
 
+   monitoring
+     The act of reviewing the status, activity, and availility of a MinIO cluster, deployment, tenant, or server.
+     MinIO provides the following tools: 
+
+     - `Prometheus <https://prometheus.io/>`__ compatible metrics and alerts
+     - :term:`Audit logs`
+     - :term:`server logs`
+     - :ref:`Healthcheck API endpoints <minio-healthcheck-api>`
+     - :ref:`Bucket notifications <minio-bucket-notifications>`
+
    multi-node multi-drive
    MNMD
    distributed
      A system :term:`topology` that uses more than one server and more than one drive per server to host a MinIO instance.
      MinIO recommends Kubernetes for distributed deployments.
+
+   network encryption
+     A method of securing data during transit from one location to another, such as server-server or client-server.
+     MinIO supports :ref:`Transport Layer Security (TLS) <minio-tls>`, version 1.2 and later, for both incoming and outgoing traffic.
 
    object
    objects
@@ -117,13 +179,37 @@ Glossary
      Initialism for "Redundant Array of Independent Disks".
      The technology merges multiple separate physical disks into a single storage unit or array.
      Some RAID levels provide data redundancy or fault tolerance by duplicating data, striping data, or mirroring data across physical disks.
+     
      See also: :term:`JBOD`.
 
    replication
+   mirror
      The duplication of a :ref:`bucket <minio-bucket-replication>` or entire :ref:`site <minio-site-replication-overview>` to another location.
-   
+
+   scanner 
+   MinIO Scanner
+     One of several low-priority processes MinIO runs to check:
+     
+     - lifecycle management rules requiring object transition
+     - bucket or site replication status
+     - object :term:`bitrot` and healing
+
+   self signed certificates
+     A self-signed certificate is one created by, issued by, and signed by the company or developer responsible for the content the certificate secures.
+     Self-signed certificates are not issued by or signed by a publicly trusted, third-party Certificate Authority (CA).
+     These types of certificates do not expire or require periodic review, and they cannot be revoked.
+
+   server logs
+     Records the :mc:`minio server` operations logged to the system console.
+     :ref:`Server logs <minio-logging>` support general monitoring and troubleshooting of operations.
+
+     For more detailed logging information, see :term:`audit logs`.
+
+   server pool
+     A set of :mc:`minio server` nodes which combine their drives and resources to support object storage and retrieval requests.
+
    service account
-     A MinIO deployment or tenant account with limited account typically used with API calls.
+     A MinIO deployment or tenant user account with limited account typically used with API calls.
 
    single-node multi-drive
    SNMD
@@ -132,13 +218,34 @@ Glossary
    single-node single-drive
    SNSD
    filesystem
-     A system :term:`topology` that deploys MinIo on a single compute resource with a single drive.
-     This adds S3-type functionality to an otherwise standard filesystem mode. 
+     A system :term:`topology` that deploys MinIO on a single compute resource with a single drive.
+     This adds S3-type functionality to an otherwise standard filesystem. 
+
+   SSE-C
+     A method of :term:`encryption at rest` that encrypts an object at the time of writing with an encryption key included with the write request.
+     To retrieve the object, you must provide the same encryption key provided when originally writing the object.
+     Additionally, you must self-manage the encryption key(s) used.
+
+     See also: :term:`SSE-KMS`, :term:`SSE-S3`, :term:`encryption at rest`, :term:`network encryption`.
+
+   SSE-KMS
+     A method of :term:`encryption at rest` that encrypts each object at the time of writing with separate keys managed by a service provider.
+     Use keys at either the bucket level (default) or at the object level.
+     MinIO recommends the SSE-KMS method for key management of encryption.
+
+     See also: :term:`SSE-S3`, :term:`SSE-C`, :term:`encryption at rest`, :term:`network encryption`.
+
+   SSE-S3
+     A method of :term:`encryption at rest` that encrypts each object at the time of writing with a single key for all objects on a deployment.
+     A deployment uses a single external key to decrypt any object throughout the deployment.
+
+     See also: :term:`SSE-KMS`, :term:`SSE-C`, :term:`encryption at rest`, :term:`network encryption`.
    
    SUBNET
-     MinIO's Subscription Network tracks support tickets and providers 24 hour direct-to-engineer access for subscribed accounts.
+     `MinIO's Subscription Network <|SUBNET|>`__ tracks support tickets and provides 24 hour direct-to-engineer access for subscribed accounts.
 
    tenant
+   tenants
      In a :term:`distributed` mode, a specific MinIO deployment.
      One instance of the MinIO Operator may have multiple tenants.
 
@@ -148,29 +255,11 @@ Glossary
      
      - :term:`multi-node multi-drive`
      - :term:`single-node multi-drive`
-     - :term:`signle-node signle-drive`
+     - :term:`single-node single-drive`
 
    versioning
      The retention of multiple iterations of an :term:`object` as it changes over time.
   
-
-..
-
-  To define:
-  
-   audit Logs
-   cluster registration 
-   disk encryption
-   hashing
-   HBA 
-   health diagnostics
-   IAM integration
-   monitoring
-   network encryption
-   scanner | MinIO Scanner
-   self signed certificates
-   server pool
-   SSE-C 
-   SSE-KMS
-   SSE-S3 
    webhook
+     A :ref:`webhook <minio-bucket-notifications-publish-webhook>` is a method for altering the behavior of a web page or web application with a custom callback.
+     The format is typically :abbr:`JSON (JavaScript Object Notation)` sent as an HTTP POST request.

--- a/source/index.rst
+++ b/source/index.rst
@@ -104,7 +104,8 @@ without validating their usage do so at their own risk.
       /reference/minio-mc
       /reference/minio-mc-admin
       /reference/kubectl-minio-plugin
-
+      /glossary
+      
 .. cond:: linux or macos or windows
 
    .. toctree::
@@ -132,3 +133,4 @@ without validating their usage do so at their own risk.
       /reference/minio-mc
       /reference/minio-mc-admin
       /reference/minio-server/minio-server
+      /glossary

--- a/source/operations/install-deploy-manage/decommission-server-pool.rst
+++ b/source/operations/install-deploy-manage/decommission-server-pool.rst
@@ -11,7 +11,7 @@ Decommission a Server Pool
    :depth: 1
 
 Starting with :minio-release:`RELEASE.2022-01-25T19-56-04Z`, MinIO supports
-decommissioning and removing a :ref:`server pools <minio-intro-server-pool>`
+decommissioning and removing a :ref:`server pool <minio-intro-server-pool>`
 from a deployment. Decommissioning is designed for removing an older server pool
 whose hardware is no longer sufficient or performant compared to the pools in
 the deployment. MinIO automatically migrates data from the decommissioned pool
@@ -89,12 +89,13 @@ this procedure.
 Deployment Must Have Sufficient Storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The decommissioning process migrates objects from the target pool to other
-pools in the deployment. The total available storage on the deployment
-*must* exceed the total storage of the decommissioned pool.
+The decommissioning process migrates objects from the target pool to other pools in the deployment. 
+The total available storage on the deployment *must* exceed the total storage of the decommissioned pool.
 
-For example, consider a deployment with the following distribution of
-used and free storage:
+Use the `Erasure Code Calculator <https://min.io/product/erasure-code-calculator>`__ to determine the usable storage capacity.
+Then reduce that by the size of the objects already on the deployment.
+
+For example, consider a deployment with the following distribution of used and free storage:
 
 .. list-table::
    :stub-columns: 1
@@ -113,9 +114,8 @@ used and free storage:
      - 100TB Used
      - 200TB Total
 
-Decommissioning Pool 1 requires distributing the 100TB of used storage
-across the remaining pools. Pool 2 and Pool 3 each have 100TB of unused
-storage space and can safely absorb the data stored on Pool 1. 
+Decommissioning Pool 1 requires distributing the 100TB of used storage across the remaining pools. 
+Pool 2 and Pool 3 each have 100TB of unused storage space and can safely absorb the data stored on Pool 1. 
 
 However, if Pool 1 were full (e.g. 200TB of used space), decommissioning would
 completely fill the remaining pools and potentially prevent any further write


### PR DESCRIPTION
This PR adds a glossary to the docs site.
One scss file is changed to update the internal xref style to use the standard link color.

This PR does **not** apply `:term:` links throughout the docs to link to the glossary.
That will be done in a later pass.

The glossary is included as one of the **Reference** docs in the navigation panel.

Makes progress on #465.