### PR TITLE
Release updates mc RELEASE.2022-11-07T23-47-39Z 

### DIFF
--- a/source/administration/bucket-replication.rst
+++ b/source/administration/bucket-replication.rst
@@ -196,7 +196,7 @@ or modifying a replication rule:
 
 - For existing replication rules, add ``"existing-objects"`` to the list of
   existing replication features using 
-  :mc-cmd:`mc replicate edit --replicate`. You must specify *all* desired
+  :mc-cmd:`mc replicate update --replicate`. You must specify *all* desired
   replication features when editing the replication rule. 
 
 Enabling existing object replication does not increase the priority of objects

--- a/source/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.rst
@@ -28,9 +28,9 @@ Multi-Site Active-Active replication configurations can span multiple racks, dat
 
 .. seealso::
 
-   - Use the :mc:`mc replicate edit` command to modify an existing replication rule.
+   - Use the :mc:`mc replicate update` command to modify an existing replication rule.
 
-   - Use the :mc:`mc replicate edit` command with the :mc-cmd:`--state "disable" <mc replicate edit --state>` flag to disable an existing replication rule.
+   - Use the :mc:`mc replicate update` command with the :mc-cmd:`--state "disable" <mc replicate update --state>` flag to disable an existing replication rule.
 
    - Use the :mc:`mc replicate rm` command to remove an existing replication rule.
 
@@ -86,7 +86,7 @@ Click to expand any of the following:
 
    MinIO supports automatically replicating existing objects in a bucket.
 
-   MinIO requires explicitly enabling replication of existing objects using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate edit --replicate` and including the ``existing-objects`` replication feature flag. 
+   MinIO requires explicitly enabling replication of existing objects using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate update --replicate` and including the ``existing-objects`` replication feature flag. 
    This procedure includes the required flags for enabling replication of existing objects.
 
 .. dropdown:: Replication of Delete Operations
@@ -99,7 +99,7 @@ Click to expand any of the following:
 
    - For delete operations on versions of an object, MinIO replication also deletes those versions on the target bucket.
 
-   MinIO requires explicitly enabling replication of delete operations using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate edit --replicate`. 
+   MinIO requires explicitly enabling replication of delete operations using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate update --replicate`. 
    This procedure includes the required flags for enabling replication of delete operations and delete markers.
 
    MinIO does *not* replicate delete operations resulting from the application of :ref:`lifecycle management expiration rules <minio-lifecycle-management-expiration>`. 

--- a/source/administration/bucket-replication/enable-server-side-one-way-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-one-way-bucket-replication.rst
@@ -48,7 +48,7 @@ Click to expand any of the following:
 
    MinIO supports automatically replicating existing objects in a bucket.
 
-   MinIO requires explicitly enabling replication of existing objects using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate edit --replicate` and including the ``existing-objects`` replication feature flag. 
+   MinIO requires explicitly enabling replication of existing objects using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate update --replicate` and including the ``existing-objects`` replication feature flag. 
    This procedure includes the required flags for enabling replication of existing objects.
 
 .. dropdown:: Replication of Delete Operations
@@ -61,7 +61,7 @@ Click to expand any of the following:
 
    - For delete operations on versions of an object, MinIO replication also deletes those versions on the target bucket.
 
-   MinIO requires explicitly enabling replication of delete operations using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate edit --replicate`. 
+   MinIO requires explicitly enabling replication of delete operations using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate update --replicate`. 
    This procedure includes the required flags for enabling replication of delete operations and delete markers.
 
    MinIO does *not* replicate delete operations resulting from the application of :ref:`lifecycle management expiration rules <minio-lifecycle-management-expiration>`.
@@ -150,8 +150,8 @@ This procedure assumes each alias corresponds to a user with the :ref:`necessary
 
 .. seealso::
 
-   - Use the :mc:`mc replicate edit` command to modify an existing replication rule.
+   - Use the :mc:`mc replicate update` command to modify an existing replication rule.
 
-   - Use the :mc:`mc replicate edit` command with the :mc-cmd:`--state "disable" <mc replicate edit --state>` flag to disable an existing replication rule.
+   - Use the :mc:`mc replicate update` command with the :mc-cmd:`--state "disable" <mc replicate update --state>` flag to disable an existing replication rule.
 
    - Use the :mc:`mc replicate rm` command to remove an existing replication rule.

--- a/source/administration/bucket-replication/enable-server-side-two-way-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-two-way-bucket-replication.rst
@@ -78,7 +78,7 @@ Considerations
 
    MinIO supports automatically replicating existing objects in a bucket.
 
-   MinIO requires explicitly enabling replication of existing objects using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate edit --replicate` and including the ``existing-objects`` replication feature flag. 
+   MinIO requires explicitly enabling replication of existing objects using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate update --replicate` and including the ``existing-objects`` replication feature flag. 
    This procedure includes the required flags for enabling replication of existing objects.
 
 .. dropdown:: Replication of Delete Operations
@@ -91,7 +91,7 @@ Considerations
 
    - For delete operations on versions of an object, MinIO replication also deletes those versions on the target bucket.
 
-   MinIO requires explicitly enabling replication of delete operations using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate edit --replicate`. 
+   MinIO requires explicitly enabling replication of delete operations using the :mc-cmd:`mc replicate add --replicate` or :mc-cmd:`mc replicate update --replicate`. 
    This procedure includes the required flags for enabling replication of delete operations and delete markers.
 
    MinIO does *not* replicate delete operations resulting from the application of :ref:`lifecycle management expiration rules <minio-lifecycle-management-expiration>`. 
@@ -202,9 +202,9 @@ Once both objects exist on both deployments, you have successfully set up two-wa
 
 .. seealso::
 
-   - Use the :mc:`mc replicate edit` command to modify an existing
+   - Use the :mc:`mc replicate update` command to modify an existing
      replication rule.
 
-   - Use the :mc:`mc replicate edit` command with the :mc-cmd:`--state "disable" <mc replicate edit --state>` flag to disable an existing replication rule.
+   - Use the :mc:`mc replicate update` command with the :mc-cmd:`--state "disable" <mc replicate update --state>` flag to disable an existing replication rule.
 
    - Use the :mc:`mc replicate rm` command to remove an existing replication rule.

--- a/source/administration/identity-access-management/oidc-access-management.rst
+++ b/source/administration/identity-access-management/oidc-access-management.rst
@@ -77,6 +77,6 @@ Defer to the documentation for your preferred OIDC provider for instructions on 
 Creating Policies to Match Claims
 ---------------------------------
 
-Use either the MinIO Console *or* the :mc:`mc admin policy` command to create policies that match one or more claim values:
+Use either the MinIO Console *or* the :mc:`mc admin policy` command to create policies that match one or more claim values.
 
 .. todo - instructions

--- a/source/administration/identity-access-management/policy-based-access-control.rst
+++ b/source/administration/identity-access-management/policy-based-access-control.rst
@@ -772,6 +772,10 @@ services:
 .. policy-action:: admin:StartBatchJob
 
    Allows user to begin a batch job run.
+   
+.. policy-action:: admin:Rebalance
+
+   Allows access to start, query, or stop a rebalancing of objects across pools with varying free storage space.
 
 ``mc admin`` Policy Condition Keys
 ----------------------------------

--- a/source/operations/concepts.rst
+++ b/source/operations/concepts.rst
@@ -126,6 +126,27 @@ There are several options to manage your MinIO deployments and clusters:
 - The :ref:`MinIO Console <minio-console>` graphical user interface for individual instances
 - In Kubernetes, with the :ref:`MinIO Operator Console <minio-operator-console>`
 
+.. _minio-rebalance:
+
+How do I manage object distribution across a MinIO deployment?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MinIO optimizes storage of objects across available pools by writing new objects (that is, objects with no existing versions) to the server pool with the most free space compared total amount of free space on all available server pools.
+MinIO does not perform the costly action of rebalancing objects from older pools to newer pools.
+Instead, new objects typically route to the new pool as it has the most free space.
+As that pool fills, new write operations eventually balance out across all pools in the deployment.
+For more information on write preference calculation logic, see :ref:`Writing Files <minio-writing-files>` below.
+
+Rebalancing data across all pools after an expansion is an expensive operation that requires scanning the entire deployment and moving objects between pools.
+This may take a long time to complete depending on the amount of data to move.
+
+Starting with MinIO Client version RELEASE.2022-11-07T23-47-39Z, you can manually initiate a rebalancing operation across all server pools using :mc:`mc admin rebalance`. 
+
+Rebalancing does not block ongoing operations and runs in parallel to all other I/O. 
+This can result in reduced performance of regular operations. 
+Consider scheduling rebalancing operations during non-peak periods to avoid impacting production workloads. 
+You can start and stop rebalancing at any time
+
 How do I upload objects to MinIO?
 ---------------------------------
 

--- a/source/operations/install-deploy-manage/expand-minio-deployment.rst
+++ b/source/operations/install-deploy-manage/expand-minio-deployment.rst
@@ -28,6 +28,7 @@ The procedure on this page expands an existing
 :ref:`distributed <deploy-minio-distributed>` MinIO deployment with an
 additional server pool. 
 
+
 .. _expand-minio-distributed-prereqs:
 
 Prerequisites
@@ -132,10 +133,12 @@ erasure parity settings.
 Considerations
 --------------
 
+.. _minio-writing-files:
+
 Writing Files
 ~~~~~~~~~~~~~
 
-MinIO does not rebalance objects across the new server pools. 
+MinIO does not automatically rebalance objects across the new server pools. 
 Instead, MinIO performs new write operations to the pool with the most free
 storage weighted by the amount of free space on the pool divided by the free space across all available pools.
 
@@ -157,6 +160,9 @@ MinIO calculates the probability of a write operation to each of the pools as:
 
 In addition to the free space calculation, if a write option (with parity) would bring a disk
 usage above 99% or a known free inode count below 1000, MinIO does not write to the pool.
+
+If desired, you can manually initiate a rebalance procedure with :mc:`mc admin rebalance`.
+For more about how rebalancing works, see :ref:`managing objects across a deployment <minio-rebalance>`.
 
 Likewise, MinIO does not write to pools in a decommissioning process.
 

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -65,6 +65,16 @@ The following table lists :mc:`mc admin` commands:
           :start-after: start-mc-admin-heal-desc
           :end-before: end-mc-admin-heal-desc
 
+   * - :mc-cmd:`mc admin idp ldap`
+     - .. include:: /reference/minio-mc-admin/mc-admin-heal.rst
+          :start-after: start-mc-admin-idp-ldap-desc
+          :end-before: end-mc-admin-idp-ldap-desc
+  
+   * - :mc-cmd:`mc admin idp openid`
+     - .. include:: /reference/minio-mc-admin/mc-admin-heal.rst
+          :start-after: start-mc-admin-idp-openid-desc
+          :end-before: end-mc-admin-idp-openid-desc
+
    * - :mc-cmd:`mc admin info`
      - .. include:: /reference/minio-mc-admin/mc-admin-info.rst
           :start-after: start-mc-admin-info-desc
@@ -94,6 +104,11 @@ The following table lists :mc:`mc admin` commands:
      - .. include:: /reference/minio-mc-admin/mc-admin-prometheus.rst
           :start-after: start-mc-admin-prometheus-desc
           :end-before: end-mc-admin-prometheus-desc
+
+   * - :mc-cmd:`mc admin rebalance`
+     - .. include:: /reference/minio-mc-admin/mc-admin-rebalance.rst
+          :start-after: start-mc-admin-rebalance-desc
+          :end-before: end-mc-admin-rebalance-desc
 
    * - :mc-cmd:`mc admin replicate`
      - .. include:: /reference/minio-mc-admin/mc-admin-replicate.rst
@@ -186,8 +201,8 @@ the newly added MinIO deployment:
 Global Options
 --------------
 
-:mc:`mc admin` supports the same global options as 
-:mc-cmd:`mc`. See :ref:`minio-mc-global-options`.
+:mc:`mc admin` supports the same global options as :mc-cmd:`mc`. 
+See :ref:`minio-mc-global-options`.
 
 .. toctree::
    :titlesonly:

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -1932,6 +1932,8 @@ using these environment variables.
       This configuration setting corresponds with the 
       :envvar:`MINIO_NOTIFY_WEBHOOK_COMMENT` environment variable.
 
+.. _minio-ldap-config-settings:
+
 Active Directory / LDAP Identity Management
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2123,6 +2125,8 @@ configuration settings.
 
       This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_COMMENT` environment variable.   
+
+.. _minio-open-id-config-settings:
 
 OpenID Identity Management
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc-admin/mc-admin-idp-ldap.rst
+++ b/source/reference/minio-mc-admin/mc-admin-idp-ldap.rst
@@ -1,0 +1,309 @@
+.. _minio-mc-admin-idp-ldap:
+
+=====================
+``mc admin idp ldap``
+=====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin idp ldap
+
+Description
+-----------
+
+.. start-mc-admin-idp-ldap-desc
+
+The :mc-cmd:`mc admin idp ldap` commands allow you to add, modify, review, list, remove, enable, and disable server configurations to 3rd party :ref:`Active Directory or LDAP Identity and Access Management (IAM) integrations <minio-external-identity-management-ad-ldap>`.
+
+.. end-mc-admin-idp-ldap-desc
+
+Define configuration settings as an alternative to using environment variables when :ref:`setting up an AD/LDAP connection <minio-authenticate-using-ad-ldap-generic>`.
+
+.. note::
+
+   Configuration settings do **not** override settings configured as environment variables.
+
+
+The :mc-cmd:`mc admin idp ldap` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc admin idp ldap add`
+     - Create an AD/LDAP IDP server configuration.
+
+   * - :mc-cmd:`mc admin idp ldap update`
+     - Modify an existing AD/LDAP IDP server configuration.
+
+   * - :mc-cmd:`mc admin idp ldap remove`
+     - Remove an AD/LDAP IDP server configuration from a deployment.
+
+   * - :mc-cmd:`mc admin idp ldap list`
+     - Outputs a list of the existing AD/LDAP server configurations for a deployment.
+
+   * - :mc-cmd:`mc admin idp ldap info`
+     - Displays details for a specific AD/LDAP server configuration.
+
+   * - :mc-cmd:`mc admin idp ldap enable`
+     - Enables an AD/LDAP server configuration.
+
+   * - :mc-cmd:`mc admin idp ldap disable`
+     - Disables an AD/LDAP server configuration.
+
+Configuration Parameters
+------------------------
+
+The :mc-cmd:`mc admin idp ldap` subcommands support configuration parameters.
+The parameters define the server's interaction with the Active Directory or LDAP IAM provider.
+
+For a more detailed explanation of the configuration parameters, refer to the :ref:`config setting documentation <minio-ldap-config-settings>`.
+
+Syntax
+------
+
+.. mc-cmd:: add
+
+   Create a new set of configurations for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example creates the configuration settings for the ``myminio`` deployment as defined in a new ``test-config`` setup for LDAP integration.
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc admin idp ldap add                                               \
+                  myminio                                                        \
+                  test-config                                                    \                                                        
+                  server_addr=myldapserver:636                                   \                                                       
+                  lookup_bind_dn=cn=admin,dc=min,dc=io                           \                                               
+                  lookup_bind_password=somesecret                                \                                                    
+                  user_dn_search_base_dn=dc=min,dc=io                            \                                                
+                  user_dn_search_filter="(uid=%s)"                               \                                                   
+                  group_search_base_dn=ou=swengg,dc=min,dc=io                    \                                        
+                  group_search_filter="(&(objectclass=groupofnames)(member=%d))"                                                          
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp ldap add          \
+                                       ALIAS             \
+                                       [CFG_NAME]        \
+                                       [CFG_PARAM1]      \
+                                       [CFG_PARAM2]...
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command creates default configuration values.
+         - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-ldap-config-settings>` key-value pairs in the format of ``PARAMETER="value"``.
+
+.. mc-cmd:: update
+
+   Modify an existing set of configurations for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example changes two of the configuration settings for the ``myminio`` deployment as defined in the ``test-config`` setup for LDAP integration.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp ldap update                                \
+                              myminio                               \
+                              test_config                           \
+                              lookup_bind_dn=cn=admin,dc=min,dc=io  \
+                              lookup_bind_password=somesecret                                                              
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp ldap update           \
+                                            ALIAS            \
+                                            [CFG_NAME]       \
+                                            [CFG_PARAM1]     \
+                                            [CFG_PARAM2]...
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command updates the default configuration.
+         - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-ldap-config-settings>` key-value pairs to update in the format of ``PARAMETER="value"``.
+
+.. mc-cmd:: remove
+
+   Remove an existing set of configurations for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example removes the ``test-config`` settings for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp ldap remove myminio test_config                                                              
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp ldap remove     \
+                                            ALIAS      \
+                                            [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command removes the default configurations. 
+
+.. mc-cmd:: list
+
+   Outputs a list of existing configuration sets for AD/LDAP providers.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example outputs a list of all AD/LDAP configuration sets defined for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp ldap list myminio                                                            
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp ldap list ALIAS
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to list AD/LDAP integration for.
+
+
+.. mc-cmd:: info
+
+   Outputs the set of values defined for an existing set of server configurations for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example outputs the configuration settings defined for the ``test_config`` set of AD/LDAP settings on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp ldap update myminio test_config                                                              
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp ldap update     \
+                                            ALIAS      \
+                                            [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the information displays for the default server configuration.
+
+.. mc-cmd:: enable
+
+   Begin using an existing set of configurations for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example enables the server configurations defined as ``test_config`` on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp ldap enable       \
+                              myminio      \
+                              test_config
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp ldap enable     \
+                                            ALIAS      \
+                                            [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command enables the default configuration values.
+
+.. mc-cmd:: disable
+
+   Stop using a set of configurations for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example disables the server configurations defined as ``test_config`` on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp ldap disable      \
+                              myminio      \
+                              test_config
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp ldap disable       \
+                                            ALIAS         \
+                                            [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command disables the default configuration values.
+
+
+
+Global Flags
+------------
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc-admin/mc-admin-idp-openid.rst
+++ b/source/reference/minio-mc-admin/mc-admin-idp-openid.rst
@@ -1,0 +1,302 @@
+.. _minio-mc-admin-idp-openid:
+
+=======================
+``mc admin idp openid``
+=======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin idp openid
+
+Description
+-----------
+
+.. start-mc-admin-idp-openid-desc
+
+The :mc-cmd:`mc admin idp openid` commands allow you to add, modify, review, list, remove, enable, and disable server configurations to 3rd party :ref:`OpenID Identity and Access Management (IAM) integrations <minio-external-identity-management-openid>`.
+
+.. end-mc-admin-idp-openid-desc
+
+Define configuration settings as an alternative to using environment variables when :ref:`setting up an OpenID connection <minio-external-identity-management-openid-configure>`.
+
+
+The :mc-cmd:`mc admin idp openid` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc admin idp openid add`
+     - Create an OpenID IDP server configuration.
+
+   * - :mc-cmd:`mc admin idp openid update`
+     - Modify an existing OpenID IDP server configuration.
+
+   * - :mc-cmd:`mc admin idp openid remove`
+     - Remove an OpenID IDP server configuration from a deployment.
+
+   * - :mc-cmd:`mc admin idp openid list`
+     - Outputs a list of the existing OpenID server configurations for a deployment.
+
+   * - :mc-cmd:`mc admin idp openid info`
+     - Displays details for a specific OpenID server configuration.
+
+   * - :mc-cmd:`mc admin idp openid enable`
+     - Enables an OpenID server configuration.
+
+   * - :mc-cmd:`mc admin idp openid disable`
+     - Disables an OpenID server configuration.
+
+Configuration Parameters
+------------------------
+
+The :mc-cmd:`mc admin idp openid` subcommands support configuration parameters.
+The parameters define the server's interaction with the IAM provider.
+
+For a more detailed explanation of the configuration parameters, refer to the :ref:`config setting documentation <minio-open-id-config-settings>`.
+
+Syntax
+------
+
+.. mc-cmd:: add
+
+   Create a new set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example creates the configuration settings for the ``myminio`` deployment as defined in a new ``test-config`` setup for Dex integration.
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc admin idp openid add myminio test-config                                  \                                                
+                client_id=minio-client-app                                                \
+                client_secret=minio-client-app-secret                                     \           
+                config_url="http://localhost:5556/dex/.well-known/openid-configuration"   \
+                scopes="openid,groups"                                                    \
+                redirect_uri="http://127.0.0.1:10000/oauth_callback"                      \
+                role_policy="consoleAdmin"                                                           
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp openid add        \
+                                       ALIAS             \
+                                       [CFG_NAME]        \
+                                       [CFG_PARAM1]      \
+                                       [CFG_PARAM2]...
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command creates default configuration values.
+         - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-open-id-config-settings>` key-value pairs in the format of ``PARAMETER="value"``.
+
+.. mc-cmd:: update
+
+   Modify an existing set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example changes two of the configuration settings for the ``myminio`` deployment as defined in the ``test-config`` setup for Dex integration.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp openid update                      \
+                                myminio                     \
+                                test_config                 \
+                                scopes="openid,groups"      \
+                                role_policy="consoleAdmin"                                                              
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp openid update           \
+                                              ALIAS            \
+                                              [CFG_NAME]       \
+                                              [CFG_PARAM1]     \
+                                              [CFG_PARAM2]...
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command updates the default configuration.
+         - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-open-id-config-settings>` key-value pairs to update in the format of ``PARAMETER="value"``.
+
+.. mc-cmd:: remove
+
+   Remove an existing set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example removes the ``test-config`` settings for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp openid remove myminio test_config                                                              
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp openid remove     \
+                                              ALIAS      \
+                                              [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command removes the default configurations. 
+
+.. mc-cmd:: list
+
+   Outputs a list of existing configuration sets for OpenID providers.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example outputs a list of all OpenID configuration sets defined for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp openid list myminio                                                            
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp openid list ALIAS
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to list OpenID integrations for.
+
+
+.. mc-cmd:: info
+
+   Outputs the set of values defined for an existing set of server configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example outputs the configuration settings defined for the ``test_config`` set of OpenID settings on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp openid update myminio test_config                                                              
+                                    
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp openid update     \
+                                              ALIAS      \
+                                              [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the information displays for the default server configuration.
+
+.. mc-cmd:: enable
+
+   Begin using an existing set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example enables the server configurations defined as ``test_config`` on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp openid enable       \
+                                myminio      \
+                                test_config
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp openid enable     \
+                                              ALIAS      \
+                                              [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command enables the default configuration values.
+
+.. mc-cmd:: disable
+
+   Stop using a set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example disables the server configurations defined as ``test_config`` on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin idp openid disable      \
+                                myminio      \
+                                test_config
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp openid disable       \
+                                              ALIAS         \
+                                              [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command disables the default configuration values.
+
+
+
+Global Flags
+------------
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc-admin/mc-admin-rebalance.rst
+++ b/source/reference/minio-mc-admin/mc-admin-rebalance.rst
@@ -1,0 +1,162 @@
+.. _minio-mc-admin-rebalance:
+
+======================
+``mc admin rebalance``
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin rebalance
+
+Permission
+----------
+
+This command requires that the user performing it have the :policy-action:`admin:Rebalance` :ref:`policy action <minio-policy>` for the deployment.
+
+Description
+-----------
+
+.. start-mc-admin-rebalance-desc
+
+The :mc-cmd:`mc admin rebalance` command allows starts, monitors, or stops a rebalancing operation on a MinIO deployment.
+Rebalancing redistributes objects across all pools in the deployment.
+
+.. end-mc-admin-rebalance-desc
+
+MinIO does not automatically rebalance objects when adding a new server pool.
+Instead, MinIO ref:`writes new objects <minio-writing-files>` to the pool with relatively more free space compared to the other available pools on the deployment.
+Triggering a manual rebalancing procedure prompts MinIO to scan the entire deployment and move objects as necessary to achieve a similar available free space across all pools.
+
+This is an expensive and time consuming operation.
+Consider only running a rebalance procedure during light or no use of the deployment.
+If write operations do occur during a rebalance operation, they process in parallel and write to a pool not actively in rebalancing.
+
+You can stop a rebalance and start it again later as needed.
+
+Follow the progress of an ongoing rebalance operation using the following command:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin trace --call rebalance ALIAS
+
+.. admonition:: Use ``mc admin`` on MinIO Deployments Only
+   :class: note
+
+   .. include:: /includes/facts-mc-admin.rst
+      :start-after: start-minio-only
+      :end-before: end-minio-only
+
+
+The :mc-cmd:`mc admin rebalance` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc admin rebalance start`
+     - Starts a rebalance operation on a MinIO deployment.
+
+   * - :mc-cmd:`mc admin rebalance status`
+     - Outputs the current status of an in-progress rebalance operation.
+
+   * - :mc-cmd:`mc admin rebalance stop`
+     - Stops an in-progress rebalance operation.
+
+Syntax
+------
+
+.. mc-cmd:: start
+   :fullpath:
+
+   Start a rebalance operation for a MinIO deployment.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLES
+
+         Consider a MinIO deployment with two pools with an assigned alias of ``minio1``.
+         One pool has 250 GB of free space while the other pool has 3 TB of free space.
+
+         The :mc:`mc admin rebalance` command shifts objects from the pool with less free space to the pool with more free space so that there is roughly equal free space on both pools.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin rebalance start minio1
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin rebalance start ALIAS
+
+         - Replace ALIAS with the :ref:`alias <alias>` of a MinIO deployment to rebalance.
+
+.. mc-cmd:: status
+   :fullpath:
+
+   Queries the deployment with an active rebalance process and returns information about the status of the rebalance process.
+
+   The status returns the ID of the rebalance operation, the time of the operation, and details for each pool on the deployment.
+   For each pool, the status shows the pool ID, the pool's rebalance status, the percentage of used space, and rebalance progress for the pool.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin rebalance status minio1
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+
+            mc [GLOBALFLAGS] admin rebalance ALIAS
+      
+         - Replace ALIAS with the :ref:`alias <alias>` of the MinIO deployment.
+
+.. mc-cmd:: stop
+   :fullpath:
+
+   Ends an in-progress rebalance job on the specified deployment.
+
+   .. tab-set::
+      
+      .. tab-item:: EXAMPLES
+         
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin rebalance stop minio1
+        
+      .. tab-item:: SYNTAX
+         
+         The command has the following syntax:
+
+         .. code-block:: shell
+            
+            mc [GLOBALFLAGS] admin rebalance stop ALIAS
+
+         - Replace ALIAS with the :ref:`alias <alias>` of the MinIO deployment.
+
+Global Flags
+------------
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -85,7 +85,7 @@ Syntax
 
             mc admin replicate add minio1 minio2 minio3
 
-         The following command explands an existing site replication that includes peer site ``minio1`` to an additional peer site, ``minio5``.
+         The following command expands an existing site replication that includes peer site ``minio1`` to an additional peer site, ``minio5``.
          ``minio5`` contains no data.
 
          .. code-block:: shell

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -299,13 +299,13 @@ The following table lists :mc-cmd:`mc` commands:
 
    * - | :mc:`mc replicate add`
        | :mc:`mc replicate diff`
-       | :mc:`mc replicate edit`
        | :mc:`mc replicate export`
        | :mc:`mc replicate import`
        | :mc:`mc replicate ls`
        | :mc:`mc replicate resync`
        | :mc:`mc replicate rm`
        | :mc:`mc replicate status`
+       | :mc:`mc replicate update`
 
      - The :mc:`mc replicate <mc replicate add>` command configures and
        manages the :ref:`Server-Side Bucket Replication
@@ -519,8 +519,8 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-rb
    /reference/minio-mc/mc-replicate-add
    /reference/minio-mc/mc-replicate-diff
-   /reference/minio-mc/mc-replicate-edit
    /reference/minio-mc/mc-replicate-ls
+   /reference/minio-mc/mc-replicate-update
    /reference/minio-mc/mc-replicate-resync
    /reference/minio-mc/mc-replicate-rm
    /reference/minio-mc/mc-replicate-status

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -104,14 +104,14 @@ Parameters
 
    *Optional* Creates the replication rule in the "disabled" state. MinIO does
    not begin replicating objects using the rule until it is enabled using
-   :mc:`mc replicate edit`.
+   :mc:`mc replicate update`.
 
    Objects created while replication is disabled are not
    immediately eligible for replication after enabling the rule.
    You must explicitly enable replication of existing
    objects by including ``"existing-objects"`` to the list of
    replication features specified to 
-   :mc-cmd:`mc replicate edit --replicate`. See
+   :mc-cmd:`mc replicate update --replicate`. See
    :ref:`minio-replication-behavior-existing-objects` for more
    information.
 
@@ -371,7 +371,7 @@ metadata-only update to an object with the ``REPLICA`` status, MinIO marks the
 object as ``PENDING`` and eligible for replication.
 
 To disable metadata synchronization, use the 
-:mc-cmd:`mc replicate edit --replicate` command and omit 
+:mc-cmd:`mc replicate update --replicate` command and omit 
 ``replica-metadata-sync`` from the replication feature list. 
 
 Replication of Delete Operations

--- a/source/reference/minio-mc/mc-replicate-update.rst
+++ b/source/reference/minio-mc/mc-replicate-update.rst
@@ -1,8 +1,9 @@
 .. _minio-mc-replicate-edit:
+.. _minio-mc-replicate-update:
 
-=====================
-``mc replicate edit``
-=====================
+=======================
+``mc replicate update``
+=======================
 
 .. default-domain:: minio
 
@@ -11,20 +12,25 @@
    :depth: 2
 
 .. mc:: mc replicate edit
+.. mc:: mc replicate update
+
+.. versionchanged:: RELEASE.2022-11-07T23-47-39Z
+
+   ``mc replicate update`` replaces the ``mc replicate edit`` command.
 
 Syntax
 ------
 
-.. start-mc-replicate-edit-desc
+.. start-mc-replicate-update-desc
 
-The :mc:`mc replicate edit` command modifies an existing 
+The :mc:`mc replicate update` command modifies an existing 
 :ref:`bucket replication rule <minio-bucket-replication-serverside>`.
 
-.. end-mc-replicate-edit-desc
+.. end-mc-replicate-update-desc
 
 .. code-block:: shell
 
-   mc [GLOBALFLAGS] replicate edit FLAGS [FLAGS] ARGUMENTS [ARGUMENTS]
+   mc [GLOBALFLAGS] replicate update FLAGS [FLAGS] ARGUMENTS [ARGUMENTS]
 
 .. tab-set::
 
@@ -36,7 +42,7 @@ The :mc:`mc replicate edit` command modifies an existing
       .. code-block:: shell
          :class: copyable
 
-         mc replicate edit --id "c76um9h4b0t1ijr36mug"           \
+         mc replicate update --id "c76um9h4b0t1ijr36mug"           \
             --replicate "delete,delete-marker,existing-objects"  \
             myminio/mydata
 
@@ -51,7 +57,7 @@ The :mc:`mc replicate edit` command modifies an existing
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] replicate edit                \
+         mc [GLOBALFLAGS] replicate update              \
                           --id "string"                 \
                           [--remote-bucket "string"]    \
                           [--disable]                   \
@@ -78,38 +84,38 @@ Parameters
 
    .. code-block:: none
 
-      mc replicate edit --id "c75nrap4b0talo3ipthg" [FLAGS]
+      mc replicate update --id "c75nrap4b0talo3ipthg" [FLAGS]
 
 .. mc-cmd:: --id
+   :required:
    
-
-   *Required* Specify the unique ID for a configured replication rule. 
+   Specify the unique ID for a configured replication rule. 
    Use the :mc:`mc replicate ls` command to list the replication rules
    for a bucket.
 
 .. mc-cmd:: --priority
-   
+   :optional:
 
-   *Optional* Specify the integer priority of the replication rule. The value
-   *must* be unique among all other rules on the source bucket. Higher values
-   imply a *higher* priority than all other rules.
+   Specify the integer priority of the replication rule. 
+   The value *must* be unique among all other rules on the source bucket. 
+   Higher values imply a *higher* priority than all other rules.
 
 .. mc-cmd:: --remote-bucket
-   
+   :optional:
 
-    *Optional* Specify the ARN for the destination deployment and bucket. You
-    can retrieve the ARN using :mc-cmd:`mc admin bucket remote`:
+   Specify the ARN for the destination deployment and bucket. 
+   You can retrieve the ARN using :mc-cmd:`mc admin bucket remote`:
     
-    - Use the :mc-cmd:`mc admin bucket remote ls` to retrieve a list of 
-      ARNs for the bucket on the destination deployment.
+   - Use the :mc-cmd:`mc admin bucket remote ls` to retrieve a list of 
+     ARNs for the bucket on the destination deployment.
 
-    - Use the :mc-cmd:`mc admin bucket remote add` to create a replication ARN
+   - Use the :mc-cmd:`mc admin bucket remote add` to create a replication ARN
       for the bucket on the destination deployment. 
 
 .. mc-cmd:: --replicate
-   
+   :optional:
 
-   *Optional* Specify a comma-separated list of the following values to enable
+   Specify a comma-separated list of the following values to enable
    extended replication features:
 
    - ``delete`` - Directs MinIO to replicate DELETE operations to the
@@ -135,9 +141,9 @@ Parameters
      information.
 
 .. mc-cmd:: --state
-   
+   :optional:
 
-   *Optional* Enables or disables the replication rule. Specify one of the
+   Enables or disables the replication rule. Specify one of the
    following values:
 
    - ``"enable"`` - Enables the replication rule.
@@ -148,24 +154,24 @@ Parameters
    for replication after enabling the rule. You must explicitly enable
    replication of existing objects by including ``"existing-objects"`` to the
    list of replication features specified to 
-   :mc-cmd:`mc replicate edit --replicate`. See
+   :mc-cmd:`mc replicate update --replicate`. See
    :ref:`minio-replication-behavior-existing-objects` for more information.
 
 .. mc-cmd:: --storage-class
-   
+   :optional:
 
-   *Optional*  Specify the MinIO :ref:`storage class <minio-ec-storage-class>`
+   Specify the MinIO :ref:`storage class <minio-ec-storage-class>`
    to apply to replicated objects. 
 
 .. mc-cmd:: --tags
-   
+   :optional:
 
-   *Optional* Specify one or more ampersand ``&`` separated key-value pair tags
+   Specify one or more ampersand ``&`` separated key-value pair tags
    which MinIO uses for filtering objects to replicate. For example:
 
    .. code-block:: shell
 
-      mc replicate edit --id "ID" --tags "TAG1=VALUE&TAG2=VALUE&TAG3=VALUE"
+      mc replicate update --id "ID" --tags "TAG1=VALUE&TAG2=VALUE&TAG3=VALUE"
 
    MinIO applies the replication rule to any object whose tag set
    contains the specified replication tags.
@@ -183,58 +189,58 @@ Examples
 Modify an Existing Replication Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc replicate edit` to modify an existing replication rule.
+Use :mc:`mc replicate update` to modify an existing replication rule.
 
 .. code-block:: shell
    :class: copyable
 
-   mc replicate edit ALIAS/PATH \
-      --id ID \
+   mc replicate update ALIAS/PATH \
+      --id ID                     \
       [--FLAGS]
 
-- Replace :mc-cmd:`ALIAS <mc replicate edit ALIAS>` with the 
+- Replace :mc-cmd:`ALIAS <mc replicate update ALIAS>` with the 
   :mc:`alias <mc alias>` of the MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc replicate edit ALIAS>` with the path to the 
+- Replace :mc-cmd:`PATH <mc replicate update ALIAS>` with the path to the 
   bucket or bucket prefix on which the rule exists.
 
-- Replace :mc-cmd:`ID <mc replicate edit --id>` with the unique identifier for the
+- Replace :mc-cmd:`ID <mc replicate update --id>` with the unique identifier for the
   rule to modify. Use :mc:`mc replicate ls` to retrieve the list of 
   replication rules on the bucket and their corresponding identifiers.
 
 .. note::
 
    Modifying a replication configuration rule does not effect already replicated
-   objects. For example, modifying the :mc-cmd:`~mc replicate edit --tags`
+   objects. For example, modifying the :mc-cmd:`~mc replicate update --tags`
    filter does not result in the removal of replicated objects which do not
    meet the filter.
 
 Disable or Enable an Existing Replication Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc replicate edit` with the
-:mc-cmd:`~mc replicate edit --state` flag to disable or enable a 
+Use :mc:`mc replicate update` with the
+:mc-cmd:`~mc replicate update --state` flag to disable or enable a 
 replication rule.
 
 .. code-block:: shell
    :class: copyable
 
-   mc replicate edit ALIAS/PATH \
+   mc replicate update ALIAS/PATH \
       --id ID \
       --state "disabled"|"enabled"
 
-- Replace :mc-cmd:`ALIAS <mc replicate edit ALIAS>` with the 
+- Replace :mc-cmd:`ALIAS <mc replicate update ALIAS>` with the 
   :mc:`alias <mc alias>` of the MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc replicate edit ALIAS>` with the path to the 
+- Replace :mc-cmd:`PATH <mc replicate update ALIAS>` with the path to the 
   bucket or bucket prefix on which the rule exists.
 
-- Replace :mc-cmd:`ID <mc replicate edit --id>` with the unique identifier for the
+- Replace :mc-cmd:`ID <mc replicate update --id>` with the unique identifier for the
   rule to modify. Use :mc:`mc replicate ls` to retrieve the list of 
   replication rules on the bucket and their corresponding identifiers.
 
 - Specify either ``"disabled"`` or ``"enabled"`` to the 
-  :mc-cmd:`~mc replicate edit --state` flag to disable or enable the replication
+  :mc-cmd:`~mc replicate update --state` flag to disable or enable the replication
   rule.
 
 .. note::

--- a/source/reference/minio-mc/mc-support-inspect.rst
+++ b/source/reference/minio-mc/mc-support-inspect.rst
@@ -20,9 +20,7 @@ Description
 The :mc:`mc support inspect` command collects the data and metadata associated to objects at the specified path.
 MinIO assembles this data from each backend drive storing an :ref:`erasure shard <minio-erasure-coding>` for each specified object.
 
-The command produces a zip file that includes all matching files with their respective *host+drive+path*. 
-
-You can export the contents to a JSON output for further analysis.
+The command produces an encrypted zip file that includes all matching files with their respective *host+drive+path*. 
 
 The resulting report is intended for use by MinIO Engineering via |SUBNET| and may contain internal or private data points associated to the object.
 Exercise caution before sending a report to a third party or posting the report in a public forum.
@@ -53,7 +51,7 @@ Download Metadata for an Object
 You can download the metadata for an object.
 Metadata stores in an ``xl.meta`` binary file.
 
-The folloing command downloads the ``xl.meta`` from ``mybucket/myobject`` on the ``minio1`` deployment.
+The following command downloads the ``xl.meta`` from ``mybucket/myobject`` on the ``minio1`` deployment.
 
 The file downloads from all drives as a zip archive file.
 
@@ -65,23 +63,6 @@ The file downloads from all drives as a zip archive file.
 The contents of the ``xl.meta`` file are not human readable.
 You can convert the contents of an ``xl.meta`` file to JSON format.
 
-Download All Parts of an Object as an Encrypted Zip
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The following command downloads all of the constituent parts of an object with the following details:
-
-- MinIO deployment alias: ``minio1``
-- Bucket: ``mybucket``
-- Object: ``myobject``
-
-The file downloads as an encrypted zip file.
-
-.. code-block:: shell
-   :class: copyable
-
-   mc support inspect --encrypt minio1/mybucket/myobject*/*/part.*
-
-You can decrypt the resulting zip file with the :ref:`decryption tool <minio-support-decryption>`
 
 Download All Objects at a Prefix Recursively
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,25 +88,17 @@ The command has the following syntax:
 .. code-block:: shell
 
    mc [GLOBALFLAGS] support inspect       \
-                            [--encrypt]   \
-                            [--export]    \
+                            [--legacy]   \
                             ALIAS
 
 Parameters
 ~~~~~~~~~~
 
-.. mc-cmd:: --encrypt
+.. mc-cmd:: --legacy
    :optional:
 
-   Encrypt contents with a one-time key for confidential data.
+   Use the older method of exporting inspection data, which does not encrypt data by default.
    
-.. mc-cmd:: --export
-   :optional:
-
-   Export inspect data as JSON or data JSON from ``xl.meta``.
-
-   Use ``--export <value>``, replacing ``<value>`` with either ``json`` or ``djson`` as the output type.
-
 .. mc-cmd:: ALIAS
    :required:
 


### PR DESCRIPTION
Changes to the docs related to mc [RELEASE.2022-11-07T23-47-39Z](https://github.com/minio/mc/releases/tag/RELEASE.2022-11-07T23-47-39Z)

- Replaces `mc replicate edit` with `mc replicate update`
- Adds `mc admin idp oidc | ldap` commands
- Update to `mc support inspect` format
- Adds `mc admin rebalance` command
- Updates mc replicate edit references throughout docs to point to mc replicate update.
- Adds a rebalance pools section to the expand deployment doc.
- Clarifies precedence for environment variables vs config settings.

Closes #636
Closes #632
