### PR TITLE
Add reference docs for mc support logs

### DIFF
--- a/source/includes/common-mc-support.rst
+++ b/source/includes/common-mc-support.rst
@@ -6,3 +6,11 @@
    MinIO does not guarantee any functionality if used against non-MinIO deployments or if used independently of MinIO engineering and support.
 
 .. end-minio-only
+
+.. start-support-logs-opt-in
+
+Uploading logs requires registration to SUBNET.
+The uploading feature remains disabled by default until explicitly enabled for a deployment on an opt-in only basis.
+You can then disable the feature at any time with :mc-cmd:`mc support logs disable`.
+
+.. end-support-logs-opt-in

--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -151,13 +151,20 @@ For clusters with an airgap, firewall, or otherwise blocked from SUBNET directly
 #. Select :guilabel:`Diagnostics`
 #. Drag and drop the ``.gzip`` file(s) or browse to the file location to upload
 
-
 Encrypting Data
 ~~~~~~~~~~~~~~~
 
 Data from the Inspect tool in :ref:`Console <minio-console>` or the :mc-cmd:`mc support inspect` command can be encrypted.
 For more details about encrypting or decrypting such files, see :ref:`Encrypting Files <minio-support-encryption>`.
 
+Logs
+----
+
+Use the subcommands for ``mc support logs`` to :mc-cmd:`~mc support logs enable` or :mc-cmd:`~mc support logs disable` the submission of MinIO logs to SUBNET.
+You can also use :mc-cmd:`mc support logs status` to check if a log submission is in progress.
+
+Use :mc-cmd:`mc support logs show` command to display logs from the command line.
+Use the parameter flags for the :mc-cmd:`mc support logs show` command to limit the displayed logs by type or quantity.
 
 .. toctree::
    :titlesonly:

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -496,6 +496,10 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-stat
    /reference/minio-mc/mc-support-diagnostics
    /reference/minio-mc/mc-support-inspect
+   /reference/minio-mc/mc-support-logs-disable
+   /reference/minio-mc/mc-support-logs-enable
+   /reference/minio-mc/mc-support-logs-show
+   /reference/minio-mc/mc-support-logs-status
    /reference/minio-mc/mc-support-perf
    /reference/minio-mc/mc-support-profile
    /reference/minio-mc/mc-support-register

--- a/source/reference/minio-mc/mc-support-logs-disable.rst
+++ b/source/reference/minio-mc/mc-support-logs-disable.rst
@@ -1,0 +1,53 @@
+===========================
+``mc support logs disable``
+===========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+.. mc:: mc support logs disable
+
+Description
+-----------
+
+Use the :mc-cmd:`mc support logs disable` command to disable the uploading of real-time MinIO logs to |subnet|.
+
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-support-logs-opt-in
+   :end-before: end-support-logs-opt-in
+   
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-minio-only
+   :end-before: end-minio-only
+
+Example
+-------
+
+Disable Logs from Uploading to SUBNET
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command disables console logs from uploading to SUBNET for the alias ``minio1``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support logs disable minio1
+
+Syntax
+------
+
+The command has the following syntax:
+
+.. code-block:: shell
+               
+   mc [GLOBAL FLAGS] support logs disable ALIAS
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc/mc-support-logs-enable.rst
+++ b/source/reference/minio-mc/mc-support-logs-enable.rst
@@ -1,0 +1,63 @@
+==========================
+``mc support logs enable``
+==========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+.. mc:: mc support logs enable
+
+Description
+-----------
+
+Use the :mc-cmd:`mc support logs enable` command to allow real-time MinIO logs to upload to |subnet|.
+
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-support-logs-opt-in
+   :end-before: end-support-logs-opt-in
+   
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-minio-only
+   :end-before: end-minio-only
+
+.. note:: 
+
+   By default, MinIO does not scrub the logs uploaded to SUBNET.
+
+   To hide sensitive information in the logs, start the server with the :mc-cmd:`~mc server --anonymous` flag.
+   MinIO employs an aggressive scrubbing algorithm which may produce logs with reduced visibility into the deployment.
+   MinIO Engineering may later request unredacted logs if required for ongoing support cases.
+
+Example
+-------
+
+Enable Automatic Upload of MinIO Logs to SUBNET
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command starts sending the MinIO deployment's server logs to SUBNET for the alias ``minio1``.
+
+.. code-block::
+   :class: copyable
+
+   mc support logs enable minio1
+
+
+Syntax
+------
+
+The command has the following syntax:
+
+.. code-block::
+               
+   mc [GLOBAL FLAGS] support logs enable ALIAS
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+.. default-domain:: minio

--- a/source/reference/minio-mc/mc-support-logs-show.rst
+++ b/source/reference/minio-mc/mc-support-logs-show.rst
@@ -1,0 +1,100 @@
+========================
+``mc support logs show``
+========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+.. mc:: mc support logs show
+
+Description
+-----------
+
+Use the :mc-cmd:`mc support logs show` command to display MinIO server logs.
+   
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-minio-only
+   :end-before: end-minio-only
+
+Examples
+--------
+
+Show Logs for the Alias ``minio1``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command shows logs for the alias ``minio1``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support logs show minio1
+
+Show Last Five Log Entries for a Specific Node
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command shows the last five log entries on the node ``node1`` for a MinIO server with the alias ``minio1``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support logs show --last 5 minio1 node1
+
+Show Application Log Entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command shows the application logs for a MinIO server with the alias ``minio1``.
+
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-support-logs-opt-in
+   :end-before: end-support-logs-opt-in
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support logs show --type application minio1
+
+Syntax
+------
+      
+The command has the following syntax:
+
+.. code-block:: shell
+
+   mc [GLOBALFLAGS] support logs show      \
+                                 [--last]  \
+                                 [--type]  \
+                                 ALIAS
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: --last
+   :optional:
+
+   Show the most recent log entries to a specified number.
+   Takes an integer value.
+
+   If not specified, the command shows the last 10 log entries.
+   
+.. mc-cmd:: --type
+   :optional:
+
+   List error logs by type.
+
+   Valid types:
+   
+   - ``application``
+   - ``minio``
+   - ``all``
+
+   Defaults to ``all``.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc/mc-support-logs-status.rst
+++ b/source/reference/minio-mc/mc-support-logs-status.rst
@@ -1,0 +1,54 @@
+==========================
+``mc support logs status``
+==========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+.. mc:: mc support logs status
+
+Description
+-----------
+
+Use the :mc-cmd:`mc support logs status` command to output whether the specified ALIAS is set to automatically upload logs to |subnet|.
+
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-support-logs-opt-in
+   :end-before: end-support-logs-opt-in
+
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-minio-only
+   :end-before: end-minio-only
+
+Example
+-------
+
+Display Whether Logs Are Currently Uploading to SUBNET
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command outputs whether logs are currently uploading to SUBNET for the alias ``minio1``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support logs status minio1
+
+
+Syntax
+------
+
+The command has the following syntax:
+
+.. code-block:: shell
+               
+   mc [GLOBAL FLAGS] support logs enable ALIAS
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals


### PR DESCRIPTION
Adds four reference docs for the subcommands of `mc support logs`.
Adds a section to the troubleshooting doc for using `mc support logs` to send error logs to SUBNET.

Closes #511 .