### PR TITLE
Adds file to list steps needed after adding a new platform

### DIFF
--- a/new-platform.md
+++ b/new-platform.md
@@ -1,0 +1,49 @@
+# Launching a New Platform
+
+## Overview
+
+The documentation URLs take the path min.io/docs/$program/$platform/
+
+Where:
+- `$program` is `minio`, `kes`, or similar
+- `$platform` is `kubernetes/upstream`, `kubernetes/openshift`, `macos`, `container`, `windows`, `linux`, and similar
+- Not every `$program` has `$platform` specific versions of their docs
+
+## Steps
+
+When launching docs for a new `$program` or `$platform`, the following steps must be completed:
+
+1. Update the `makefile` in this repo to include the new docs
+   
+   - Use an existing `$platform` or `$program` section as a template.
+   - This creates a build command specific for the new `$platform` or `$program` docs.
+
+2. Add an `elif` section for the new `$program` or `$platform` to the `source/default-conf.py` file in this repo
+   
+   - Use an existing `elif` section as a template to follow.
+   - This allows you to exclude files that are not necessary from the build.
+
+3. Update `build-docs.sh` in this repo to automatically build the docs for the web server on each merge to the `main` branch
+
+   - Add the platform or program to the second `make` line.
+   - Create the commands to clear and add the path to the new docs using an existing section as a template.
+
+4. Update the doc main nav bar (`/source/_templates/content-navigation.html`) to include the `$program` and/or `$platform`
+
+   Work with the website design team as needed.
+
+5. Update the `sitemap_index.xml` file
+
+   - Contact a member of the website design to to add the new `$program` or `$platform` sitemap.xml path to the sitemap_index.xml on the min.io root website server.
+
+6. Update the Algolia crawler
+   
+   - Add the new `$program` or `$platform` sitemap.xml path to the **minio** Algolia crawler configuration at https://crawler.algolia.com.
+   - Select the **minio** index from the list, then select the Editor tab on the left nav
+   - Add the path to the `discoveryPatterns` section
+   - Add the path to the `pathsToMatch` section
+   - Click **Save**
+  
+7. Reindex the docs site
+   
+   After the docs are published, manually launch the **minio** index crawler from https://crawler.algolia.com by selecting **Restart crawling**.

--- a/sitemap_index.xml
+++ b/sitemap_index.xml
@@ -2,6 +2,9 @@
 
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
+      <loc>https://www.min.io/sitemap.xml</loc>
+   </sitemap>
+   <sitemap>
       <loc>https://www.min.io/docs/minio/linux/sitemap.xml</loc>
    </sitemap>
    <sitemap>

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -233,7 +233,7 @@ Glossary
      See also: :term:`SSE-KMS`, :term:`SSE-C`, :term:`encryption at rest`, :term:`network encryption`.
    
    SUBNET
-     `MinIO's Subscription Network <|SUBNET|>`__ tracks support tickets and provides 24 hour direct-to-engineer access for subscribed accounts.
+     `MinIO's Subscription Network <https://min.io/pricing?jmp=docs>`__ tracks support tickets and provides 24 hour direct-to-engineer access for subscribed accounts.
 
    tenant
    tenants

--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -115,7 +115,7 @@ Deployment Health
 ~~~~~~~~~~~~~~~~~
 
 The deployment's details include a summary of the deployment's configuration and the number of checks run and failed.
-You can select :guilabel:`Upload` to add diagnostic health data obtained from the :mc:`mc support diag` command or the MinIO Console's Support > Health page.
+You can select :guilabel:`Upload` to add diagnostic health data obtained from the :mc:`mc support diag` command or the MinIO Console's :guilabel:`Support > Health` page.
 
 If you need support from MinIO Engineering, you can create a :guilabel:`New Issue` for the deployment.
 


### PR DESCRIPTION
General cleanups I've noticed after new docs launched.

- Creates a markdown doc for steps needed after creating a new platform for the doc site. 
- Adds min.io sitemap to the sitemap_index file.
- Fixes two links causing some crawler errors in glossary and troubleshooting files.