### PR TITLE
Create a footer note for cookie and privacy policy disclaimer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ sync-minio-version:
 
 	@cp source/default-conf.py source/conf.py
 
-	@kname=$(uname -s)
+	@$(eval kname = $(shell uname -s))
 	@case "${kname}" in \
 	Darwin) \
 		sed -i "" "s|MINIOLATEST|${MINIO}|g" source/conf.py; \
@@ -82,12 +82,15 @@ sync-deps:
 	@make sync-dotnet-docs
 
 stage:
-	@make clean && make html
+	@make clean 
+	@make sync-minio-version
+	@make html
 	python -m http.server --directory $(BUILDDIR)/$(GITDIR)/html
 	
 publish:
 	@make clean
-	make html
+	@make sync-minio-version
+	@make html
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -117,10 +117,15 @@
          <div id=localtoc></div>
       </div>
       <div class="content__main">
-         <!--
+
+         
+         {% block body %} {% endblock %}
+
          {% block alertbar -%}
-            <div class="admonition important">
+            <div class="admonition note">
                <span class="alert-message">
+                  <p>This site uses cookies to improve the site experience. By continuing, you are providing consent to the use of these cookies. Please visit our <a href="https://www.min.io/privacy-policy">privacy policy</a> for more information.</p>
+                  <!--
                   <p>Welcome to the upcoming version of the MinIO Documentation!
                      The content on this page is under active development and 
                      may change at any time.
@@ -128,11 +133,11 @@
                      <a href="https://docs.min.io"> legacy documentation</a>.
                      Thank you for your patience.
                   </p>
+                  -->
                </span>
             </div>
          {% endblock %}
-         -->
-         {% block body %} {% endblock %}
+
          <div class="footer">
             <div>
                <p>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</p>

--- a/source/installation/upgrade-minio.rst
+++ b/source/installation/upgrade-minio.rst
@@ -178,7 +178,7 @@ cannot use :mc-cmd:`mc admin update` to retrieve the binary over the network.
    .. code-block:: shell
       :class: copyable
 
-      mc admin service ALIAS
+      mc admin service restart ALIAS
 
    Replace ``ALIAS`` with the :ref:`alias <alias>` for the target deployment.
 


### PR DESCRIPTION
This PR closes #490. 
It adds a note admonition box just above the footer on each page for a cookie and privacy policy disclaimer.
This is a stop gap until we can get a redesign with a dismissible disclaimer that mimics the rest of the min.io website.

Also updates the Makefile to 
- add a statement that actually stores the `uname` value on MacOS 
- adds `make sync-minio-version` to `make stage` and `make publish` so that we capture/update the version variables with each build.

Also closes #484, a tiny issue that required correcting the restart command when upgrading MinIO.