### PR TITLE
Add extension to create sitemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/minio/docs.git"
   },
-  "author": "Ravind Kumar",
+  "author": "MinIO Documentation Team",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/minio/docs/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-docutils == 0.18
+docutils == 0.17
 sphinx == 4.3.2
 sphinx-copybutton == 0.5.0
 sphinx-design == 0.2.0
 sphinx-markdown-tables == 0.0.15
 Sphinx-Substitution-Extensions == 2020.9.30.0
+sphinx-sitemap == 2.2.0
 sphinx-togglebutton === 0.3.2
 sphinxcontrib-images === 0.9.4
 myst-parser === 0.18.0

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -2,18 +2,18 @@
 
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
-      <loc>https://www.min.io/docs/linux/sitemap.xml</loc>
+      <loc>https://www.min.io/docs/minio/linux/sitemap.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://www.min.io/docs/windows/sitemap.xml</loc>
+      <loc>https://www.min.io/docs/minio/windows/sitemap.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://www.min.io/docs/macos/sitemap.xml</loc>
+      <loc>https://www.min.io/docs/minio/macos/sitemap.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://www.min.io/docs/kubernetes/sitemap.xml</loc>
+      <loc>https://www.min.io/docs/minio/kubernetes/upstream/sitemap.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://www.min.io/docs/containers/sitemap.xml</loc>
+      <loc>https://www.min.io/docs/minio/container/sitemap.xml</loc>
    </sitemap>
 </sitemapindex>

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+   <sitemap>
+      <loc>https://www.min.io/docs/linux/sitemap.xml</loc>
+   </sitemap>
+   <sitemap>
+      <loc>https://www.min.io/docs/windows/sitemap.xml</loc>
+   </sitemap>
+   <sitemap>
+      <loc>https://www.min.io/docs/macos/sitemap.xml</loc>
+   </sitemap>
+   <sitemap>
+      <loc>https://www.min.io/docs/kubernetes/sitemap.xml</loc>
+   </sitemap>
+   <sitemap>
+      <loc>https://www.min.io/docs/containers/sitemap.xml</loc>
+   </sitemap>
+</sitemapindex>

--- a/source/_static/css/algolia.css
+++ b/source/_static/css/algolia.css
@@ -1,0 +1,2 @@
+.wy-nav-side { overflow: visible; }
+.wy-side-scroll { overflow: inherit; }

--- a/source/_static/js/algolia.js
+++ b/source/_static/js/algolia.js
@@ -1,0 +1,9 @@
+docsearch({
+  apiKey: '0ba0d26da4d1483f96c03fe508304a64',
+  indexName: 'minio',
+  inputSelector: '#algolia input[type=text],
+  debug: false,
+  algoliaOptions: {
+    hitsPerPage: 8,
+  }
+});

--- a/source/_templates/searchbox.html
+++ b/source/_templates/searchbox.html
@@ -1,4 +1,5 @@
 {%- if pagename != "search" and builder != "singlehtml" %}
+
 <form class="search" action="{{ pathto('search') }}" method="get" role="search">
    <div class="search__inner">
       <button id="search-close" class="icon visible-rm" type="button">
@@ -8,7 +9,7 @@
          Hide Search
       </button>
 
-      <input type="text" class="search__text" id="docs-search" name="q" aria-labelledby="searchlabel" placeholder="Search Documentation" />
+      <input type="text" class="search__text" id="algolia" name="q" aria-labelledby="searchlabel" placeholder="Search Documentation" />
       
       <kbd class="hidden-rm">
          <span id="search-meta-key"></span>

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -47,11 +47,10 @@ extensions = [
     'minio',
     'cond',
     'sphinx_copybutton',
-    'sphinx_markdown_tables',
     'sphinx-prompt',
     'sphinx_substitution_extensions',
     'sphinx_togglebutton',
-    'sphinx-sitemap',
+    'sphinx_sitemap',
     'sphinxcontrib.images',
     'myst_parser',
     'sphinx_design',
@@ -267,7 +266,8 @@ html_css_files = ['css/main.min.css', 'custom.css']
 
 html_js_files = ['js/main.js']
 
-html_extra_path = [ 'extra', 'https://www.min.io/robots.txt']
+# Add https://www.min.io/robots.txt to html_extra_path list once available.
+html_extra_path = [ 'extra']
 
 html_title = 'MinIO Object Storage for ' + platform.capitalize()
 

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -34,7 +34,7 @@ copyright = '2020-Present, MinIO, Inc. '
 author = 'MinIO Documentation Team'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1'
+release = '0.2'
 
 
 # -- General configuration ---------------------------------------------------
@@ -105,7 +105,7 @@ exclude_patterns = ['includes/*', '*-template.rst']
 # The sitemaps are combined in a sitemapindex.xml file at the root level.
 
 if tags.has("linux"):
-    html_baseurl = 'https://www.min.io/docs/linux/'
+    html_baseurl = 'https://www.min.io/docs/minio/linux/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-tenant.rst',
         'operations/install-deploy-manage/modify-minio-tenant.rst',
@@ -130,7 +130,7 @@ if tags.has("linux"):
         'reference/kubectl-minio-plugin/kubectl-minio-version.rst',
     ]
 elif tags.has("macos"):
-    html_baseurl = 'https://www.min.io/docs/macos/'
+    html_baseurl = 'https://www.min.io/docs/minio/macos/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-tenant.rst',
         'operations/install-deploy-manage/modify-minio-tenant.rst',
@@ -156,7 +156,7 @@ elif tags.has("macos"):
     ]
 elif tags.has("windows"):
     # html_baseurl is used for generating the sitemap.xml for each platform. These are combined in a sitemapindex.xml.
-    html_baseurl = 'https://www.min.io/docs/windows/'
+    html_baseurl = 'https://www.min.io/docs/minio/windows/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-tenant.rst',
         'operations/install-deploy-manage/modify-minio-tenant.rst',
@@ -181,7 +181,7 @@ elif tags.has("windows"):
         'reference/kubectl-minio-plugin/kubectl-minio-version.rst',
     ]
 elif tags.has("container"):
-    html_baseurl = 'https://www.min.io/docs/containers/'
+    html_baseurl = 'https://www.min.io/docs/minio/container/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-tenant.rst',
         'operations/install-deploy-manage/modify-minio-tenant.rst',
@@ -208,7 +208,7 @@ elif tags.has("container"):
         'reference/kubectl-minio-plugin/kubectl-minio-version.rst',
     ]
 elif tags.has("k8s"):
-    html_baseurl = 'https://www.min.io/docs/kubernetes/'
+    html_baseurl = 'https://www.min.io/docs/minio/kubernetes/upstream/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-single-node-single-drive.rst',
         'operations/install-deploy-manage/deploy-minio-single-node-multi-drive.rst',
@@ -284,7 +284,7 @@ sphinx_tabs_disable_css_loading = True
 # k8s is temporary until integrating the references here
 
 intersphinx_mapping = {
-    'baremetal': ('https://docs.min.io/minio/baremetal/', None),
+    'baremetal': ('https://www.min.io/docs/minio/', None),
 }
 
 rst_prolog = """

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -51,6 +51,7 @@ extensions = [
     'sphinx-prompt',
     'sphinx_substitution_extensions',
     'sphinx_togglebutton',
+    'sphinx-sitemap',
     'sphinxcontrib.images',
     'myst_parser',
     'sphinx_design',
@@ -84,7 +85,7 @@ extlinks = {
 
 suppress_warnings = [
     'toc.excluded',
-    'myst.ref',
+    'ref.myst',
     'myst.header',
     'myst'
 ]
@@ -101,8 +102,11 @@ templates_path = ['_templates']
 exclude_patterns = ['includes/*', '*-template.rst']
 
 # template for adding custom exclude paths if necessary for a given tag
+# html_baseurl is used by sphinx_sitemap extension to generate a sitemap.xml for each platform.
+# The sitemaps are combined in a sitemapindex.xml file at the root level.
 
 if tags.has("linux"):
+    html_baseurl = 'https://www.min.io/docs/linux/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-tenant.rst',
         'operations/install-deploy-manage/modify-minio-tenant.rst',
@@ -127,6 +131,7 @@ if tags.has("linux"):
         'reference/kubectl-minio-plugin/kubectl-minio-version.rst',
     ]
 elif tags.has("macos"):
+    html_baseurl = 'https://www.min.io/docs/macos/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-tenant.rst',
         'operations/install-deploy-manage/modify-minio-tenant.rst',
@@ -151,6 +156,8 @@ elif tags.has("macos"):
         'reference/kubectl-minio-plugin/kubectl-minio-version.rst',
     ]
 elif tags.has("windows"):
+    # html_baseurl is used for generating the sitemap.xml for each platform. These are combined in a sitemapindex.xml.
+    html_baseurl = 'https://www.min.io/docs/windows/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-tenant.rst',
         'operations/install-deploy-manage/modify-minio-tenant.rst',
@@ -175,6 +182,7 @@ elif tags.has("windows"):
         'reference/kubectl-minio-plugin/kubectl-minio-version.rst',
     ]
 elif tags.has("container"):
+    html_baseurl = 'https://www.min.io/docs/containers/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-tenant.rst',
         'operations/install-deploy-manage/modify-minio-tenant.rst',
@@ -201,6 +209,7 @@ elif tags.has("container"):
         'reference/kubectl-minio-plugin/kubectl-minio-version.rst',
     ]
 elif tags.has("k8s"):
+    html_baseurl = 'https://www.min.io/docs/kubernetes/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-single-node-single-drive.rst',
         'operations/install-deploy-manage/deploy-minio-single-node-multi-drive.rst',
@@ -258,7 +267,7 @@ html_css_files = ['css/main.min.css', 'custom.css']
 
 html_js_files = ['js/main.js']
 
-html_extra_path = [ 'extra']
+html_extra_path = [ 'extra', 'https://www.min.io/robots.txt']
 
 html_title = 'MinIO Object Storage for ' + platform.capitalize()
 


### PR DESCRIPTION
This PR adds the `sphinx_sitemap` to the list of extensions in default-conf.py.
The extension creates a sitemap.xml file at the root of the generated HTML output at the end of an HTML build.

This allows us to create the sitemap.xml file for each product/platform.
We'll need the website team to add a sitemap-index.xml file at the root of min.io that links to each of the product/platform doc sitemaps.