### PR TITLE
Corrects missing part of alias set command

### DIFF
--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -60,9 +60,10 @@ Procedure
    .. code-block:: shell
       :class: copyable
       
-      mc alias set PATH ACCESSKEY SECRETKEY
+      mc alias set NEWALIAS PATH ACCESSKEY SECRETKEY
 
-   - Replace PATH with the IP address or hostname and port for the new deployment.
+   - Replace ``NEWALIAS`` with the alias to create for the deployment.
+   - Replace ``PATH`` with the IP address or hostname and port for the new deployment.
    - Replace ``ACCESSKEY`` and ``SECRETKEY`` with the credentials you used when creating the new deployment.
 
 #. Export the existing deployment's **configurations**


### PR DESCRIPTION
Fixes a missing part of the `mc alias set` command and adds formatting to the `PATH` in the replacement list for the command.