### PR TITLE
Update syntax highlight color

### DIFF
--- a/source/_static/scss/includes/_reset.scss
+++ b/source/_static/scss/includes/_reset.scss
@@ -141,6 +141,11 @@ a {
     .w {
         text-decoration: none;
     }
+
+    .s1,
+    .s2 {
+        color: #3f7a08;
+    }
 }
 
 pre {


### PR DESCRIPTION
**Issue**: Green syntax is too light in the dark theme.
<img width="574" alt="Screenshot 2022-08-23 at 17 30 29" src="https://user-images.githubusercontent.com/13393018/186170955-cd0be168-b9bc-43d2-8e73-dde9d72648d2.png">

**Fix** 
<img width="574" alt="Screenshot 2022-08-23 at 17 30 41" src="https://user-images.githubusercontent.com/13393018/186170989-f8e2bee8-6655-443b-a2b6-5a92a6119fa1.png">
