### PR TITLE
Updating global flags to point to the list in the minio-mc page

### DIFF
--- a/source/developers/javascript/API.md
+++ b/source/developers/javascript/API.md
@@ -53,6 +53,7 @@ var s3Client = new Minio.Client({
 | [`setBucketReplication`](#setBucketReplication)       |                                                     |                                               |                                                               |                                                       |     |
 | [`getBucketReplication`](#getBucketReplication)       |                                                     |                                               |                                                               |                                                       |     |
 | [`removeBucketReplication`](#removeBucketReplication) |                                                     |                                               |                                                               |                                                       |     |
+
 ## 1.  Constructor
 
 <a name="MinioClient_endpoint"></a>

--- a/source/includes/common-minio-mc.rst
+++ b/source/includes/common-minio-mc.rst
@@ -1,23 +1,8 @@
 .. start-minio-mc-globals
 
-.. mc-cmd:: --debug
-   :optional:
-   
-   Enables verbose output to the console.
+This command supports any of the :ref:`global flags <minio-mc-global-options>`.
 
-   For example:
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc --debug COMMAND
-
-.. mc-cmd:: --config-dir
-   :optional:
-
-   The path to a ``JSON`` formatted configuration file that
-   :program:`mc` uses for storing data. See :ref:`mc-configuration` for
-   more information on how :program:`mc` uses the configuration file.
+.. end-minio-mc-globals
 
 .. start-minio-mc-json-globals
 
@@ -35,36 +20,6 @@
       mc --JSON COMMAND
 
 .. end-minio-mc-json-globals
-
-.. mc-cmd:: --no-color
-   :optional:
-
-   Disables the built-in color theme for console output. Useful for dumb
-   terminals.
-
-.. mc-cmd:: --quiet
-   :optional:
-
-   Suppresses console output. 
-
-.. mc-cmd:: --insecure
-   :optional:
-
-   Disables TLS/SSL certificate verification. Allows TLS connectivity to 
-   servers with invalid certificates. Exercise caution when using this
-   option against untrusted S3 hosts.
-
-.. mc-cmd:: --version
-   :optional:   
-
-   Displays the current version of :mc-cmd:`mc`. 
-
-.. mc-cmd:: --help
-   :optional:
-
-   Displays a summary of command usage on the terminal.
-
-.. end-minio-mc-globals
 
 .. start-minio-mc-no-flags
 

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -433,6 +433,11 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
 
    Displays the current version of :mc-cmd:`mc`. 
 
+.. mc-cmd:: --help
+   :optional:
+
+   Displays a summary of command usage on the terminal.
+
 .. toctree::
    :titlesonly:
    :hidden:


### PR DESCRIPTION
Closes #515 .

Removes the common-includes global flags list and points all `mc` command pages to the list at reference/minio-mc.