### PR TITLE
Add --interactive flag info to kubectl create tenant docs

### DIFF
--- a/source/administration/minio-console.rst
+++ b/source/administration/minio-console.rst
@@ -147,7 +147,7 @@ Use the :guilabel:`Search` bar to search for specific buckets or objects.
 Select the row for the bucket or object to browse. 
 
 Select :guilabel:`Create Bucket` to create a new bucket on the deployment.
-The S3 API allows for a maximum of 500,000 buckets per deployment.
+MinIO recommends no more than 500,000 buckets per deployment.
 
 Each bucket has :guilabel:`Manage` and :guilabel:`Browse` buttons.
 

--- a/source/reference/kubectl-minio-plugin/kubectl-minio-tenant-create.rst
+++ b/source/reference/kubectl-minio-plugin/kubectl-minio-tenant-create.rst
@@ -72,6 +72,7 @@ Syntax
 
          kubectl minio tenant create                  \
                               TENANT_NAME             \
+                              [--interactive]         \
                               --capacity              \
                               --servers               \
                               --volumes               \
@@ -88,6 +89,23 @@ Flags
 -----
 
 The command supports the following flags:
+
+.. mc-cmd:: --interactive
+   :optional:
+
+   Offers command line prompts to request the information required to set up a new tenant.
+   Use this instead of the remaining flags when creating a new tenant.
+
+   When added, prompts ask for input for the following values:
+
+   - Tenant name
+   - Total servers
+   - Total volumes
+   - Namespace
+   - Capacity
+   - Disable TLS
+   - Disable audit logs
+   - Disable prometheus
 
 .. mc-cmd:: TENANT_NAME
    :required:


### PR DESCRIPTION
Applies changes in Operator 4.5.0 release.

- Adds flag to `kubectl minio tenant create` doc
- Softens wording on bucket limit to be recommended in the MinIO console doc for PR#649

Closes #569