### PR TITLE
Update guilabel style; fixes for build errors

### DIFF
--- a/source/_static/scss/includes/_reset.scss
+++ b/source/_static/scss/includes/_reset.scss
@@ -312,6 +312,15 @@ abbr, acronym {
     font-family: inherit;
 }
 
+.guilabel {
+    font-weight: bolder;
+    text-transform: lowercase;
+    font-variant: small-caps;
+    background: var(--theme-light-bg);
+    border-radius: 999px;
+    padding: 0rem .5rem 0rem .5rem;
+}
+
 dt:target,
 span.highlighted {
     background-color: transparent;

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -70,7 +70,7 @@ default applies the transition operation to the *current* object version.
 
 To transition noncurrent object versions, specify the 
 :mc-cmd:`~mc ilm add --noncurrentversion-transition-days` and
-:mc-cmd:`~mc ilm add --noncurrentversion-transition-storage-class` options
+:mc-cmd:`~mc ilm add --noncurrentversion-tier` options
 when creating the transition rule. 
 
 .. _minio-lifecycle-management-expiration:

--- a/source/includes/common-minio-tiering.rst
+++ b/source/includes/common-minio-tiering.rst
@@ -31,13 +31,13 @@ The example above specifies the following arguments:
      - Specify the full path to the bucket for which you are
        creating the lifecycle management rule.
 
-   * - :mc-cmd:`TIERNAME <mc ilm add --storage-class>`
+   * - :mc-cmd:`TIERNAME <mc ilm add --tier>`
      - The remote storage tier to which MinIO transitions objects. 
        Specify the remote storage tier name created in the previous step.
 
        If you want to transition noncurrent object versions to a distinct
        remote tier, specify a different tier name for 
-       :mc-cmd:`~mc ilm add --noncurrentversion-transition-storage-class`.
+       :mc-cmd:`~mc ilm add --noncurrentversion-tier`.
 
    * - :mc-cmd:`DAYS <mc ilm add --transition-days>`
      - The number of calendar days after which MinIO marks an object as 

--- a/source/reference/minio-mc/mc-license-info.rst
+++ b/source/reference/minio-mc/mc-license-info.rst
@@ -67,7 +67,7 @@ Parameters
 .. mc-cmd:: --airgap
    :optional:
 
-   Use in environments where the client machine running the :ref:`minio client <minio client>` does not have network access to SUBNET (for example, airgapped, firewalled, or similar configuration) to display instructions for how to register the deployment with SUBNET.
+   Use in environments where the client machine running the :ref:`minio client <minio-client>` does not have network access to SUBNET (for example, airgapped, firewalled, or similar configuration) to display instructions for how to register the deployment with SUBNET.
    
    If the deployment is airgapped, but the local device has network access, you do not need to use the ``--airgap`` flag.
 


### PR DESCRIPTION
Applies style changes to the `.guilabel` css class to better set off the labels in the docs:

- Adds a pill box effect
- bolds the text
- Applies the `--theme-light-bg` color variable to the background

Corrections for build errors

- `mc ilm add` changed `storage-class` flags to `tier` instead. Updated several pages with references to those flags.
- Corrects a bad reference in the `mc license info` doc to the minio client page that was missing a hyphen.