### PR TITLE
Fix doc menu and search being hidden on mobile

### DIFF
--- a/source/_static/js/main.js
+++ b/source/_static/js/main.js
@@ -107,7 +107,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
       tocTargetEl.parentNode.replaceChild(tocOriginalEl, tocTargetEl);
     }
     else {
-      tocAsideEL.style.display = "none";
+      tocAsideEL.classList.add("content__toc--empty");
     }
     
     // Treat the TOC as a dropdown in mobile

--- a/source/_static/scss/includes/_toc.scss
+++ b/source/_static/scss/includes/_toc.scss
@@ -57,6 +57,12 @@ div.topic {
     }
 }
 
+.content__toc--empty {
+    @include breakpoint-min(breakpoints(lg)) {
+        display: none;
+    }
+}
+
 #table-of-contents {
     flex: 1;
     position: relative;


### PR DESCRIPTION
We might need to enable TOC on all pages to maintain the original mobile menu design. 