### PR TITLE
Add mc license to reference docs

### DIFF
--- a/source/operations/checklists/hardware.rst
+++ b/source/operations/checklists/hardware.rst
@@ -316,7 +316,7 @@ Run all three tests with default options.
 Operating System Diagnostic Tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you cannot run the :mc:`mc support diagnostics` or the results show unexpected results, you can use the operating system's default tools.
+If you cannot run the :mc:`mc support diag` or the results show unexpected results, you can use the operating system's default tools.
 
 Test each drive independently on all servers to ensure they are identical in performance.
 Use the results of these OS-level tools to verify the capabilities of your storage hardware.

--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -69,9 +69,9 @@ Registering Your MinIO Deployment with SUBNET
 
       You can register for SUBNET from the command line.
 
-      Refer to :mc:`mc support register` for instructions.
+      Refer to :mc-cmd:`mc license register` for instructions.
 
-      For clusters without direct Internet access, refer to the instructions in the :ref:`airgap example <minio-support-register-airgap>` of the :mc:`mc support register` documentation.
+      For clusters without direct Internet access, refer to the instructions in the :ref:`airgap example <minio-license-register-airgap>` of the :mc-cmd:`mc license register` documentation.
 
 
 SUBNET Issues
@@ -89,7 +89,7 @@ Use the search bar to locate an existing issue or add a new issue.
    :alt: MinIO SUBNET with the Issues section displaying a list of an organization's issues
    :align: center
 
-Select an existing issue from the list to expand the converation or add a response.
+Select an existing issue from the list to expand the conversation or add a response.
 
 .. image:: /images/subnet/issue-expanded.png
    :width: 600px
@@ -115,7 +115,7 @@ Deployment Health
 ~~~~~~~~~~~~~~~~~
 
 The deployment's details include a summary of the deployment's configuration and the number of checks run and failed.
-You can select :guilabel:`Upload` to add diagnostic health data obtained from the :mc:`mc support diagnostics` command or the MinIO Console's Support > Health page.
+You can select :guilabel:`Upload` to add diagnostic health data obtained from the :mc-cmd:`mc support diag` command or the MinIO Console's Support > Health page.
 
 If you need support from MinIO Engineering, you can create a :guilabel:`New Issue` for the deployment.
 
@@ -145,7 +145,7 @@ If you registered the cluster with SUBNET, Performance and Inspection files can 
 
 For clusters with an airgap, firewall, or otherwise blocked from SUBNET directly, you can manually upload files to SUBNET after logging in.
 
-#. Generate the file(s) to upload from the command line with :mc:`mc support diagnostics` or :mc:`mc support inspect`
+#. Generate the file(s) to upload from the command line with :mc-cmd:`mc support diag` or :mc-cmd:`mc support inspect`
 #. Sign in to `SUBNET <https://subnet.min.io>`_
 #. Select :guilabel:`Deployments`
 #. Select :guilabel:`Diagnostics`

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -35,7 +35,7 @@ See :ref:`minio-mc-commands` for a list of supported commands.
    licensed Free and Open Source (FOSS) software. 
 
    Applications integrating :program:`mc` may trigger AGPLv3 compliance
-   requirements. `MinIO Commericial Licensing <https://min.io/pricing>`__
+   requirements. `MinIO Commercial Licensing <https://min.io/pricing>`__
    is the best option for applications which trigger AGPLv3 obligations where
    open-sourcing the application is not an option.   
 
@@ -224,6 +224,11 @@ The following table lists :mc-cmd:`mc` commands:
        the :ref:`Object Legal Hold (WORM) <minio-object-locking-legalhold>`
        settings for object(s).
 
+   * - | :mc:`mc license register` 
+       | :mc:`mc license info`
+       | :mc:`mc license update` 
+     - The ``mc license`` command registers clusters with |SUBNET|, displays information about the cluster's current license, or updates the license key for a cluster.
+
    * - :mc:`mc ls`
      - .. include:: /reference/minio-mc/mc-ls.rst
           :start-after: start-mc-ls-desc
@@ -311,13 +316,12 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-stat-desc
           :end-before: end-mc-stat-desc
 
-   * - | :mc:`mc support diagnostics`
+   * - | :mc:`mc support diag`
        | :mc:`mc support inspect`
        | :mc:`mc support perf`
        | :mc:`mc support profile`
-       | :mc:`mc support register`
      - The MinIO Client ``mc support`` commands provides tools for analyzing deployment health or performance and for running diagnostics.
-       You can also register your deployment with |SUBNET| and upload generated health reports for further analysis by MinIO engineering.
+       You can also upload generated health reports for further analysis by MinIO engineering.
 
    * - | :mc:`mc tag set`
        | :mc:`mc tag remove`
@@ -466,6 +470,9 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-legalhold-set
    /reference/minio-mc/mc-legalhold-info
    /reference/minio-mc/mc-legalhold-clear
+   /reference/minio-mc/mc-license-info
+   /reference/minio-mc/mc-license-register
+   /reference/minio-mc/mc-license-update
    /reference/minio-mc/mc-ls
    /reference/minio-mc/mc-mb
    /reference/minio-mc/mc-mirror
@@ -494,11 +501,10 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-share-list
    /reference/minio-mc/mc-sql
    /reference/minio-mc/mc-stat
-   /reference/minio-mc/mc-support-diagnostics
+   /reference/minio-mc/mc-support-diag
    /reference/minio-mc/mc-support-inspect
    /reference/minio-mc/mc-support-perf
    /reference/minio-mc/mc-support-profile
-   /reference/minio-mc/mc-support-register
    /reference/minio-mc/mc-tag-set
    /reference/minio-mc/mc-tag-list
    /reference/minio-mc/mc-tag-remove

--- a/source/reference/minio-mc/mc-license-info.rst
+++ b/source/reference/minio-mc/mc-license-info.rst
@@ -1,0 +1,77 @@
+===================
+``mc license info``
+===================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+.. mc:: mc license info
+
+Description
+-----------
+
+The :mc-cmd:`mc license info` command displays information about the MinIO deployment's license status.
+Specifically, whether the deployment uses the AGPLv3 Open Source license of the `MinIO Commercial License <https://min.io/product/subnet?ref=docs>`__.
+
+You must register your deployment with MinIO |SUBNET| to activate your commercial license.
+
+For example, the command returns the following information for an unregistered deployment:
+
+.. code-block:: shell
+
+   You are using GNU AFFERO GENERAL PUBLIC LICENSE Version 3 (https://www.gnu.org/licenses/agpl-3.0.txt)
+
+   If you are building proprietary applications, you may want to choose the commercial license 
+   included as part of the Standard and Enterprise subscription plans. (https://min.io/signup?ref=mc)
+
+   Applications must otherwise comply with all the GNU AGPLv3 License & Trademark obligations.
+
+Use :mc-cmd:`mc license register` to associate your deployment with your SUBNET account.
+If you are not already signed up for SUBNET, see the `Registration <https://min.io/pricing?ref=docs>`__ page.
+
+Examples
+--------
+
+Display the Current License for a Deployment with Alias ``minio1``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: shell
+   :class: copyable
+
+   mc license info minio1
+
+If a deployment uses an expired MinIO Commercial License, the command outputs an error message.
+
+Syntax
+------
+      
+The command has the following syntax:
+
+.. code-block:: shell
+
+   mc [GLOBALFLAGS] license info       \
+                            ALIAS      \
+                            [--airgap]
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment.
+   
+.. mc-cmd:: --airgap
+   :optional:
+
+   Use in environments without network access to SUBNET (for example, airgapped, firewalled, or similar configuration) to display instructions for how to register the deployment with SUBNET.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc/mc-license-register.rst
+++ b/source/reference/minio-mc/mc-license-register.rst
@@ -1,5 +1,5 @@
 =======================
-``mc support register``
+``mc license register``
 =======================
 
 .. default-domain:: minio
@@ -9,39 +9,48 @@
    :depth: 1
 
 .. mc:: mc support register
+.. mc:: mc license register
+
+.. note::
+
+   .. versionchanged:: RELEASE.2022-07-15T09-20-55Z
+
+   ``mc license register`` replaces the ``mc support register`` command.
 
 Description
 -----------
 
-The :mc:`mc support register` command connects your deployment with your |SUBNET| account.
+The :mc-cmd:`mc license register` command connects your deployment with your |SUBNET| account.
 
-After registration, upload deployment health reports directly to SUBNET using :mc:`mc support diagnostics` command.
+After registration, you can upload deployment health reports directly to SUBNET using the :mc-cmd:`mc support diag` command.
 
 
 Examples
 --------
 
-Register a Deployment Using the Cluster's Name
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Register a Deployment Using the Deployment's Name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Register the MinIO deployment at alias ``minio1`` on SUBNET, using ``minio1`` as the cluster name:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc support register minio1
-
-Register a Deployment with a Different Cluster Name
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Register a MinIO deployment at alias ``minio2`` on SUBNET, using ``second-cluster`` as the name:
+Register the MinIO deployment at alias ``minio1`` on SUBNET, using ``minio1`` as the deployment name:
 
 .. code-block:: shell
    :class: copyable
 
-   mc support register minio2 --name second-cluster
+   mc license register minio1
 
-.. _minio-support-register-airgap:
+If not already registered, a prompt asks for SUBNET credentials for the deployment.
+
+Register a Deployment with a Different Deployment Name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Register a MinIO deployment at alias ``minio2`` on SUBNET, using ``second-deployment`` as the name:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc license register minio2 --name second-deployment
+
+.. _minio-license-register-airgap:
 
 Register a Deployment Without Direct Internet Access
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,7 +60,7 @@ Register a MinIO deployment at alias ``minio3`` on SUBNET that does not have dir
 .. code-block:: shell
    :class: copyable
 
-   mc support register minio3 --airgap
+   mc license register minio3 --airgap
 
 #. Run the command to return a registration token
 #. Copy the registration token
@@ -71,7 +80,7 @@ The command has the following syntax:
 
 .. code-block:: shell
 
-   mc [GLOBALFLAGS] support register       \
+   mc [GLOBALFLAGS] license register       \
                             ALIAS          \
                             [--name value] \
                             [--airgap]
@@ -87,16 +96,16 @@ Parameters
 .. mc-cmd:: --name
    :optional:
 
-   Specify a name other than the alias to associate to the MinIO cluster in SUBNET.
+   Specify a name other than the alias to associate to the MinIO deployment in SUBNET.
 
-   Use ``--name <value>`` replacing ``<value>`` with the name you want to use for the cluster on SUBNET.
+   Use ``--name <value>`` replacing ``<value>`` with the name you want to use for the deployment on SUBNET.
    
 .. mc-cmd:: --airgap
    :optional:
 
    Use in environments without network access to SUBNET (for example, airgapped, firewalled, or similar configuration).
 
-   For instructions, see the :ref:`airgap example <minio-support-register-airgap>`.
+   For instructions, see the :ref:`airgap example <minio-license-register-airgap>`.
 
 
 Global Flags

--- a/source/reference/minio-mc/mc-license-update.rst
+++ b/source/reference/minio-mc/mc-license-update.rst
@@ -1,0 +1,65 @@
+=====================
+``mc license update``
+=====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+.. mc:: mc license update
+
+Description
+-----------
+
+Use the :mc-cmd:`mc license update` command to replace a license key for a deployment.
+
+Examples
+--------
+
+Update the License Key for a Deployment with Alias ``minio1``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: shell
+   :class: copyable
+
+   mc license update minio1 license.key
+
+Syntax
+------
+      
+The command has the following syntax:
+
+.. code-block:: shell
+
+   mc [GLOBALFLAGS] license update                 \
+                            ALIAS                  \
+                            LICENSE-FILE-WITH-PATH \
+                            [--airgap]
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment.
+
+.. mc-cmd:: LICENSE-FILE-WITH-PATH
+   :required:
+
+   The path (relative to the current working directory) and file name of the key to use to update the deployment's license.
+   
+.. mc-cmd:: --airgap
+   :optional:
+
+   Use in environments without network access to SUBNET (for example, airgapped, firewalled, or similar configuration).
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc/mc-support-diag.rst
+++ b/source/reference/minio-mc/mc-support-diag.rst
@@ -1,6 +1,6 @@
-==========================
-``mc support diagnostics``
-==========================
+===================
+``mc support diag``
+===================
 
 .. default-domain:: minio
 
@@ -8,12 +8,12 @@
    :local:
    :depth: 1
 
-.. mc:: mc support diagnostics
+.. mc:: mc support diag
 
 Description
 -----------
 
-The :mc:`mc support diagnostics` command generates a health report for a MinIO deployment.
+The :mc-cmd:`mc support diag` command generates a health report for a MinIO deployment.
 For deployments registered with the MinIO subscription network (|subnet-short|), the command can automatically upload the health report for analysis.
 
 The resulting health report is intended for use by MinIO Engineering via SUBNET and may contain internal or private data points.
@@ -26,10 +26,10 @@ During the test, MinIO freezes all S3 calls and queues read or write operations 
 The queue is limited based on the supported maximum concurrent :ref:`requests per host <minio-hardware-checklist-memory>`.
 Requests that exceed this limit on a given host return a ``503`` error after ~10 seconds.
 
-Use the :mc:`mc support diagnostics` command to trigger the diagnostic test.
+Use the :mc-cmd:`mc support diag` command to trigger the diagnostic test.
 For clusters registered with SUBNET, the command uploads the results as part of SUBNET Health reports. 
 
-For airgapped or firewalled environments, or other environments that prevent direct network access from the deployment, you can save the report locally with the :mc-cmd:`~mc support diagnostics --airgap` flag.
+For airgapped or firewalled environments, or other environments that prevent direct network access from the deployment, you can save the report locally with the :mc-cmd:`~mc support diag --airgap` flag.
 After saving, you can then upload the results of the test to SUBNET manually.
 
 .. include:: /includes/common-mc-support.rst
@@ -73,7 +73,7 @@ Generate health data for a MinIO cluster and automatically for a MinIO cluster a
 
    mc support diag minio1
 
-The automatic upload of data only occurs for deployments registered with SUBNET using :mc:`mc support register`.
+The automatic upload of data only occurs for deployments registered with SUBNET using :mc-cmd:`mc license register`.
 
 .. _minio-support-diagnostics-airgap:
 


### PR DESCRIPTION
Closes #523 

This PR 

- adds the three commands for `mc license` to the reference docs for `mc`.
- Replaces `mc support register` with `mc license register`.
- Updates references to `mc support register` to point to `mc license register` instead.