### PR TITLE
Minor fix to filter results based on platform

### DIFF
--- a/source/_static/js/main.js
+++ b/source/_static/js/main.js
@@ -302,6 +302,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
   // --------------------------------------------------
   (function () {
     const docSearchEl = document.getElementById("docsearch");
+    const platform = document.head.querySelector('meta[name="docsearch:platform"]').content
 
     if(docSearchEl) {
       // Init Docsearch
@@ -311,6 +312,9 @@ window.addEventListener("DOMContentLoaded", (event) => {
         indexName: 'minio',
         apiKey: '6bc246d81fd3b79f51cf88f0b2481bac',
         placeholder: 'Search Documentation',
+        searchParameters: {
+          facetFilters: ['platform:' + platform]
+        }
       });
 
       // Trigger Docsearch modal on custom button clicks


### PR DESCRIPTION
JS hack to filter by platform as part of our search, to remove some duplication we were seeing that came with "global" search.

If we implement a dedicated search page, we can have tabs for Platform vs Global search that hopefully handles this gracefully.

LMK how bad this hack is :) 