### PR TITLE
Attempting to enable github rendering of markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ sphinx-sitemap == 2.2.0
 sphinx-togglebutton === 0.3.2
 sphinxcontrib-images === 0.9.4
 myst-parser === 0.18.0
+linkify === 1.4
+linkify-it-py === 2.0.0

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -218,6 +218,10 @@ else:
 
 exclude_patterns.extend(excludes)
 
+# MyST Parser Customization
+myst_gfm_only = True
+myst_heading_anchors = 2
+
 # Copy-Button Customization
 
 copybutton_selector = "div.copyable pre"


### PR DESCRIPTION
# Summary

The default Markdown parser MyST provides doesn't seem to like the way we've designed our SDK Markdown docs.

This change *should* enable github-strict parsing. It also adds auto-headers to all H1s, which might resolve some of the TOC issues.

This gives us some breathing room to fixup the SDKs where we can still allow for the files to look good in GitHub, but know they will render properly on our Sphinx-built docs.