### PR TITLE
Mc issues

### DIFF
--- a/source/design.rst
+++ b/source/design.rst
@@ -270,6 +270,12 @@ You can set custom text for the note title:
 
    This is a `link <https://min.io>`__ to an external page. 
 
+To note a version change:
+
+.. versionchanged:: RELEASE.2022-07-15T09-20-55Z
+
+   ``mc license register`` replaces the ``mc support register`` command.
+
 Important Admonition
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/operations/concepts.rst
+++ b/source/operations/concepts.rst
@@ -126,7 +126,6 @@ There are several options to manage your MinIO deployments and clusters:
 - The :ref:`MinIO Console <minio-console>` graphical user interface for individual instances
 - In Kubernetes, with the :ref:`MinIO Operator Console <minio-operator-console>`
 
-
 How does MinIO provide availability, redundancy, and reliability?
 -----------------------------------------------------------------
 

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -31,6 +31,7 @@ Where :ref:`bucket replication <minio-bucket-replication>` manages the mirroring
 Only one deployment can have any data when initiating a new site replication configuration.
 
 Site replication enforces :ref:`bucket versioning <minio-bucket-versioning>` on all buckets, including existing buckets and any buckets added after initiating site replication.
+Site replication fully synchronizes versioned objects, compared to :mc:`mc mirror` which operates only on the latest version of an object
 
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only
    :class: note

--- a/source/reference/minio-mc-admin/mc-admin-top.rst
+++ b/source/reference/minio-mc-admin/mc-admin-top.rst
@@ -10,6 +10,12 @@
 
 .. mc:: mc admin top
 
+.. note::
+
+   .. versionchanged:: RELEASE.2022-08-11T00-30-48Z
+
+   :mc-cmd:`mc support top` replaces the ``mc admin top`` command.
+
 Description
 -----------
 

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -248,6 +248,11 @@ The following table lists :mc-cmd:`mc` commands:
      - .. include:: /reference/minio-mc/mc-mv.rst
           :start-after: start-mc-mv-desc
           :end-before: end-mc-mv-desc
+
+   * - :mc:`mc pipe`
+     - .. include:: /reference/minio-mc/mc-pipe.rst
+          :start-after: start-mc-pipe-desc
+          :end-before: end-mc-pipe-desc  
      
    * - | :mc:`mc policy set`
        | :mc:`mc policy set-json`
@@ -292,7 +297,6 @@ The following table lists :mc-cmd:`mc` commands:
        :ref:`active-active replication configurations
        <minio-bucket-replication-serverside-twoway>` and
        :ref:`resynchronization <minio-replication-behavior-resync>`.
-       
      
    * - :mc:`mc rm`
      - .. include:: /reference/minio-mc/mc-rm.rst
@@ -320,6 +324,7 @@ The following table lists :mc-cmd:`mc` commands:
        | :mc:`mc support inspect`
        | :mc:`mc support perf`
        | :mc:`mc support profile`
+       | :mc:`mc support top`
      - The MinIO Client ``mc support`` commands provides tools for analyzing deployment health or performance and for running diagnostics.
        You can also upload generated health reports for further analysis by MinIO engineering.
 
@@ -335,6 +340,11 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-tree-desc
           :end-before: end-mc-tree-desc
      
+   * - :mc:`mc undo`
+     - .. include:: /reference/minio-mc/mc-undo.rst
+          :start-after: start-mc-undo-desc
+          :end-before: end-mc-undo-desc
+
    * - :mc:`mc update`
      - .. include:: /reference/minio-mc/mc-update.rst
           :start-after: start-mc-update-desc
@@ -477,6 +487,7 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-mb
    /reference/minio-mc/mc-mirror
    /reference/minio-mc/mc-mv
+   /reference/minio-mc/mc-pipe
    /reference/minio-mc/mc-policy-set
    /reference/minio-mc/mc-policy-get
    /reference/minio-mc/mc-policy-list
@@ -509,10 +520,12 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-support-logs-status
    /reference/minio-mc/mc-support-perf
    /reference/minio-mc/mc-support-profile
+   /reference/minio-mc/mc-support-top
    /reference/minio-mc/mc-tag-set
    /reference/minio-mc/mc-tag-list
    /reference/minio-mc/mc-tag-remove
    /reference/minio-mc/mc-tree
+   /reference/minio-mc/mc-undo
    /reference/minio-mc/mc-update
    /reference/minio-mc/mc-version
    /reference/minio-mc/mc-watch

--- a/source/reference/minio-mc/mc-cp.rst
+++ b/source/reference/minio-mc/mc-cp.rst
@@ -30,6 +30,11 @@ the source can MinIO *or* a local filesystem.
 You can also use :mc:`mc cp` against the local filesystem to produce
 similar results to the ``cp`` commandline tool.
 
+.. note::
+
+   :mc:`mc cp` only copies the latest version or the specified version of an object without any version information or modification date.
+   To copy all versions, version information, and related metadata, use :mc:`mc replicate add` or :mc:`mc admin replicate`.
+
 .. tab-set::
 
    .. tab-item:: EXAMPLE
@@ -261,14 +266,14 @@ Parameters
    :mc-cmd:`~mc cp TARGET`. 
          
    See :aws-docs:`AmazonS3/latest/dev/storage-class-intro.html` for
-   more information on S3 storage classses.
+   more information on S3 storage classes.
 
 .. mc-cmd:: --tags
    
 
    *Optional* Applies one or more tags to the copied objects.
 
-   Specify an ampersand-seperated list of key-value pairs as 
+   Specify an ampersand-separated list of key-value pairs as 
    ``KEY1=VALUE1&KEY2=VALUE2``, where each pair represents one tag to
    assign to the objects.
 

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -20,6 +20,12 @@ The :mc:`mc mirror` command synchronizes content to MinIO deployment, similar to
 
 .. end-mc-mirror-desc
 
+.. note::
+   
+   :mc:`mc mirror` only synchronizes the current object without any version information or metadata.
+   To synchronize an object's version history and metadata, consider using :mc:`mc replicate` or :mc:`mc admin replicate`.
+
+
 .. tab-set::
 
    .. tab-item:: EXAMPLE
@@ -92,7 +98,7 @@ Parameters
 
 .. mc-cmd:: TARGET
 
-   *REQUIRED* The full path to bucket in which :mc:`mc mirror` copies synchronized SOURCE objects. Specify the ``TARGET`` as ``ALIAS/PATH``, where:
+   *REQUIRED* The full path to bucket to which :mc:`mc mirror` synchronizes SOURCE objects. Specify the ``TARGET`` as ``ALIAS/PATH``, where:
 
    - ``ALIAS`` is the :mc:`alias <mc alias>` of a configured S3-compatible host, *and*
 
@@ -113,7 +119,7 @@ Parameters
 .. mc-cmd:: --disable-multipart
    
 
-   Disables multipart upload for the copy session.
+   Disables multipart upload for the synchronization session.
 
 .. mc-cmd:: --encrypt-key
    
@@ -202,7 +208,7 @@ Parameters
    For example, objects A, B, and C exist on Source.
    Objects C, D, and E exist on Target.
 
-   When running ``mc mirror --remove``, objects A and B copy to Target and objects D and E are removed from Target.
+   When running ``mc mirror --remove``, objects A and B synchronize to Target and objects D and E are removed from Target.
    Since an object C already exists on both, nothing moves from Source to Target. 
 
    After the action, only objects A, B, and C exist on both the Source and the Target.

--- a/source/reference/minio-mc/mc-mv.rst
+++ b/source/reference/minio-mc/mc-mv.rst
@@ -46,6 +46,7 @@ similar results to the ``mv`` commandline tool.
          mc [GLOBALFLAGS] mv         \
          [--attr "string"]           \
          [--continue]                \
+         [--disable-multipart]       \
          [--encrypt "string"]        \
          [--encrypt-key "string"]    \
          [--newer-than "string"]     \
@@ -97,6 +98,7 @@ Parameters
    directory or bucket.
 
 .. mc-cmd:: TARGET
+   :required:
 
    *Required* The full path to the bucket to which the command moves the
    object(s) at the specified :mc-cmd:`~mc mv SOURCE`. Specify the 
@@ -136,6 +138,20 @@ Parameters
    
 
    *Optional* Create or resume a move session. 
+
+.. mc-cmd:: --disable-multipart
+   
+
+   *Optional* Disables the multipart upload feature.
+
+   Multipart upload breaks an object into a set of separate parts.
+   Each part uploads individually and in any order.
+   If any individual part upload fails, MinIO retries that part without affecting the other parts.
+   After upload completes, the parts combine to restore the original object.
+
+   MinIO recommends using multipart upload for any object larger than 100 MB.
+   For more information on multipart upload, refer to the :s3-docs:`Amazon S3 documentation <mpuoverview.html>`
+
 
 .. mc-cmd:: --encrypt
    

--- a/source/reference/minio-mc/mc-pipe.rst
+++ b/source/reference/minio-mc/mc-pipe.rst
@@ -1,0 +1,177 @@
+===========
+``mc pipe``
+===========
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc pipe
+
+Syntax
+------
+
+.. start-mc-pipe-desc
+
+The :mc:`mc pipe` command streams content from `STDIN <https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html>`__ to a target object.
+
+.. end-mc-pipe-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command writes contents of ``STDIN`` to an S3 compatible storage.
+
+      .. code-block:: shell
+         :class: copyable
+
+         echo "My Meeting Notes" | mc pipe s3/engineering/meeting-notes.txt
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] pipe                              \
+                          TARGET                            \
+                          [--encrypt "string"]              \
+                          [--storage-class, --sc "string"]  \
+                          [--attr "string"]                 \
+                          [--tags "string"]                 \
+                          [--encrypt-key "string"] 
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the :ref:`alias <mc-alias-set>` or prefix where the command should run.
+
+.. mc-cmd:: --attr
+   :optional:
+
+   Add custom metadata for the object.
+
+   Specify key-value pairs as ``KEY=VALUE\;``, separating each pair with a back slash and semicolon (``\;``). 
+   For example, ``--attr key1=value1\;key2=value2\;key3=value3``.
+
+.. mc-cmd:: --encrypt
+   :optional:
+   
+   Encrypt or decrypt objects using :ref:`server-side encryption <minio-sse>` with server-managed keys. 
+   Specify key-value pairs as ``KEY=VALUE``.
+   
+   - Each ``KEY`` represents a bucket or object. 
+   - Each ``VALUE`` represents the data key to use for encrypting object(s).
+
+   Enclose the entire list of key-value pairs passed to :mc-cmd:`~mc pipe --encrypt` in double-quotes ``"``.
+
+   :mc-cmd:`~mc pipe --encrypt` can use the ``MC_ENCRYPT`` environment variable for retrieving a list of encryption key-value pairs as an alternative to specifying them on the command line.
+
+.. mc-cmd:: --encrypt-key
+   :optional:
+
+   Encrypt or decrypt objects using server-side encryption with client-specified keys. 
+   Specify key-value pairs as ``KEY=VALUE``.
+   
+   - Each ``KEY`` represents a bucket or object. 
+   - Each ``VALUE`` represents the data key to use for encrypting object(s).
+
+   Enclose the entire list of key-value pairs passed to :mc-cmd:`~mc pipe --encrypt-key` in double quotes ``"``.
+
+   :mc-cmd:`~mc pipe --encrypt-key` can use the ``MC_ENCRYPT_KEY`` environment variable for retrieving a list of encryption key-value pairs as an alternative to specifying them on the command line.
+
+.. mc-cmd:: --storage-class, --sc
+   :optional:
+
+   Set the storage class for the new object at the :mc-cmd:`~mc pipe TARGET`. 
+         
+   See :aws-docs:`Amazons documentation <AmazonS3/latest/dev/storage-class-intro.html>` for more information on S3 storage classes.
+
+.. mc-cmd:: --tags
+   :optional:
+
+   Applies one or more tags to the TARGET.
+
+   Specify an ampersand-separated list of key-value pairs as ``KEY1=VALUE1&KEY2=VALUE2``, where each pair represents one tag to assign to the objects.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Write Contents of ``STDIN`` to the Local Filesystem
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command writes the contents of STDIN to the ``/tmp`` folder on the local filesystem.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc pipe /tmp/hello-world.go
+
+Copy an ISO Image to S3 Storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command first streams the contents of an iso image for Debian and then uses the stream to create the object at an S3 path.
+
+.. code-block:: shell
+   :class: copyable
+
+   cat debian-live-11.5.0-amd64-mate.iso | mc pipe s3/opensource-isos/debian-11-5.iso
+
+Stream MySQL Database Dump to S3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command first streams a MySQL database and uses the stream to create a backup on S3 with :mc-cmd:`mc pipe`:
+
+.. code-block:: shell
+   :class: copyable
+
+   mysqldump -u root -p ******* accountsdb | mc pipe s3/sql-backups/backups/accountsdb-sep-28-2022.sql
+
+Write a File to a Reduced Redundancy Storage Class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command takes the STDIN stream and creates an object on the Reduced Redundancy storage class on S3.
+
+.. code-block:: shell
+   :class: copyable
+
+    mc pipe --storage-class REDUCED_REDUNDANCY s3/personalbuck/meeting-notes.txt
+
+Copy a File to a MinIO Deployment with Metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command uploads an MP3 file to a MinIO deployment with an ALIAS of ``myminio`` and a ``music`` bucket.
+The object writes with some metadata for ``Cache-Control`` and ``Artist``.
+
+.. code-block:: shell
+   :class: copyable
+
+   cat music.mp3 | mc pipe --attr "Cache-Control=max-age=90000,min-fresh=9000;Artist=Unknown" myminio/music/guitar.mp3
+
+Set Tags on Uploaded Objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command creates an object on a MinIO deployment with an ALIAS of ``myminio`` in bucket ``mybucket`` with two tags.
+
+.. code-block:: shell
+   :class: copyable
+
+   tar cvf - . | mc pipe --tags "category=prod&type=backup" myminio/mybucket/backup.tar

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -23,10 +23,12 @@ The :mc:`mc replicate add` command creates a new :ref:`server-side replication
 
 .. end-mc-replicate-add-desc
 
-The MinIO deployment automatically begins synchronizing new objects to the
-remote MinIO deployment after creating the rule. You can optionally configure
-synchronization of existing objects, delete operations, and fully-deleted
-objects.
+.. note::
+
+   Where :mc:`mc mirror` only synchronizes the current version of an object, ``mc replicate`` synchronizes all versions, version information, and metadata for the objects.
+
+The MinIO deployment automatically begins synchronizing new objects to the remote MinIO deployment after creating the rule. 
+You can optionally configure synchronization of existing objects, delete operations, and fully-deleted objects.
 
 This command *requires* first configuring the remote bucket target using the
 :mc-cmd:`mc admin bucket remote add` command. You must specify the resulting

--- a/source/reference/minio-mc/mc-support-top-api.rst
+++ b/source/reference/minio-mc/mc-support-top-api.rst
@@ -1,0 +1,109 @@
+======================
+``mc support top api``
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc support top api
+
+Syntax
+------
+
+.. start-mc-support-top-api-desc
+
+The :mc:`mc support top api` command summarizes the real-time API events on a MinIO deployment server.
+
+.. end-mc-support-top-api-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command udisplays the current in-progress S3 API calls on the :term:`alias` ``myminio``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc support top api myminio/
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] support top api    \
+                          TARGET             \
+                          [--name "string"]  \
+                          [--path "string"]  \
+                          [--node "string"]  \
+                          [--errors, -e]
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the alias, prefix, or object where the command should run.
+   The path must include at least an :ref:`ALIAS <mc-alias-set>`.
+
+.. mc-cmd:: --name
+   :optional:
+
+   Outputs a summary of current API calls matching the entered string.
+
+
+.. mc-cmd:: --path
+   :optional:
+
+   Outputs a summary of current API calls for a specified path.
+
+.. mc-cmd:: --node
+   :optional:
+
+   Outputs a summary of the current API calls on matching servers.
+
+.. mc-cmd:: --errors, -e
+   :optional:
+
+   Outputs a summary of current API calls returning errors.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Display All Current In-progress S3 API Calls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command displays all in-progress S3 calls for the ``myminio`` deployment:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support top api myminio/
+
+Display Current, In-progress ``s3.PutObject`` Calls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command displays all in-progress ``s3.PutObject`` calls for the ``myminio`` deployment:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support top api --name s3.PutObject myminio/

--- a/source/reference/minio-mc/mc-support-top-disk.rst
+++ b/source/reference/minio-mc/mc-support-top-disk.rst
@@ -1,0 +1,69 @@
+=======================
+``mc support top disk``
+=======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc support top disk
+
+Syntax
+------
+
+.. start-mc-support-top-disk-desc
+
+The :mc:`mc support top disk` command displays current disk statistics.
+
+.. end-mc-support-top-disk-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command udisplays the current in-progress S3 API calls on the :term:`alias` ``myminio``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc support top disk myminio/
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] support top disk                     \
+                                      [--count, -c "integer"]  \
+                                      TARGET
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the :ref:`alias <mc-alias-set>` or :term:`prefix` where the command should run.
+
+.. mc-cmd:: --count, -c
+   :optional:
+
+   Display statistics for up to the entered number of disks.
+
+   If no entry is made, the command returns statistics for up to 10 disks.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+

--- a/source/reference/minio-mc/mc-support-top-locks.rst
+++ b/source/reference/minio-mc/mc-support-top-locks.rst
@@ -1,0 +1,87 @@
+========================
+``mc support top locks``
+========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc support top locks
+
+Syntax
+------
+
+.. start-mc-support-top-locks-desc
+
+The :mc:`mc support top locks` command lists the ten oldest locks on a MinIO deployment.
+
+.. end-mc-support-top-locks-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command displays the current in-progress S3 API calls on the :term:`alias` ``myminio``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc support top locks myminio/
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] support top locks  \
+                          [--stale]          \ 
+                          TARGET
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the :ref:`alias <mc-alias-set>` or prefix where the command should run.
+
+.. mc-cmd:: --stale
+   :optional:
+
+   Return only stale locks.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Display the 10 Oldest Locks on the ``myminio`` Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support top locks myminio/
+
+Display Stale Locks on the ``myminio`` Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command displays all in-progress ``s3.PutObject`` calls for the ``myminio`` deployment:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support top locks --stale myminio/

--- a/source/reference/minio-mc/mc-support-top.rst
+++ b/source/reference/minio-mc/mc-support-top.rst
@@ -1,0 +1,54 @@
+==================
+``mc support top``
+==================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc support top
+
+.. note::
+
+   .. versionchanged:: RELEASE.2022-08-11T00-30-48Z
+
+   ``mc support top`` replaces the ``mc admin top`` command.
+
+Description
+-----------
+
+.. start-mc-support-top-desc
+
+The :mc:`mc support top` command returns statistics for distributed
+MinIO deployments, similar to the output of the ``top`` command in a shell. 
+
+:mc:`mc support top` is not supported on single-node single-drive MinIO deployments.
+
+.. end-mc-support-top-desc
+
+:mc-cmd:`mc support top` has the following subcommands:
+
+- :mc-cmd:`~mc support top api`
+- :mc-cmd:`~mc support top locks`
+- :mc-cmd:`~mc support top disk`
+
+Refer to the pages linked above for each subcommand for details.
+
+Syntax
+------
+
+The command has the following syntax:
+
+.. code-block:: shell
+
+   mc support top COMMAND [COMMAND FLAGS] [ARGUMENTS ...]
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-support-top-api
+   /reference/minio-mc/mc-support-top-locks
+   /reference/minio-mc/mc-support-top-disk

--- a/source/reference/minio-mc/mc-undo.rst
+++ b/source/reference/minio-mc/mc-undo.rst
@@ -1,0 +1,125 @@
+.. _minio-mc-undo:
+
+===========
+``mc undo``
+===========
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc undo
+
+Syntax
+------
+
+.. start-mc-undo-desc
+
+The :mc:`mc undo` command reverses changes due to either a ``PUT`` or ``DELETE`` operation at a specified path.
+
+.. end-mc-undo-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command undoes the last three uploads and/or removals of the ``file.zip`` object on the ``myminio`` deployment in the ``data`` bucket:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc undo myminio/data/file.zip --last 3
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] undo               \
+                          TARGET             \
+                          [--last "integer"] \
+                          [--recursive, r]   \
+                          [--force]          \
+                          [--dry-run]
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the object or prefix where the command should run.
+   The path must include the :ref:`ALIAS <mc-alias-set>`, bucket, and prefix or object name.
+
+.. mc-cmd:: --last
+   :optional:
+
+   Accepts an integer value specifying the number of ``PUT`` and/or ``DELETE`` changes to undo.
+   
+   If not specified, the command undoes one (``1``) operation.
+
+.. mc-cmd:: --recursive, r
+   :optional:
+
+   Performs the command in a recursive fashion.
+   Use this flag to undo changes on a prefix, for example.
+
+.. mc-cmd:: --force
+   :optional:
+
+   Force a recursive operation.
+
+.. mc-cmd:: --dry-run
+   :optional:
+
+   Output the results of the command without actually performing the operations.
+   Use this flag to test the outcome of running the command in a particular way.
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Undo the Last Three Uploads or Deletions on an Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command undoes the last three uploads and/or removals of the ``file.zip`` object on the ``myminio`` deployment in the ``data`` bucket:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc undo myminio/data/file.zip --last 3
+
+Undo the Last Upload or Deletion of any Object at a Prefix
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc undo` to reverse the most recent ``PUT`` or ``DELETE`` operation performed on the ``myminio`` alias in the ``data`` bucket under the ``presentations/recordings/`` :term:`prefix`:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc undo myminio/data/presentations/recordings/ --recursive --force
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility


### PR DESCRIPTION
Addresses five outstanding Issues in the `mc` reference docs.

- Adds `--disable-multipart` flag for `mc mv` (Closes #516 )
- Adds `mc pipe` to reference docs (Closes #517 )
- Adds `mc undo` to reference docs (Closes #520 )
- Adds `mc support top` commands to replace `mc admin top` (Closes #526)
- Updates `mc cp`, `mc mirror`, `mc replicate`, and `mc admin replicate` to clarify the differences in what copies (Closes #532)