### PR TITLE
Adding bucket limit information

### DIFF
--- a/source/administration/minio-console.rst
+++ b/source/administration/minio-console.rst
@@ -147,6 +147,7 @@ Use the :guilabel:`Search` bar to search for specific buckets or objects.
 Select the row for the bucket or object to browse. 
 
 Select :guilabel:`Create Bucket` to create a new bucket on the deployment.
+The S3 API allows for a maximum of 500,000 buckets per deployment.
 
 Each bucket has :guilabel:`Manage` and :guilabel:`Browse` buttons.
 

--- a/source/operations/checklists.rst
+++ b/source/operations/checklists.rst
@@ -18,6 +18,13 @@ Coordination with MinIO Engineering via SUBNET ensures end-to-end support for pe
 Community users can seek support on the `MinIO Community Slack <https://slack.min.io>`__. 
 Community Support is best-effort only and has no SLAs around responsiveness.
 
+Checklists:
+
+- :ref:`Hardware checklists <minio-hardware-checklist>`
+- :ref:`Security Checklist <minio-security-checklist>`
+- :ref:`Software Checklist <minio-software-checklists>`
+- :ref:`Thresholds and Limits <minio-server-limits>`
+
 .. toctree::
    :titlesonly:
    :hidden:

--- a/source/operations/checklists/hardware.rst
+++ b/source/operations/checklists/hardware.rst
@@ -1,3 +1,5 @@
+.. _minio-hardware-checklist:
+
 ==================
 Hardware Checklist
 ==================
@@ -20,6 +22,7 @@ When selecting hardware for your MinIO implementation, take into account the fol
 - Number of objects by average object size
 - Average retention time of data in years
 - Number of sites to be deployed
+- Number of expected buckets
 
 .. _deploy-minio-distributed-recommendations:
 

--- a/source/operations/checklists/security.rst
+++ b/source/operations/checklists/security.rst
@@ -1,3 +1,5 @@
+.. _minio-security-checklist:
+
 ==================
 Security Checklist
 ==================

--- a/source/operations/checklists/software.rst
+++ b/source/operations/checklists/software.rst
@@ -1,3 +1,5 @@
+.. _minio-software-checklists:
+
 ==================
 Software Checklist
 ==================

--- a/source/operations/checklists/thresholds.rst
+++ b/source/operations/checklists/thresholds.rst
@@ -1,0 +1,139 @@
+.. _minio-server-limits:
+
+=====================
+Thresholds and Limits
+=====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+This page reflects limits and thresholds that apply to MinIO.
+
+Refer to the :ref:`hardware <minio-hardware-checklist>` and :ref:`software <minio-software-checklists>` for related recommendations and requirements.
+
+S3 API Limits
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+   :width: 90%
+
+   * - Item
+     - Specification 
+
+   * - Maximum object size
+     - 50 TiB
+
+   * - Minimum object size
+     - 0 B
+
+   * - Maximum object size per PUT operation
+     - | 5 TiB for non-multipart upload
+       | 50 TiB for multipart upload
+
+   * - Maximum number of parts per upload
+     - 10,000
+
+   * - Part size range
+     - 5 MiB to 5 GiB. Last part can be 0 B to 5 GiB
+
+   * - Maximum number of parts returned per list parts request
+     - 10,000
+
+   * - Maximum number of objects returned per list objects request
+     - 1,000
+
+   * - Maximum number of multipart uploads returned per list multipart uploads request
+     - 1,000
+
+   * - Maximum length for bucket names
+     - 63
+
+   * - Maximum length for object names
+     - 1024
+
+   * - Maximum length for each ``/`` separated object name segment
+     - 255
+
+Erasure Code Limits
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+   :width: 90%
+
+   * - Item
+     - Specification 
+
+   * - Maximum number of servers per cluster
+     - no limit
+
+   * - Minimum number of servers
+     - 1
+
+   * - Minimum number of drives per server when server count is 1
+     - 1 (for |SNSD| deployments, which do not provide additional reliability or availability)
+
+   * - Minimum number of drives per server when server count is 2 or more
+     - 1
+
+   * - Maximum number of drives per server
+     - no limit
+
+   * - Read quorum
+     - :math:`N/2`
+
+   * - Write quorum
+     - :math:`(N/2)+1`
+
+
+Unsupported S3 Bucket APIs
+--------------------------
+
+MinIO does not support the following API calls available in S3.
+These APIs are either redundant or only provide functionality within AWS S3.
+
+- ``BucketACL``, ``ObjectACL`` (use :ref:`Policies <minio-policy>`)
+- ``BucketCORS`` (CORS enabled by default on all buckets for all HTTP verbs)
+- ``BucketWebsite`` (use ``caddy`` or ``nginx``)
+- ``BucketAnalytics``, ``BucketMetrics``, ``BucketLogging`` (use :ref:`Bucket Notifications <minio-bucket-notifications>`)
+- ``BucketRequestPayment``
+
+Object Name Limitations
+-----------------------
+
+Filesystem and Operating System Restrictions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Object Names in MinIO are restricted primarily by the local operating system and filesystem.
+Windows and some other operating systems restrict file systems with certain special characters, such as ``^``, ``*``, ``|``, ``\``, ``/``, ``&``, ``"``, or ``;``.
+
+The above list is not exhaustive and may not apply to your operating system and filesystem combination.
+
+Consult your operating system vendor or filesystem documentation for a comprehensive list for your situation.
+
+MinIO recommends using LInux operating system with an XFS based filesystem for production workloads.
+
+Conflicting Objects
+~~~~~~~~~~~~~~~~~~~
+
+Objects cannot have a conflicting object as its parent.
+Applications must assign non-conflicting, unique keys.
+
+MinIO does not support a situation where an object's name is also the name of the prefix for a child object. 
+For the following example operations, the second PUT operation fails because of a naming conflict with the object created by the first.
+
+.. code-block::
+   
+   PUT <bucketname>/a/b/1.txt
+   PUT <bucketname>/a/b
+
+.. code-block::
+   
+   PUT <bucketname>/a/b
+   PUT <bucketname>/a/b/1.txt


### PR DESCRIPTION
- Imports the limits doc from legacy into the Checklists section
- Adds 500K limit to buckets in several places

Closes #548