### PR TITLE
Nginx Config

### DIFF
--- a/redirects/container.conf
+++ b/redirects/container.conf
@@ -1,0 +1,3 @@
+        location /minio/baremetal/quickstart/container.html {
+             return 301 /docs/container/operations/index.html
+        }

--- a/redirects/general.conf
+++ b/redirects/general.conf
@@ -1,0 +1,11 @@
+        location /docs/minio-gateway-for-nas.html {
+             return 301 https://blog.min.io/deprecation-of-the-minio-gateway?ref=docs;
+        }
+
+        location /docs/minio-gateway-for-s3.html {
+             return 301 https://blog.min.io/deprecation-of-the-minio-gateway?ref=docs;
+        }
+
+        location /docs/minio-vault-legacy.html {
+             return 301 /docs/linux/operations/server-side-encryption/configure-minio-kes-hashicorp.html;
+        }

--- a/redirects/k8s.conf
+++ b/redirects/k8s.conf
@@ -1,0 +1,70 @@
+# This file contains all redirects for the Kubernetes Documentation for MinIO
+# This includes redirecting links from legacy docs and the Docs V1 projects
+
+       # Use this as a template
+    #  location <path> {
+    #        return 301 /docs/k8s/<filepath>.html;
+    #  }
+
+
+        location /minio/baremetal/quickstart/k8s.html {
+             return 301 /docs/k8s/operations/index.html;
+        }
+
+       location /minio/k8s/deployment/deploy-minio-operator.html {
+             return 301 /docs/k8s/operations/installation.html;
+       }
+
+
+       location /minio/k8s/tenant-management/deploy-minio-tenant.html {
+             return 301 /docs/k8s/operations/install-deploy-manage/deploy-minio-tenant.html;
+       }
+
+       location /minio/k8s/core-concepts/core-concepts.html {
+             return /docs/k8s/operations/concepts.html;
+       }
+
+       location /minio/k8s/tenant-management/manage-minio-tenant.html {
+             return /docs/k8s/operations/deploy-manage-tenants.html;
+       }
+
+       location /minio/k8s/tutorials/user-management.html {
+             return /docs/k8s/administration/identity-access-management/minio-user-management.html;
+       }
+
+       location /minio/k8s/tutorials/group-management.html {
+             return /docs/k8s/administration/identity-access-management/minio-group-management.html;
+       }
+
+       location /minio/k8s/tutorials/policy-management.html {
+             return /docs/k8s/administration/identity-access-management/policy-based-access-control.html;
+       }
+
+       location /minio/k8s/reference/production-recommendations.html {
+             return /docs/k8s/operations/checklists.html;
+       }
+
+       location /minio/k8s/operator-console/operator-console.html {
+             return docs/k8s/operations/install-deploy-manage/minio-operator-console.html;
+       }
+
+
+       # OpenShift Specific 
+       # Will need to change these when we have dedicated OS platform docs
+       # -----------------------------------------------------------------
+
+       location /minio/k8s/openshift/deploy-minio-on-openshift.html {
+             return 301 /docs/k8s/operations/installation.html;
+       }
+
+       location /minio/k8s/openshift/deploy-minio-tenant.html {
+             return 301 /docs/k8s/operations/install-deploy-manage/deploy-minio-tenant.html;
+       }
+
+       # -----------------------------------------------------------------
+
+        # This one *must* be last in the order so as to not override other specific pages
+
+        location /minio/k8s/* {
+             return 301 /docs/k8s/index.html;
+        }

--- a/redirects/linux.conf
+++ b/redirects/linux.conf
@@ -1,0 +1,344 @@
+        # Top level redirects from NuDocs 1 to NuDocs 2
+        # =============================================
+
+        location /minio/baremetal/introduction/minio-overview.html {
+             return 301 /docs/linux/operations/concepts.html;
+        }
+
+        location /minio/baremetal/concepts/erasure-coding.html {
+             return 301 /docs/linux/operations/concepts/erasure-coding.html;
+        }
+
+        location /minio/baremetal/quickstart/linux.html {
+             return 301 /docs/linux/operations/index.html;
+        }
+
+
+        # Deploy/Manage Redirects from NuDocs 1 to NuDocs 2
+        # =================================================
+
+        location /minio/baremetal/installation/deployment-and-management.html {
+             return 301 /docs/linux/operations/installation.html;
+        }
+
+        location /minio/baremetal/installation/deploy-minio-distributed.html {
+             return 301 /docs/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html;
+        }
+
+        location /minio/baremetal/installation/deploy-minio-single-node-single-drive.html {
+             return 301 /docs/linux/operations/install-deploy-manage/deploy-minio-single-node-single-drive.html;
+        }
+
+        location /minio/baremetal/installation/expand-minio-distributed.html {
+             return 301 /docs/linux/operations/install-deploy-manage/expand-minio-deployment.html;
+        }
+
+        location /minio/baremetal/installation/upgrade-minio.html {
+             return 301 /docs/linux/operations/install-deploy-manage/upgrade-minio-deployment.html;
+        }
+
+        location /minio/baremetal/installation/restore-minio.html {
+             return 301 /docs/linux/operations/data-recovery.html;
+        }
+
+        location /minio/baremetal/installation/decommission-pool.html {
+             return 301 /docs/linux/operations/install-deploy-manage/decommission-server-pool.html;
+        }        
+
+
+        # Security Redirects from NuDocs 1 to NuDocs 2
+        # ============================================
+
+        location /minio/baremetal/security/IAM/identity-access-management.html {
+             return 301 /docs/linux/administration/identity-access-management.html;
+        }
+
+        location /minio/baremetal/security/security-overview.html {
+             return 301 /docs/linux/operations/server-side-encryption.html;
+        }
+
+        location /minio/baremetal/security/encryption/encryption-key-management.html {
+             return 301 /docs/linux/operations/server-side-encryption.html;
+        }
+
+        location /minio/baremetal/security/minio-identity-management/basic-authentication-with-minio-identity-provider.html {
+             return 301 /docs/linux/administration/identity-access-management/minio-identity-management.html;
+        }
+
+        location /minio/baremetal/security/minio-identity-management/user-management.html {
+             return 301 /docs/linux/administration/identity-access-management/minio-user-management.html;
+        }
+
+        location /minio/baremetal/security/minio-identity-management/group-management.html {
+             return 301 /docs/linux/administration/identity-access-management/minio-group-management.html;
+        }
+
+        location /minio/baremetal/security/minio-identity-management/policy-based-access-control.html {
+             return 301 /docs/linux/administration/identity-access-management/policy-based-access-control.html;
+        }
+
+        location /minio/baremetal/security/openid-external-identity-management/external-authentication-with-openid-identity-provider.html {
+             return 301 /docs/linux/administration/identity-access-management/oidc-access-management.html;
+        }
+
+        location /minio/baremetal/security/openid-external-identity-management/configure-openid-external-identity-management.html {
+             return 301 /docs/linux/operations/external-iam/configure-openid-external-identity-management.html;
+        }
+
+        location /minio/baremetal/security/openid-external-identity-management/AssumeRoleWithWebIdentity.html {
+             return 301 /docs/linux/developers/security-token-service/AssumeRoleWithWebIdentity.html;
+        }
+
+        location /minio/baremetal/security/ad-ldap-external-identity-management/external-authentication-with-ad-ldap-identity-provider.html {
+             return 301 /docs/linux/administration/identity-access-management/ad-ldap-access-management.html;
+        }
+
+        location /minio/baremetal/security/ad-ldap-external-identity-management/configure-openid-external-identity-management.html {
+             return 301 /docs/linux/operations/external-iam/configure-ad-ldap-external-identity-management.html;
+        }
+        
+        location /minio/baremetal/security/ad-ldap-external-identity-management/AssumeRoleWithWebIdentity.html {
+             return 301 /docs/linux/developers/security-token-service/AssumeRoleWithLDAPIdentity.html;
+        }
+
+        location /minio/baremetal/security/encryption-overview.html {
+             return 301 /docs/linux/operations/server-side-encryption.html;
+        }
+
+        location /minio/baremetal/security/server-side-encryption/minio-server-side-encryption.html {
+             return 301 /docs/linux/operations/server-side-encryption.html;
+        }
+
+        location /minio/baremetal/security/server-side-encryption/configure-minio-kes-hashicorp.html {
+             return 301 /docs/linux/operations/server-side-encryption/configure-minio-kes-hashicorp.html;
+        }
+
+        location /minio/baremetal/security/server-side-encryption/configure-minio-kes-aws.html {
+             return 301 /docs/linux/operations/server-side-encryption/configure-minio-kes-aws.html;
+        }
+
+        location /minio/baremetal/security/server-side-encryption/configure-minio-kes-gcp.html {
+             return 301 /docs/linux/operations/server-side-encryption/configure-minio-kes-gcp.html;
+        }
+
+        location /minio/baremetal/security/server-side-encryption/configure-minio-kes-azure.html {
+             return 301 /docs/linux/operations/server-side-encryption/configure-minio-kes-azure.html;
+        }
+
+        location /minio/baremetal/security/server-side-encryption/server-side-encryption-sse-kms.html {
+             return 301 /docs/linux/operations/server-side-encryption/server-side-encryption-sse-kms.html;
+        }
+
+        location /minio/baremetal/security/server-side-encryption/server-side-encryption-sse-s3.html {
+             return 301 /docs/linux/operations/server-side-encryption/server-side-encryption-sse-s3.html;
+        }
+
+        location /minio/baremetal/security/server-side-encryption/server-side-encryption-sse-c.html {
+             return 301 /docs/linux/operations/server-side-encryption/server-side-encryption-sse-c.html;
+        }
+
+        location /minio/baremetal/security/network-encryption/minio-tls.html {
+             return 301 /docs/linux/operations/network-encryption.html;
+        }
+
+        # Object Management Redirects from NuDocs 1 to NuDocs 2
+        # =====================================================
+
+        location /minio/baremetal/object-retention/minio-object-retention.html {
+             return 301 /docs/linux/administration/object-management.html;
+        }
+
+        location /minio/baremetal/object-retention/bucket-versioning.html {
+             return 301 /docs/linux/administration/object-management/object-versioning.html;
+        }
+
+        location /minio/baremetal/object-retention/minio-object-locking.html {
+             return 301 /docs/linux/administration/object-management/object-retention.html;
+        }
+
+        location /minio/baremetal/lifecycle-management/lifecycle-management-overview.html {
+             return 301 /docs/linux/administration/object-management/object-lifecycle-management.html;
+        }
+
+        location /minio/baremetal/lifecycle-management/transition-objects-to-s3.html {
+             return 301 /docs/linux/administration/object-management/transition-objects-to-s3.html;
+        }
+
+        location /minio/baremetal/lifecycle-management/transition-objects-to-gcs.html {
+             return 301 /docs/linux/administration/object-management/transition-objects-to-gcs.html;
+        }
+
+        location /minio/baremetal/lifecycle-management/transition-objects-to-azure.html {
+             return 301 /docs/linux/administration/object-management/transition-objects-to-azure.html;
+        }
+
+        # Replication Redirects from NuDocs 1 to NuDocs 2
+        # ===============================================
+
+        location /minio/baremetal/lifecycle-management/create-lifecycle-management-expiration-rule.html {
+             return 301 /docs/linux/administration/object-management/create-lifecycle-management-expiration-rule.html;
+        }
+
+        location /minio/baremetal/replication/replication-overview.html {
+             return 301 /docs/linux/administration/bucket-replication.html;
+        }
+
+        location /minio/baremetal/bucket-replication-overview.html {
+             return 301 /docs/linux/administration/bucket-replication.html;
+        }
+
+        location /minio/baremetal/replication/enable-server-side-one-way-bucket-replication.html {
+             return 301 /docs/linux/administration/bucket-replication/enable-server-side-one-way-bucket-replication.html;
+        }
+
+        location /minio/baremetal/replication/enable-server-side-two-way-bucket-replication.html {
+             return 301 /docs/linux/administration/bucket-replication/enable-server-side-two-way-bucket-replication.html;
+        }
+
+        location /minio/baremetal/replication/enable-server-side-multi-site-bucket-replication.html {
+             return 301 /docs/linux/administration/bucket-replication/enable-server-side-one-way-bucket-replication.html;
+        }
+
+        location /minio/baremetal/replication/server-side-replication-resynchronize-remote.html {
+             return 301 /docs/linux/administration/bucket-replication/server-side-replication-resynchronize-remote.html;
+        }
+
+        location /minio/baremetal/replication/site-replication-overview.html {
+             return 301 /docs/linux/operations/install-deploy-manage/multi-site-replication.html;
+        }
+
+        # Monitoring Redirects from NuDocs 1 to NuDocs 2
+        # ==============================================
+
+        location /minio/baremetal/monitoring/monitoring-overview.html {
+             return 301 /docs/linux/operations/monitoring.html;
+        }
+
+        location /minio/baremetal/monitoring/metrics-alerts/minio-metrics-and-alerts.html {
+             return 301 /docs/linux/operations/monitoring.html;
+        }
+
+        location /minio/baremetal/monitoring/metrics-alerts/collect-minio-metrics-using-prometheus.html {
+             return 301 /docs/linux/operations/monitoring/collect-minio-metrics-using-prometheus.html;
+        }
+
+        location /minio/baremetal/monitoring/logging/minio-logging.html { 
+             return 301 /docs/linux/monitoring/minio-logging.html;
+        }
+
+        location /minio/baremetal/monitoring/healthcheck-probe.html {
+             return 301 /docs/linux/operations/monitoring/healthcheck-probe.html;
+        }
+
+        # Bucket Notification Redirects from NuDocs 1 to NuDocs 2
+        # =======================================================
+
+        location /minio/baremetal/monitoring/bucket-notifications/bucket-notifications.html {
+             return 301 /docs/linux/administration/monitoring.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-amqp.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-amqp.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-mqtt.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-mqtt.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-nats.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-nats.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-nsq.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-nsq.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-elasticsearch.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-elasticsearch.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-kafka.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-kafka.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-mysql.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-mysql.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-postgresql.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-postgresql.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-redis.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-redis.html;
+        }
+
+        location /minio/baremetal/monitoring/bucket-notifications/publish-events-to-webhook.html {
+             return 301 /docs/linux/administration/monitoring/publish-events-to-webhook.html;
+        }
+
+        
+
+
+        # Reference Redirects from NuDocs 1 to NuDocs 2
+        # =============================================
+
+
+        location /minio/baremetal/reference/minio-mc.html {
+             return 301 /docs/linux/reference/minio-mc.html;
+        }
+
+        location /minio/baremetal/reference/minio-mc/ {
+             rewrite /minio/baremetal/reference/minio-mc/(.*) /docs/linux/reference/minio-mc/$1 permanent;
+        }
+
+        location /minio/baremetal/reference/minio-mc-admin.html {
+             return 301 /docs/linux/reference/minio-mc.html;
+        }
+
+        location /minio/baremetal/reference/minio-mc/ {
+             rewrite /minio/baremetal/reference/minio-mc-admin/(.*) /docs/linux/reference/minio-mc-admin/$1 permanent;
+        }
+
+        location /minio/baremetal/reference/minio-server.html {
+             return 301 /docs/linux/reference/minio-server.html;
+        }
+
+        location /minio/baremetal/console/minio-console.html {
+             return 301 /docs/linux/administration/minio-console.html;
+        }
+
+        location /minio/baremetal/sdk/minio-drivers.html {
+             return 301 /docs/linux/developers/minio-drivers.html;
+        }
+
+        location /minio/baremetal/sdk/java/minio-java.html {
+             return 301 /docs/linux/developers/java/minio-java.html
+        }
+
+        location /minio/baremetal/sdk/python/minio-python.html {
+             return 301 /docs/linux/developers/python/minio-python.html
+        }
+
+        location /minio/baremetal/sdk/go/minio-go.html {
+             return 301 /docs/linux/developers/go/minio-go.html
+        }
+
+        location /minio/baremetal/sdk/dotnet/minio-dotnet.html {
+             return 301 /docs/linux/developers/dotnet/minio-dotnet.html
+        }
+
+        # Miscellaneous Redirects from NuDocs 1 to NuDocs 2
+        # =================================================
+
+        location /minio/baremetal/support/support-overview.html {
+             return 301 /docs/linux/operations/troubleshooting.html;
+        }
+
+        location /minio/baremetal/support/encrypting-files.html {
+             return 301 /docs/linux/operations/troubleshooting/encrypting-files.html;
+        }
+
+        location /minio/baremetal/* {
+             return 301 /docs/linux/index.html;
+        }

--- a/redirects/macos.conf
+++ b/redirects/macos.conf
@@ -1,0 +1,3 @@
+        location /minio/baremetal/quickstart/macos.html {
+             return 301 /docs/macos/operations/index.html
+        }

--- a/redirects/windows.conf
+++ b/redirects/windows.conf
@@ -1,0 +1,3 @@
+        location /minio/baremetal/quickstart/windows.html {
+             return 301 /docs/windows/operations/index.html
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-docutils == 0.18
+docutils == 0.17
 sphinx == 4.3.2
 sphinx-copybutton == 0.5.0
 sphinx-design == 0.2.0
-sphinx-markdown-tables == 0.0.15
 Sphinx-Substitution-Extensions == 2020.9.30.0
 sphinx-togglebutton === 0.3.2
 sphinxcontrib-images === 0.9.4

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -47,7 +47,6 @@ extensions = [
     'minio',
     'cond',
     'sphinx_copybutton',
-    'sphinx_markdown_tables',
     'sphinx-prompt',
     'sphinx_substitution_extensions',
     'sphinx_togglebutton',
@@ -84,9 +83,8 @@ extlinks = {
 
 suppress_warnings = [
     'toc.excluded',
-    'myst.ref',
     'myst.header',
-    'myst'
+    'ref.myst'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/developers/haskell/API.md
+++ b/source/developers/haskell/API.md
@@ -53,6 +53,7 @@ var s3Client = new Minio.Client({
 | [`setBucketReplication`](#setBucketReplication)       |                                                     |                                               |                                                               |                                                       |     |
 | [`getBucketReplication`](#getBucketReplication)       |                                                     |                                               |                                                               |                                                       |     |
 | [`removeBucketReplication`](#removeBucketReplication) |                                                     |                                               |                                                               |                                                       |     |
+
 ## 1.  Constructor
 
 <a name="MinioClient_endpoint"></a>


### PR DESCRIPTION
This is the initial work for what should be a git-managed set of nginx configs we can include into the Nginx Docs server.

The idea here is we manage redirects in git, and either chron-copy them to a location we can include via the sites-available/<file>, *or* we just include them from the git path (if nginx tolerates that)

I can't really _test_ these right now since they are using live URLs. if we move forward with the soft-launch, we'll have a few opportunities to maybe test a subset of these URLs and see what happens.

Please let me know if there is anything *obviously* wrong here.

ToDo: The Legacy Docs redirects