### PR TITLE
Expand Operation Concepts and Create Administration Concepts doc

### DIFF
--- a/source/administration/concepts.rst
+++ b/source/administration/concepts.rst
@@ -1,0 +1,161 @@
+============================
+Core Administration Concepts
+============================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+The following core concepts are fundamental to the administration of MinIO deployments, including but not limited to object retention, encryption, and access management.
+
+What Is Object Storage?
+-----------------------
+
+.. _objects:
+
+An :ref:`object <objects>` is binary data, sometimes referred to as a Binary Large OBject (BLOB). 
+Blobs can be images, audio files, spreadsheets, or even binary executable code. 
+Object Storage platforms like MinIO provide dedicated tools and capabilities for storing, retrieving, and searching for blobs. 
+
+.. _buckets:
+
+MinIO Object Storage uses :ref:`buckets <buckets>` to organize objects. 
+A bucket is similar to a folder or directory in a filesystem, where each bucket can hold an arbitrary number of objects. 
+MinIO buckets provide the same functionality as AWS S3 buckets. 
+
+For example, consider an application that hosts a web blog. 
+The application needs to store a variety of blobs, including rich multimedia like videos and images. 
+
+MinIO supports multiple levels of nested directories through the feature of ``prefixing``  to support even the most dynamic object storage workloads.
+
+
+How does MinIO determine access to objects?
+-------------------------------------------
+
+MinIO requires the client perform both authentication and authorization for each new operation.
+:ref:`Identity and access management (IAM) <minio-authentication-and-identity-management>` is therefore a critical component of a MinIO configuration.
+
+*Authentication* verifies the identity of a connecting client. 
+MinIO requires clients to authenticate using :s3-api:`AWS Signature Version 4 protocol <sig-v4-authenticating-requests.html>` with support for the deprecated Signature Version 2 protocol. 
+Specifically, clients must present a valid access key and secret key to access any S3 or MinIO administrative API, such as ``PUT``, ``GET``, and ``DELETE`` operations. 
+
+MinIO then checks that authenticated users or clients have *authorization* to perform actions or use resources on the deployment. 
+MinIO uses :ref:`Policy-Based Access Control (PBAC) <minio-policy>`, where each policy describes one or more rules that outline the permissions of a user or group of users. 
+MinIO supports S3-specific :ref:`actions <minio-policy-actions>` and :ref:`conditions <minio-policy-conditions>` when creating policies. 
+
+By default, MinIO *denies* access to actions or resources not explicitly referenced in a user's assigned or inherited policies.
+
+MinIO provides an access management feature as part of the software.
+Alternatively, you can configure MinIO to authenticate with one of several external IAM providers using either :ref:`Active Directory/LDAP <minio-external-identity-management-ad-ldap>` or :ref:`OpenID/OIDC <minio-external-identity-management-openid>`.
+
+
+How does MinIO secure data?
+---------------------------
+
+MinIO supports methods that encode objects while on disk (encryption-at-rest) and during transition from one location to another (encryption-in-transit, or "in flight").
+When enabled, MinIO utilizes :ref:`server-side encryption <minio-encryption-overview>` to write objects in an encrypted state.
+To retrieve and read an encrypted object, the user must have appropriate access privileges and also provide the object's decryption key.
+
+MinIO supports **Transport Layer Security** (TLS) versions 1.2 and 1.3 encrypting objects.
+TLS replaces the previously used Secure Socket Layer (SSL) method that has since been deprecated.
+The TLS standard, maintained by the Internet Engineering Task Force (IETF), provides the standards used by internet communications to support encryption, authentication, and data integrity.
+
+The process of authenticating a user and verifying access to objects is known as the `TLS Handshake`.
+Once authenticated, TLS provides the cipher to encrypt and then decrypt the transfer of information from the server to the requesting client.
+
+MinIO supports several methods of :ref:`Server-Side Encryption <minio-encryption-overview>`.
+
+Can I organize objects in a folder structure within buckets?
+------------------------------------------------------------
+
+MinIO utilizes a :term:`prefix` method for each object that mimics a folder structure from traditional file systems.
+Prefixing involves prepending the name of an object with a fixed string.
+
+With prefixes, you do not manually create folders and subfolders.
+Instead, MinIO looks for the ``/`` character in the prefix of an object's name.
+Each ``/`` indicates a new folder or subfolder.
+
+Using the object's name and prefix, MinIO automatically generates a series of folders and subfolders for stored objects.
+When you use the same prefix string on multiple objects, MinIO identifies those as similar or grouped objects.
+
+For example, an object named ``/articles/john.doe/2022-01-02-MinIO-Object-Storage.md`` winds up in the ``articles`` bucket in a folder labeled ``john.doe``.
+
+A MinIO object store might resemble the following structure, with three buckets.
+MinIO automatically generates two folders in the ``articles`` bucket based on the prefixes for those objects.
+
+.. code-block:: text
+
+   / #root
+   /images/
+      2022-01-02-MinIO-Diagram.png
+      2022-01-03-MinIO-Advanced-Deployment.png
+      MinIO-Logo.png
+   /videos/
+      2022-01-04-MinIO-Interview.mp4
+   /articles/
+      /john.doe/
+         2022-01-02-MinIO-Object-Storage.md
+         2022-01-02-MinIO-Object-Storage-comments.json
+      /jane.doe/
+         2022-01-03-MinIO-Advanced-Deployment.png
+         2022-01-02-MinIO-Advanced-Deployment-comments.json
+         2022-01-04-MinIO-Interview.md
+
+
+How can I backup and restore objects on MinIO?
+----------------------------------------------
+
+MinIO provides two types of replication to copy an object, its versions, and its metadata from one location to another.
+You can configure replication at either the :ref:`bucket level <minio-bucket-replication>` or at the :ref:`site level <minio-site-replication-overview>`.
+
+- Bucket level replication can function as either one-way, active-passive replication (such as for archival purposes) or as two-way, active-active replication to keep two buckets in sync with each other.
+- Site level replication functions as two-way, active-active replication to keep multiple data locations (such as different geographic data centers) in sync with one another.
+
+Besides replication, MinIO provides a mirroring service.
+:mc:`mc mirror` copies only the actual object to any other S3 compatible data store, including other MinIO stores.
+However, versions and metadata do not back up with the :mc:`mc mirror` command.
+
+
+What tools does MinIO provide to manage objects based on speed and frequency of access?
+---------------------------------------------------------------------------------------
+
+:ref:`Tiering rules <minio-lifecycle-management-tiering>` allow frequently accessed objects to store on hot or warm storage, which is typically more expensive but provides better performance.
+
+Less frequently accessed objects can move to cold storage.
+Cold storage often exchanges slower performance for a cheaper price.
+
+
+How does MinIO protect objects from accidental overwrite or deletion?
+---------------------------------------------------------------------
+
+Locking
+~~~~~~~
+
+Locks, a Write Once Read Many (WORM) mechanism, prevent the deletion or modification of an object.
+When locked, MinIO retains the objects indefinitely until someone removes the lock or the lock expires.
+
+MinIO provides:
+
+- :ref:`legal holds <minio-object-locking-legalhold>` locks for indefinite retention by all users
+- :ref:`compliance holds <minio-object-locking-compliance>` for time-based restrictions for all users
+- :ref:`governing locks <minio-object-locking-governance>` for time-based rules for non-privileged users
+
+Versioning
+~~~~~~~~~~
+
+By default, objects written with the same name (including prefix) overwrite an existing object of the same name.
+MinIO provides a configuration option to create buckets with versioning enabled.
+:ref:`Versioning <minio-bucket-versioning>` provides access to various iterations of a uniquely named object as it changes over time. 
+When enabled, MinIO writes mutated objects to a different version than the original, allowing access to both the original object and the newer, changed object.
+
+Additional configurations on the MinIO bucket determine how long to retain older versions of each object in the bucket.
+
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   :glob:
+
+   /operations/concepts/*

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -24,22 +24,13 @@ Glossary
      
      See also: :term:`server logs`.
 
-   bitrot 
+   bit rot 
      Data corruption that occurrs without the user’s knowledge. 
-     Some common reasons for bitrot include:
      
-     - ageing drives
-     - current spikes
-     - bugs in disk firmware
-     - phantom writes
-     - misdirected reads/writes
-     - driver errors
-     - accidental overwrites
-     
-     MinIO combats bitrot with :term:`hashing` and :term:`erasure coding`.
+     MinIO combats bit rot with :term:`hashing` and :term:`erasure coding`.
 
-   bitrot healing
-     Objects corrupted due to bitrot automatically restore to a healed state at time of read.
+   bit rot healing
+     Objects corrupted due to bit rot automatically restore to a healed state at time of read.
      MinIO captures and heals corrupted objects on the fly with its :term:`hashing` implementation.
 
    bucket
@@ -103,7 +94,7 @@ Glossary
      The use of an algorithm to create a unique, fixed-length string (a `value`) to identify a piece of data.
    
    healing
-     Restoration of data from partial loss due to bitrot, drive failure, or site failure.
+     Restoration of data from partial loss due to bit rot, drive failure, or site failure.
 
    health diagnostics
      A suite of MinIO :ref:`API endpoints <minio-healthcheck-api>` available to check whether a server is
@@ -192,7 +183,7 @@ Glossary
      
      - lifecycle management rules requiring object transition
      - bucket or site replication status
-     - object :term:`bitrot` and healing
+     - object :term:`bit rot` and healing
 
    self signed certificates
      A self-signed certificate is one created by, issued by, and signed by the company or developer responsible for the content the certificate secures.
@@ -263,3 +254,7 @@ Glossary
    webhook
      A :ref:`webhook <minio-bucket-notifications-publish-webhook>` is a method for altering the behavior of a web page or web application with a custom callback.
      The format is typically :abbr:`JSON (JavaScript Object Notation)` sent as an HTTP POST request.
+
+   WORM
+     Write Once Read Many (WORM) is a data retention methodology that functions as part of object locking.
+     Many requests can retrieve can view a WORM-locked object (``read many``), but no write requests can change the object (``write once``).

--- a/source/index.rst
+++ b/source/index.rst
@@ -107,6 +107,7 @@ without validating their usage do so at their own risk.
       /administration/identity-access-management
       /administration/server-side-encryption
       /administration/bucket-replication
+      /administration/concepts
       /developers/minio-drivers
       /developers/security-token-service
       /reference/minio-mc
@@ -136,6 +137,7 @@ without validating their usage do so at their own risk.
       /administration/identity-access-management
       /administration/server-side-encryption
       /administration/bucket-replication
+      /administration/concepts
       /developers/minio-drivers
       /developers/security-token-service
       /reference/minio-mc

--- a/source/operations/concepts/erasure-coding.rst
+++ b/source/operations/concepts/erasure-coding.rst
@@ -10,35 +10,24 @@ Erasure Coding
    :local:
    :depth: 2
 
-MinIO Erasure Coding is a data redundancy and availability feature that allows
-MinIO deployments to automatically reconstruct objects on-the-fly despite the
-loss of multiple drives or nodes in the cluster. Erasure Coding provides
-object-level healing with less overhead than adjacent technologies such as
-RAID or replication. 
+MinIO Erasure Coding is a data redundancy and availability feature that allows MinIO deployments to automatically reconstruct objects on-the-fly despite the loss of multiple drives or nodes in the cluster. 
+Erasure Coding provides object-level healing with significantly less overhead than adjacent technologies such as RAID or replication. 
 
-MinIO splits each new object into data and parity blocks, where parity blocks
-support reconstruction of missing or corrupted data blocks. MinIO writes these
-blocks to a single :ref:`erasure set <minio-ec-erasure-set>` in the deployment.
-Since erasure set drives are striped across the deployment, a given node 
-typically contains only a portion of data or parity blocks for each object.
-MinIO can therefore tolerate the loss of multiple drives or nodes in the
-deployment depending on the configured parity and deployment topology.
+MinIO splits each new object into data and parity blocks, where parity blocks support reconstruction of missing or corrupted data blocks. 
+MinIO writes these blocks to a single :ref:`erasure set <minio-ec-erasure-set>` in the deployment.
+Since erasure set drives are striped across the server pool, a given node contains only a portion of data or parity blocks for each object.
+MinIO can therefore tolerate the loss of multiple drives or nodes in the deployment depending on the configured parity and deployment topology.
 
 .. image:: /images/erasure-code.jpg
    :width: 600px
    :alt: MinIO Erasure Coding example
    :align: center
 
-At maximum parity, MinIO can tolerate the loss of up to half the drives per
-erasure set (``N/2-1``) and still perform read and write operations. MinIO
-defaults to 4 parity blocks per object with tolerance for the loss of 4 drives
-per erasure set. For more complete information on selecting erasure code parity,
-see :ref:`minio-ec-parity`.
+At maximum parity, MinIO can tolerate the loss of up to half the drives per erasure set (:math:`(N / 2) - 1`) and still perform read and write operations. 
+MinIO defaults to 4 parity blocks per object with tolerance for the loss of 4 drives per erasure set. 
+For more complete information on selecting erasure code parity, see :ref:`minio-ec-parity`.
 
-Use the MinIO `Erasure Code Calculator 
-<https://min.io/product/erasure-code-calculator?ref=docs>`__ when planning and
-designing your MinIO deployment to explore the effect of erasure code settings
-on your intended topology.
+Use the MinIO `Erasure Code Calculator <https://min.io/product/erasure-code-calculator?ref=docs>`__ when planning and designing your MinIO deployment to explore the effect of erasure code settings on your intended topology.
 
 Zero-Parity Deployments
 -----------------------
@@ -53,50 +42,45 @@ Zero-parity deployments depend on the underlying storage for resiliency and avai
 Erasure Sets
 ------------
 
-An *Erasure Set* is a set of drives in a MinIO deployment that support Erasure
-Coding. MinIO evenly distributes object data and parity blocks among the drives
-in the Erasure Set. MinIO randomly and uniformly distributes the data and parity
-blocks across drives in the erasure set with *no overlap*. Each unique object
-has no more than one data or parity block per drive in the set.
+An *Erasure Set* is a set of drives in a MinIO deployment that support Erasure Coding. 
+MinIO evenly distributes object data and parity blocks among the drives in the Erasure Set. 
+MinIO randomly and uniformly distributes the data and parity blocks across drives in the erasure set with *no overlap*. 
+Each unique object has no more than one data or parity block per drive in the set.
 
-MinIO calculates the number and size of *Erasure Sets* by dividing the total
-number of drives in the :ref:`Server Pool <minio-intro-server-pool>` into sets
-consisting of between 4 and 16 drives each. 
+MinIO calculates the number and size of *Erasure Sets* by dividing the total number of drives in the :ref:`Server Pool <minio-intro-server-pool>` into sets consisting of between 4 and 16 drives each. 
 
-Use the MinIO 
-`Erasure Coding Calculator <https://min.io/product/erasure-code-calculator>`__
-to determine the optimal erasure set size for your preferred MinIO topology.
+For clusters, pools, or deployments with more than 16 drives, MinIO divides the drives into multiple erasure sets of the same number of drives.
+For this reason, the total number of drives in a deployment must be divisible evenly by a number between 4 and 16.
+
+For example, 20 drives are divided into two erasure sets of 10 drives each.
+28 drives are divided into 2 erasure sets of 14 drives each.
+40 drives are divided into 4 erasure sets of 10 drives each.
+
+Because numbers such as 17, 19, or 34 cannot be evenly divided by any number between 2 and 16, you cannot have a deployment with such a number of drives.
+Add or remove drives to return to an allowable number of drives.
+
+Use the MinIO `Erasure Coding Calculator <https://min.io/product/erasure-code-calculator>`__ to determine the optimal erasure set size for your preferred MinIO topology.
 
 .. _minio-ec-parity:
 
 Erasure Code Parity (``EC:N``)
 ------------------------------
 
-MinIO uses a Reed-Solomon algorithm to split objects into data and parity blocks
-based on the :ref:`Erasure Set <minio-ec-erasure-set>` size in the deployment.
-For a given erasure set of size ``M``, MinIO splits objects into ``N`` parity
-blocks and ``M-N`` data blocks. 
+MinIO uses a Reed-Solomon algorithm to split objects into data and parity blocks based on the :ref:`Erasure Set <minio-ec-erasure-set>` size in the deployment.
+For a given erasure set of size ``M``, MinIO splits objects into ``N`` parity blocks and ``M-N`` data blocks. 
 
-MinIO uses the ``EC:N`` notation to refer to the number of parity blocks (``N``)
-in the deployment. MinIO defaults to ``EC:4`` or 4 parity blocks per object.
-MinIO uses the same ``EC:N`` value for all erasure sets and
-:ref:`server pools <minio-intro-server-pool>` in the deployment.
+MinIO uses the ``EC:N`` notation to refer to the number of parity blocks (``N``) in the deployment. 
+MinIO defaults to ``EC:4`` or 4 parity blocks per object. 
+MinIO uses the same ``EC:N`` value for all erasure sets and :ref:`server pools <minio-intro-server-pool>` in the deployment.
 
-MinIO can tolerate the loss of up to ``N`` drives per erasure set and 
-continue performing read and write operations ("quorum"). If ``N`` is equal
-to exactly 1/2 the drives in the erasure set, MinIO write quorum requires
-``N+1`` drives to avoid data inconsistency ("split-brain").
+MinIO can tolerate the loss of up to ``N`` drives per erasure set and continue performing read and write operations ("quorum"). 
+If ``N`` is equal to exactly 1/2 the drives in the erasure set, MinIO write quorum requires :math:`N + 1` drives to avoid data inconsistency ("split-brain").
 
-Setting the parity for a deployment is a balance between availability
-and total usable storage. Higher parity values increase resiliency to drive
-or node failure at the cost of usable storage, while lower parity provides
-maximum storage with reduced tolerance for drive/node failures. 
-Use the MinIO `Erasure Code Calculator 
-<https://min.io/product/erasure-code-calculator?ref=docs>`__ to explore the
-effect of parity on your planned cluster deployment.
+Setting the parity for a deployment is a balance between availability and total usable storage. 
+Higher parity values increase resiliency to drive or node failure at the cost of usable storage, while lower parity provides maximum storage with reduced tolerance for drive/node failures. 
+Use the MinIO `Erasure Code Calculator <https://min.io/product/erasure-code-calculator?ref=docs>`__ to explore the effect of parity on your planned cluster deployment.
 
-The following table lists the outcome of varying erasure code parity levels on
-a MinIO deployment consisting of 1 node and 16 1TB drives:
+The following table lists the outcome of varying erasure code parity levels on a MinIO deployment consisting of 1 node and 16 1TB drives:
 
 .. list-table:: Outcome of Parity Settings on a 16 Drive MinIO Cluster
    :header-rows: 1
@@ -132,14 +116,14 @@ a MinIO deployment consisting of 1 node and 16 1TB drives:
 Storage Classes
 ~~~~~~~~~~~~~~~
 
-MinIO supports storage classes with Erasure Coding to allow applications to
-specify per-object :ref:`parity <minio-ec-parity>`. Each storage class specifies
-a ``EC:N`` parity setting to apply to objects created with that class. 
+MinIO supports redundancy storage classes with Erasure Coding to allow applications to specify per-object :ref:`parity <minio-ec-parity>`. 
+Each storage class specifies a ``EC:N`` parity setting to apply to objects created with that class. 
 
-MinIO storage classes are *distinct* from Amazon Web Services 
-:s3-docs:`storage classes <storage-class-intro.html>`. MinIO storage classes
-define *parity settings per object*, while AWS storage classes define *storage
-tiers per object*. 
+MinIO storage classes for erasure coding are *distinct* from Amazon Web Services :s3-docs:`storage classes <storage-class-intro.html>` used for tiering. 
+MinIO erasure coding storage classes define *parity settings per object*, while AWS storage classes define *storage tiers per object*. 
+
+.. note:: 
+   For transitioning objects between storage classes for tiering purposes in MinIO, refer to the documentation on :ref:`lifecycle management <minio-lifecycle-management-tiering>`.
 
 MinIO provides the following two storage classes:
 
@@ -148,8 +132,7 @@ MinIO provides the following two storage classes:
    .. tab-item:: STANDARD
 
       The ``STANDARD`` storage class is the default class for all objects.
-      MinIO sets the ``STANDARD`` parity based on the number of volumes
-      in the Erasure Set:
+      MinIO sets the ``STANDARD`` parity based on the number of volumes in the Erasure Set:
 
       .. list-table::
          :header-rows: 1
@@ -171,67 +154,51 @@ MinIO provides the following two storage classes:
       You can override the default ``STANDARD`` parity using either:
 
       - The :envvar:`MINIO_STORAGE_CLASS_STANDARD` environment variable, *or*
-      - The :mc:`mc admin config` command to modify the
-        ``storage_class.standard`` configuration setting.
+      - The :mc:`mc admin config` command to modify the ``storage_class.standard`` configuration setting.
 
-      The maximum value is half of the total drives in the
-      :ref:`Erasure Set <minio-ec-erasure-set>`. The minimum value is ``2``.
+      The maximum value is half of the total drives in the :ref:`Erasure Set <minio-ec-erasure-set>`. 
+      The minimum value is ``2``.
 
-      ``STANDARD`` parity *must* be greater than or equal to
-      ``REDUCED_REDUNDANCY``. If ``REDUCED_REDUNDANCY`` is unset, ``STANDARD``
-      parity *must* be greater than 2.
+      ``STANDARD`` parity *must* be greater than or equal to ``REDUCED_REDUNDANCY``. 
+      If ``REDUCED_REDUNDANCY`` is unset, ``STANDARD`` parity *must* be greater than 2.
 
    .. tab-item:: REDUCED_REDUNDANCY
 
-      The ``REDUCED_REDUNDANCY`` storage class allows creating objects with
-      lower parity than ``STANDARD``. ``REDUCED_REDUNDANCY`` requires 
-      *at least* 5 drives in the MinIO deployment. 
+      The ``REDUCED_REDUNDANCY`` storage class allows creating objects with lower parity than ``STANDARD``. 
+      ``REDUCED_REDUNDANCY`` requires *at least* 5 drives in the MinIO deployment. 
       
       MinIO sets the ``REDUCED_REDUNDANCY`` parity to ``EC:2`` by default.
-      You can override ``REDUCED_REDUNDANCY`` storage class parity using
-      either:
+      You can override ``REDUCED_REDUNDANCY`` storage class parity using either:
 
       - The :envvar:`MINIO_STORAGE_CLASS_RRS` environment variable, *or*
-      - The :mc:`mc admin config` command to modify the 
-        ``storage_class.rrs`` configuration setting.
+      - The :mc:`mc admin config` command to modify the ``storage_class.rrs`` configuration setting.
 
-      ``REDUCED_REDUNDANCY`` parity *must* be less than or equal to
-      ``STANDARD``.
+      ``REDUCED_REDUNDANCY`` parity *must* be less than or equal to ``STANDARD``.
 
-MinIO references the ``x-amz-storage-class`` header in request metadata for
-determining which storage class to assign an object. The specific syntax
-or method for setting headers depends on your preferred method for
-interfacing with the MinIO server.
+MinIO references the ``x-amz-storage-class`` header in request metadata for determining which storage class to assign an object. 
+The specific syntax or method for setting headers depends on your preferred method for interfacing with the MinIO server.
 
-- For the :mc:`mc` command line tool, certain commands include a specific
-  option for setting the storage class. For example, the :mc:`mc cp` command
-  has the :mc-cmd:`~mc cp storage-class` option for specifying the
-  storage class to assign to the object being copied.
+- For the :mc:`mc` command line tool, certain commands include a specific option for setting the storage class. 
+  For example, the :mc:`mc cp` command has the :mc-cmd:`~mc cp storage-class` option for specifying the storage class to assign to the object being copied.
 
-- For MinIO SDKs, the ``S3Client`` object has specific methods for setting
-  request headers. For example, the ``minio-go`` SDK ``S3Client.PutObject``
-  method takes a ``PutObjectOptions`` data structure as a parameter.
-  The ``PutObjectOptions`` data structure includes the ``StorageClass``
-  option for specifying the storage class to assign to the object being
-  created.
+- For MinIO SDKs, the ``S3Client`` object has specific methods for setting request headers. 
+  For example, the ``minio-go`` SDK ``S3Client.PutObject`` method takes a ``PutObjectOptions`` data structure as a parameter.
+  The ``PutObjectOptions`` data structure includes the ``StorageClass`` option for specifying the storage class to assign to the object being   created.
 
 
 .. _minio-ec-bitrot-protection:
 
-BitRot Protection
------------------
+Bit Rot Protection
+------------------
 
 .. TODO- ReWrite w/ more detail.
 
-Silent data corruption or bitrot is a serious problem faced by disk drives
-resulting in data getting corrupted without the user’s knowledge. The reasons
-are manifold (ageing drives, current spikes, bugs in disk firmware, phantom
-writes, misdirected reads/writes, driver errors, accidental overwrites) but the
-result is the same - compromised data.
+Silent data corruption or bit rot is a serious problem faced by disk drives resulting in data getting corrupted without the user’s knowledge. 
+The corruption of data occurs when the electrical charge on a portion of the disk disperses or changes with no notification to or input from the user.
+Many events can lead to such a silent corruption of stored data.
+For example, ageing drives, current spikes, bugs in disk firmware, phantom writes, misdirected reads/writes, driver errors, accidental overwrites, or a random cosmic ray can each lead to a bit change.
+Whatever the cause, the result is the same - compromised data.
 
-MinIO’s optimized implementation of the HighwayHash algorithm ensures that it
-will never read corrupted data - it captures and heals corrupted objects on the
-fly. Integrity is ensured from end to end by computing a hash on READ and
-verifying it on WRITE from the application, across the network and to the
-memory/drive. The implementation is designed for speed and can achieve hashing
-speeds over 10 GB/sec on a single core on Intel CPUs.
+MinIO’s optimized implementation of the :minio-git:`HighwayHash algorithm <highwayhash/blob/master/README.md>` ensures that it captures and heals corrupted objects on the fly. 
+Integrity is ensured from end to end by computing a hash on READ and verifying it on WRITE from the application, across the network, and to the memory or drive. 
+The implementation is designed for speed and can achieve hashing speeds over 10 GB/sec on a single core on Intel CPUs.

--- a/source/operations/install-deploy-manage/deploy-minio-single-node-multi-drive.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-single-node-multi-drive.rst
@@ -15,7 +15,7 @@ This topology provides increased drive-level reliability and failover protection
 
 .. cond:: linux or macos or windows
 
-   For production environments, MinIO strongly recommends deploying  with the :ref:`Multi-Node Multi-Drive (Distributed) <minio-mnmd>` topology.
+   For production environments, MinIO strongly recommends deploying with the :ref:`Multi-Node Multi-Drive (Distributed) <minio-mnmd>` topology.
 
 .. cond:: container
 

--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -22,7 +22,7 @@ corrupted and heals those objects.
 
 :mc:`mc admin heal` is resource intensive and typically not required even
 after disk failures or corruption events. Instead, MinIO automatically heals
-objects damaged by silent bitrot corruption, disk failure, or other issues on
+objects damaged by silent bit rot corruption, disk failure, or other issues on
 POST/GET. MinIO also performs periodic background object healing.
 
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only


### PR DESCRIPTION
This adds additional concept topics to the Operational Concepts page.
This splits off some of the existing topics and creates and administration concepts page as well, and expands the subjects covered in that page.

Adds the administration concept page to the toctree on the index page.

Partially addresses four tasks in #492.