### PR TITLE
Add a template for doc change update

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc-change.md
+++ b/.github/ISSUE_TEMPLATE/doc-change.md
@@ -1,0 +1,16 @@
+---
+name: Documentation update issue
+about: Opening a new issue to update the documentation after a PR submission in other projects
+title: ''
+labels: 'doc-change'
+assignees: ''
+
+---
+
+Opening a new issue to document a new feature/change.
+
+The reference PR is in the title, kindly make sure that the PR is 
+approved and merged first.
+
+Ping the PR owner is you have further questions about the documentation change.
+

--- a/.github/ISSUE_TEMPLATE/doc-change.md
+++ b/.github/ISSUE_TEMPLATE/doc-change.md
@@ -12,5 +12,6 @@ Opening a new issue to document a new feature/change.
 The reference PR is in the title, kindly make sure that the PR is 
 approved and merged first.
 
-Ping the PR owner is you have further questions about the documentation change.
+If the feature/change is not yet merged to latest stable, leave the PR in the RFM state and merge/publish only when we have a new release of the related product.
+Ping the PR owner if you have further questions about the documentation change.
 


### PR DESCRIPTION
This template will be linked from other projects to easily open a new request issue after a change in the documentation.

Other projects will have a link for this template like this:

https://github.com/minio/docs/issues/new?labels=doc-change-request&template=doc-change.md&title=Doc+Update+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN