### PR TITLE
Changes to get Algolia crawler to pull OpenShift docs

### DIFF
--- a/source/administration/bucket-replication.rst
+++ b/source/administration/bucket-replication.rst
@@ -274,7 +274,7 @@ add to the queue.
 .. versionchanged:: RELEASE.2022-08-11T04-37-28Z
 
    Failed or pending replications requeue automatically when performing a list or any ``GET`` or ``HEAD`` API method. 
-   For example, using :mc:`mc stat`, :mc:`mc cat`,  or :mc-cmd:`mc ls` after a remote location comes back online requeues replication.
+   For example, using :mc:`mc stat`, :mc:`mc cat`,  or :mc:`mc ls` after a remote location comes back online requeues replication.
 
 MinIO sets the ``X-Amz-Replication-Status`` metadata field according to the
 replication state of the object:

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -182,7 +182,7 @@ elif tags.has("container"):
         'developers/*',
         'integrations/*'
     ]
-elif tags.has("k8s"):
+elif tags.has("k8s") and not tags.has("openshift"):
     html_baseurl = 'https://min.io/docs/minio/kubernetes/upstream/'
     excludes = [
         'operations/install-deploy-manage/deploy-minio-single-node-single-drive.rst',
@@ -196,7 +196,21 @@ elif tags.has("k8s"):
         'reference/minio-mc*',
         'developers/*',
         'integrations/*'
-
+    ]
+elif tags.has("openshift"):
+    html_baseurl = 'https://min.io/docs/minio/kubernetes/openshift/'
+    excludes = [
+        'operations/install-deploy-manage/deploy-minio-single-node-single-drive.rst',
+        'operations/install-deploy-manage/deploy-minio-single-node-multi-drive.rst',
+        'operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.rst',
+        'operations/install-deploy-manage/upgrade-minio-deployment.rst',
+        'operations/install-deploy-manage/expand-minio-deployment.rst',
+        'operations/install-deploy-manage/decommission-server-pool.rst',
+        'operations/manage-existing-deployments.rst',
+        'reference/minio-server*',
+        'reference/minio-mc*',
+        'developers/*',
+        'integrations/*'
     ]
 else:
     excludes = []

--- a/source/index.rst
+++ b/source/index.rst
@@ -72,7 +72,7 @@ and non-protected.
 
    .. include:: /includes/container/quickstart.rst
 
-.. cond:: k8s
+.. cond:: k8s or openshift
 
    .. toctree::
       :titlesonly:
@@ -121,7 +121,7 @@ and non-protected.
       /administration/bucket-replication
       /administration/concepts
 
-.. cond:: k8s or container or macos or windows
+.. cond:: k8s or openshift or container or macos or windows
 
    .. toctree::
       :titlesonly:
@@ -146,7 +146,7 @@ and non-protected.
       /reference/minio-server/minio-server
       /integrations/integrations
 
-.. cond:: k8s
+.. cond:: k8s or openshift
 
    .. toctree::
       :titlesonly:


### PR DESCRIPTION
Algolia's crawler is not picking up the OpenShift docs.
This has fixes to get the sitemap to build correctly so the OpenShift docs can be crawled.