### PR TITLE
Fix incorrect font being displayed on docs

### DIFF
--- a/source/_static/scss/includes/_font.scss
+++ b/source/_static/scss/includes/_font.scss
@@ -1,19 +1,19 @@
 @font-face {
-     font-family: "Mark";
+     font-family: "Inter";
      src: url("../fonts/inter/Inter-Regular.woff2") format("woff2");
      font-weight: 400;
      font-style: normal;
 }
 
  @font-face {
-     font-family: "Mark";
+     font-family: "Inter";
      src: url("../fonts/inter/Inter-Medium.woff2") format("woff2");
      font-weight: 500;
      font-style: normal;
 }
 
 @font-face {
-     font-family: "Mark";
+     font-family: "Inter";
      src: url("../fonts/inter/Inter-Bold.woff2") format("woff2");
      font-weight: 700;
      font-style: normal;


### PR DESCRIPTION
Sans-serif font was being displayed on docs instead of Inter due to a font definition issue