### PR TITLE
Update file on URL

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -141,8 +141,8 @@ rst_prolog = """
 
 .. |minio-tag| replace:: `RELEASE.2022-07-04T21-02-54Z <https://github.com/minio/minio/releases/tag/RELEASE.2022-07-04T21-02-54Z>`__
 .. |minio-latest| replace:: RELEASE.2022-07-04T21-02-54Z
-.. |minio-rpm| replace:: https://dl.min.io/server/minio/release/linux-amd64/minio-20220704210254.0.0.x86_64.rpm
-.. |minio-deb| replace:: https://dl.min.io/server/minio/release/linux-amd64/minio_20220704210254.0.0_amd64.deb
+.. |minio-rpm| replace:: https://dl.min.io/server/minio/release/linux-amd64/minio-20220706202949.0.0.x86_64.rpm
+.. |minio-deb| replace:: https://dl.min.io/server/minio/release/linux-amd64/minio_20220706202949.0.0_amd64.deb
 .. |subnet| replace:: `MinIO SUBNET <https://min.io/pricing?jmp=docs>`__
 .. |subnet-short| replace:: `SUBNET <https://min.io/pricing?jmp=docs>`__
 .. |SNSD| replace:: :abbr:`SNSD (Single-Node Single-Drive)`


### PR DESCRIPTION
In https://docs.min.io/minio/baremetal/installation/deploy-minio-distributed.html 
we can't download files because they does not exist:

https://dl.min.io/server/minio/release/linux-amd64/minio-20220704210254.0.0.x86_64.rpm

```
Not Found
```

We need to update these files, so we can download them.