### PR TITLE
MinIO Nov 2022 releases updates

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -38,24 +38,47 @@ Syntax
 .. mc-cmd:: set
    :fullpath:
 
-   Sets a :ref:`configuration key <minio-server-configuration-settings>` on the 
-   MinIO deployment.
+   Sets a :ref:`configuration key <minio-server-configuration-settings>` on the MinIO deployment.
+   Configurations defined by environment variables override configurations defined by this command.
+
+   For distributed deployments, use to modify existing endpoints.
+
+   Endpoints using the http protocol can be either the hostname or IP address, and they may use either ``http`` or ``https``.
 
 .. mc-cmd:: get
    :fullpath:
 
-   Gets a :ref:`configuration key <minio-server-configuration-settings>` on the
-   MinIO deployment.
+   Gets a :ref:`configuration key <minio-server-configuration-settings>` on the MinIO deployment created using `mc admin config set`.
 
 .. mc-cmd:: export
    :fullpath:
 
    Exports any configuration settings created using `mc admin config set`.
 
+.. mc-cmd:: history
+   :fullpath:
+
+   Lists the history of changes made to configuration keys by `mc admin config`.
+
+   Configurations defined by environment variables do not show.
+
 .. mc-cmd:: import
    :fullpath:
 
    Imports configuration settings exported using `mc admin config export`.
+
+.. mc-cmd:: reset
+   :fullpath:
+
+   Resets config to defaults.
+   Configurations defined in environment variables are not affected.
+
+.. mc-cmd:: restore
+   :fullpath:
+
+   Roll back changes to configuration keys to a previous point in history.
+
+   Does not affect configurations defined by environment variables.
    
 .. _minio-server-configuration-settings:
 

--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -93,4 +93,4 @@ Syntax
 .. mc-cmd:: --remove
    
 
-   Removes dangling objects in the healing process. 
+   Removes dangling objects and data directories in the healing process not referenced by the metadata on a per-drive basis.

--- a/source/reference/minio-mc-admin/mc-admin-idp-ldap-policy.rst
+++ b/source/reference/minio-mc-admin/mc-admin-idp-ldap-policy.rst
@@ -1,0 +1,87 @@
+.. _minio-mc-admin-idp-ldap-policy:
+
+============================
+``mc admin idp ldap policy``
+============================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin idp ldap policy
+
+Description
+-----------
+
+.. start-mc-admin-idp-ldap-policy-desc
+
+The :mc-cmd:`mc admin idp ldap policy` command allows you to view the mapping relationships between policies and the associated groups or users.
+
+.. end-mc-admin-idp-ldap-policy-desc
+
+
+The :mc-cmd:`mc admin idp ldap policy` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc admin idp ldap policy entities`
+     - List policy entity mappings
+
+Syntax
+------
+
+.. mc-cmd:: entities
+
+   Display a list of mappings for a user, group, and/or policy.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLES
+
+         The following example lists all mappings for a specific policy, a set of groups, and a selection of users on the ``myminio`` deployment.
+
+         Specifically, it lists 
+         - Users mapped to the ``finteam-policy`` policy.
+         - Policies assigned to the ``uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io`` user
+         - Policies assigned to the ``cn=projectb,ou=groups,ou=swengg,dc=min,dc=io`` group
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc admin idp ldap policy entities myminio/                                            \
+                                          --policy finteam-policy                                  \
+                                          --user 'uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io'  \
+                                          --group 'cn=projectb,ou=groups,ou=swengg,dc=min,dc=io' 
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin idp ldap policy entities                \
+                                            ALIAS                          \
+                                            [--user `value`, -u `value`]   \
+                                            [--group `value`, -g `value`]  \
+                                            [--policy value]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - You may use each of the ``--user``, ``--group``, and/or ``--policy`` flags as many times as desired in the command.
+         - For each flag, the output lists the entities mapped to the specified policy, user, or group.
+         - Omit all flags to return a list of mappings for all policies.
+
+
+Global Flags
+------------
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc-admin/mc-admin-idp-ldap.rst
+++ b/source/reference/minio-mc-admin/mc-admin-idp-ldap.rst
@@ -58,6 +58,9 @@ The :mc-cmd:`mc admin idp ldap` command has the following subcommands:
    * - :mc-cmd:`mc admin idp ldap disable`
      - Disables an AD/LDAP server configuration.
 
+   * - :mc-cmd:`mc admin idp ldap policy entities`
+     - List policy association entities
+
 Configuration Parameters
 ------------------------
 
@@ -301,11 +304,10 @@ Syntax
          - Replace ``CFG_NAME`` with a unique string for this configuration.
            If not specified, the command disables the default configuration values.
 
-
-
 Global Flags
 ------------
 
 .. include:: /includes/common-minio-mc.rst
    :start-after: start-minio-mc-globals
    :end-before: end-minio-mc-globals
+

--- a/source/reference/minio-mc-admin/mc-admin-idp-openid.rst
+++ b/source/reference/minio-mc-admin/mc-admin-idp-openid.rst
@@ -71,6 +71,9 @@ Syntax
 
    You can run the command multiple times to set up multiple OpenID providers.
 
+   When adding multiple OpenID providers, only one can be a JWT Claim-based provider.
+   All others must be role-based providers.
+
    .. tab-set::
 
       .. tab-item:: EXAMPLE

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -56,7 +56,7 @@ Use :mc-cmd:`mc admin trace` to monitor API operations that return a service una
 See Console Trace for a Path
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd:`mc admin trace` to monitory activity for a specific path:
+Use :mc-cmd:`mc admin trace` to monitor activity for a specific path:
 
 .. code-block:: shell
    :class: copyable

--- a/source/reference/minio-mc/mc-ilm-add.rst
+++ b/source/reference/minio-mc/mc-ilm-add.rst
@@ -36,7 +36,7 @@ The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-man
          
          mc ilm add --expire-delete-marker mydata/myminio
 
-         mc ilm add --transition-days 30 --tier "COLDTIER" mydata/myminio
+         mc ilm add --transition-days 30 --transition-tier "COLDTIER" mydata/myminio
          
          mc ilm add --noncurrent-transition-days 7 --noncurrent-transition-tier "COLDTIER" 
 
@@ -90,7 +90,7 @@ Parameters
 .. mc-cmd:: --prefix
    :optional:
    
-   Restrict the management rule to a specific bucket prefix.
+   Restrict the management rule to a specific object prefix.
    
    For example:
 
@@ -320,7 +320,7 @@ Use the :mc:`mc ilm add` with :mc-cmd:`~mc ilm add --prefix` and :mc-cmd:`~mc il
 .. code-block:: shell
    :class: copyable
 
-   mc ilm add --prefix "doc/" --transition-days "90" --tier "MINIOTIER-1"                  \
+   mc ilm add --prefix "doc/" --transition-days "90" --trasition-tier "MINIOTIER-1"                  \
           --noncurrent-transition-days "45" --noncurrent-transition-tier "MINIOTIER-2"  \
           myminio/mybucket/
 

--- a/source/reference/minio-mc/mc-ilm-ls.rst
+++ b/source/reference/minio-mc/mc-ilm-ls.rst
@@ -17,10 +17,44 @@ Syntax
 
 .. start-mc-ilm-ls-desc
 
-The :mc:`mc ilm ls` command lists all configured object lifecycle management 
-rules on a MinIO bucket.
+The :mc:`mc ilm ls` command summrizes all configured object lifecycle management 
+rules on a MinIO bucket in a tabular format.
 
 .. end-mc-ilm-ls-desc
+
+The output of the command might resemble the following:
+
+.. code-block:: shell
+
+   ┌───────────────────────────────────────────────────────────────────────────────┐
+   │ Transition for latest version (Transition)                                    │
+   ├────────┬─────────┬────────┬─────────────────────┬──────────────┬──────────────┤
+   │ ID     │ STATUS  │ PREFIX │ TAGS                │ DAYS TO TIER │ TIER         │
+   ├────────┼─────────┼────────┼─────────────────────┼──────────────┼──────────────┤
+   │ rule-1 │ Enabled │ doc/   │ key1=val1&key2=val2 │            0 │ WARM-MINIO-1 │
+   └────────┴─────────┴────────┴─────────────────────┴──────────────┴──────────────┘
+   ┌────────────────────────────────────────────────────────────────┐
+   │ Transition for older versions (NoncurrentVersionTransition)    │
+   ├────────┬─────────┬────────┬──────┬──────────────┬──────────────┤
+   │ ID     │ STATUS  │ PREFIX │ TAGS │ DAYS TO TIER │ TIER         │
+   ├────────┼─────────┼────────┼──────┼──────────────┼──────────────┤
+   │ rule-2 │ Enabled │ logs/  │ -    │           10 │ WARM-MINIO-1 │
+   └────────┴─────────┴────────┴──────┴──────────────┴──────────────┘
+   ┌────────────────────────────────────────────────────────────────────────────────────────┐
+   │ Expiration for latest version (Expiration)                                             │
+   ├────────┬─────────┬────────┬─────────────────────┬────────────────┬─────────────────────┤
+   │ ID     │ STATUS  │ PREFIX │ TAGS                │ DAYS TO EXPIRE │ EXPIRE DELETEMARKER │
+   ├────────┼─────────┼────────┼─────────────────────┼────────────────┼─────────────────────┤
+   │ rule-1 │ Enabled │ doc/   │ key1=val1&key2=val2 │             30 │ false               │
+   └────────┴─────────┴────────┴─────────────────────┴────────────────┴─────────────────────┘
+   ┌──────────────────────────────────────────────────────────────────────────────────┐
+   │ Expiration for older versions (NoncurrentVersionExpiration)                      │
+   ├────────┬─────────┬────────┬─────────────────────┬────────────────┬───────────────┤
+   │ ID     │ STATUS  │ PREFIX │ TAGS                │ DAYS TO EXPIRE │ KEEP VERSIONS │
+   ├────────┼─────────┼────────┼─────────────────────┼────────────────┼───────────────┤
+   │ rule-1 │ Enabled │ doc/   │ key1=val1&key2=val2 │             15 │             0 │
+   │ rule-2 │ Enabled │ logs/  │ -                   │              1 │             3 │
+   └────────┴─────────┴────────┴─────────────────────┴────────────────┴───────────────┘
 
 .. tab-set::
 
@@ -52,8 +86,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
    
-   *Required* The :ref:`alias <alias>` and full path to the bucket on the MinIO
+   The :ref:`alias <alias>` and full path to the bucket on the MinIO
    deployment for which to list the object lifecycle management rules. For
    example:
 
@@ -63,18 +98,17 @@ Parameters
 
 
 .. mc-cmd:: --expiry
+   :optional:
    
 
-   *Optional* :mc:`mc ilm ls` returns only fields related to lifecycle rule
-   expiration.
+   :mc:`mc ilm ls` returns only fields related to lifecycle rule expiration.
 
    Mutually exclusive with :mc-cmd:`~mc ilm ls --transition`.
 
 .. mc-cmd:: --transition
-   
+   :optional:
 
-   *Optional* :mc:`mc ilm ls` returns only fields related to lifecycle rule
-   transition.
+   :mc:`mc ilm ls` returns only fields related to lifecycle rule transition.
 
    Mutually exclusive with :mc-cmd:`~mc ilm ls --expiry`.
 


### PR DESCRIPTION
Updates docs for various releases through November 2022.

## Updates for mc RELEASE.2022-11-17T21-20-39Z
    
- Creates `mc admin idp ldap policy entities` section
- Corrects incorrect `--tier` flag in `mc ilm add`
- Adds info to `mc ilm ls` about new tabular format of output
    
Closes #645
    
- Adds info about modifying endpoints for distributed endpoits.
    
Partially addresses #644

## Updates for Bugfix [minio RELEASE.2022-11-29T23-40-49Z](https://github.com/minio/minio/releases/tag/RELEASE.2022-11-29T23-40-49Z)
    
- Adds information about the --remove flag dropping data directories as well and running on a per-drive basis [PR 16122](https://github.com/minio/minio/pull/16122)
- Adds note that MinIO only supports one JWT based OpenID provider [PR #16145](https://github.com/minio/minio/pull/16145)
    
Note: There was no Docs issue to track this release.
    
## Other fix:
- Minor correction to Admin Trace
- Clarifies that mc admin idp ldap policy entities command is cumulative, not exclusive when using multiple flags

## Add additional `mc admin config` commands

- Adds three additional commands. 
- Notes under several commands that environment variables override config keys.

Closes #653
