### PR TITLE
Update for early Dec 22 minio release

### DIFF
--- a/source/administration/identity-access-management.rst
+++ b/source/administration/identity-access-management.rst
@@ -20,7 +20,7 @@ Authentication
 Authorization
   The process of restricting the actions and resources the authenticated client can perform on the deployment. 
   MinIO uses Policy-Based Access Control (PBAC), where each policy describes one or more rules that outline the permissions of a user or group of users. 
-  MinIO supports S3-specific:ref:`actions <minio-policy-actions>` and :ref:`conditions <minio-policy-conditions>` when creating policies. 
+  MinIO supports S3-specific :ref:`actions <minio-policy-actions>` and :ref:`conditions <minio-policy-conditions>` when creating policies. 
   By default, MinIO *denies* access to actions or resources not explicitly referenced in a user's assigned or inherited policies.
 
 Identity Management

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -79,6 +79,14 @@ Glossary
      The conversion of all of the contents written to a disk to values that cannot be easily deciphered by an unauthorized entity.
      Disk encryption can be used in conjunction with other encryption technologies to create a robust data security system.
 
+   enclave
+     A description of an isolated area within a stateful Key Encryption Service (KES) server.
+     A KES server may have one enclave or multiple enclaves.
+     Each enclave within a KES server holds separate keys, policies, and administration identity.
+     An enclave cannot see or make use of any other enclave on the server.
+
+     For example, you might use multiple enclaves to hold completely separate key stores for multiple MinIO tenants within a single stateful KES server.
+
    encryption at rest
      A method of encryption that stores an object in an encrypted state.
      The object remains encrypted while not moving from one location to another.

--- a/source/includes/common/common-minio-kes.rst
+++ b/source/includes/common/common-minio-kes.rst
@@ -149,6 +149,9 @@ See the tutorials for :ref:`minio-snsd`, :ref:`minio-snmd`, or :ref:`minio-mnmd`
    # Sets the default KMS key for the backend and SSE-KMS/SSE-S3 Operations)
    MINIO_KMS_KES_KEY_NAME=minio-backend-default-key
 
+   # Optional, defines the name for the KES server enclave to use.
+   MINIO_KMS_KES_ENCLAVE=<name>
+
 Replace ``HOSTNAME`` with the IP address or hostname of the KES server.
 If the MinIO server host machines cannot resolve or reach the specified ``HOSTNAME``, the deployment may return errors or fail to start.
 
@@ -161,6 +164,14 @@ MinIO uses the :envvar:`MINIO_KMS_KES_KEY_NAME` key for the following cryptograp
 - Encrypting objects using :ref:`SSE-KMS <minio-encryption-sse-kms>` if the request does not 
   include a specific |EK|.
 - Encrypting objects using :ref:`SSE-S3 <minio-encryption-sse-s3>`.
+
+MinIO uses the :envvar:`MINIO_KMS_KES_ENCLAVE` key to define the name of the KES enclave to use.
+
+- Replace ``<name>`` with the name of the :term:`enclave` to use.
+- If not defined, MinIO does not send any enclave information.
+  This may result in using the default enclave for stateful KES servers.
+
+  A KES :term:`enclave` provides an isolated space for its associated keys separate from other enclaves on a stateful KES server.
 
 The ``minio-kes`` certificates enable mTLS between the MinIO deployment and the KES server *only*.
 They do not otherwise enable TLS for other client connections to MinIO.

--- a/source/includes/container/common-minio-kes.rst
+++ b/source/includes/container/common-minio-kes.rst
@@ -106,6 +106,7 @@ This command assumes the ``minio-kes.cert``, ``minio-kes.key``, and ``kes-server
    MINIO_KMS_KES_KEY_FILE=/certs/minio-kes.key
    MINIO_KMS_KES_CAPATH=/certs/server.cert
    MINIO_KMS_KES_KEY_NAME=minio-backend-default-key
+   MINIO_KMS_KES_ENCLAVE=<name>
 
 MinIO uses the :envvar:`MINIO_KMS_KES_KEY_NAME` key for the following cryptographic operations:
 
@@ -113,6 +114,14 @@ MinIO uses the :envvar:`MINIO_KMS_KES_KEY_NAME` key for the following cryptograp
 - Encrypting objects using :ref:`SSE-KMS <minio-encryption-sse-kms>` if the request does not 
   include a specific |EK|.
 - Encrypting objects using :ref:`SSE-S3 <minio-encryption-sse-s3>`.
+
+MinIO uses the :envvar:`MINIO_KMS_KES_ENCLAVE` key to define the name of the KES enclave to use.
+
+- Replace ``<name>`` with the name of the :term:`enclave` to use.
+- If not defined, MinIO does not send any enclave information.
+  This may result in using the default enclave for stateful KES servers.
+
+  A KES :term:`enclave` isolates its associated keys from other enclaves on a stateful KES server.
 
 The ``minio-kes`` certificates enable for mTLS between the MinIO deployment and the KES server *only*.
 They do not otherwise enable TLS for other client connections to MinIO.

--- a/source/includes/container/installation.rst
+++ b/source/includes/container/installation.rst
@@ -46,6 +46,11 @@ MinIO provides container images at the following repositories:
 - https://hub.docker.com/r/minio/minio
 - https://quay.io/repository/minio/minio?tab=info
 
+.. versionchanged:: RELEASE.2022-12-02T19-19-22Z
+
+   These images include the :ref:`MinIO Client <minio-client>` command line tool built in for container-level debugging.
+   However, to regularly interact with a container MinIO install, :ref:`install the MinIO Client <mc-install>` on your computer and define an :mc-cmd:`mc alias set <alias>` to the container instead.
+
 Use of MinIO images from any other repository, host, or organization is at your own risk.
 
 The :ref:`Single-Node Single-Drive <minio-snsd>` and :ref:`Single-Node Multi-Drive <minio-snmd>` tutorials provide instructions for the `Docker <https://www.docker.com/>`__ and :podman-docs:`Podman <>` container managers.

--- a/source/includes/windows/common-minio-kes.rst
+++ b/source/includes/windows/common-minio-kes.rst
@@ -133,6 +133,7 @@ This command assumes the ``minio-kes.cert``, ``minio-kes.key``, and ``kes-server
    MINIO_KMS_KES_KEY_FILE=|miniocertpath|\minio-kes.key
    MINIO_KMS_KES_CAPATH=|miniocertpath|\kes-server.cert
    MINIO_KMS_KES_KEY_NAME=minio-backend-default-key
+   MINIO_KMS_KES_ENCLAVE=<name>
 
 MinIO uses the :envvar:`MINIO_KMS_KES_KEY_NAME` key for the following cryptographic operations:
 
@@ -140,6 +141,14 @@ MinIO uses the :envvar:`MINIO_KMS_KES_KEY_NAME` key for the following cryptograp
 - Encrypting objects using :ref:`SSE-KMS <minio-encryption-sse-kms>` if the request does not 
   include a specific |EK|.
 - Encrypting objects using :ref:`SSE-S3 <minio-encryption-sse-s3>`.
+
+MinIO uses the :envvar:`MINIO_KMS_KES_ENCLAVE` key to define the name of the KES enclave to use for stateful KES servers.
+
+- Replace ``<name>`` with the name of the :term:`enclave` to use.
+- If not defined, MinIO does not send any enclave information.
+  This may result in using the default enclave for stateful KES servers.
+
+  A KES :term:`enclave` provides an isolated space for its associated keys separate from other enclaves on a stateful KES server.
 
 The ``minio-kes`` certificates enable mTLS between the MinIO deployment and the KES server *only*.
 They do not otherwise enable TLS for other client connections to MinIO.

--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -57,17 +57,19 @@ Registering Your MinIO Deployment with SUBNET
 
    .. tab-item:: Console Airgapped
 
-      You can register MinIO deployments for SUBNET even if they exists an airgap, firewall, or otherwise no direct Internet access.
+      Use the steps below to register MinIO deployments that do not have direct Internet access.
+      For example, deployments that exist with an airgap, behind a firewall, or in other environments with no direct Internet access.
       From the Console:
 
       #. Go to your MinIO cluster's URL, then sign in
-      #. Select the :guilabel:`Support` option
-      #. Select :guilabel:`Register`
-      #. Select the :guilabel:`Offline Activation` link at the bottom of the screen
-      #. Copy the registration token for your cluster from item 1
-      #. Go to https://subnet.min.io/cluster/register and enter the registration token when prompted
-      #. Copy the generated API key and paste it in item 3 of the **Offline Registration** window in the MinIO Console
-      #. Select :guilabel:`Register`
+      #. Select the :guilabel:`Support` tab, then select :guilabel:`Health`
+      #. Select :guilabel:`Register your Cluster`
+      #. Select the :guilabel:`Airgap` tab
+      #. Copy the provided link, which includes a token value for the deployment
+      #. Paste the link into a web browser on a device with access to the Internet
+      #. After successful registration, copy the provided API key
+      #. In the MinIO Console, select the :guilabel:`API Key` tab
+      #. Paste the copied API key from SUBNET into the :guilabel:`API Key` field, then select :guilabel:`Register`
 
    .. tab-item:: Command Line
 

--- a/source/reference/minio-mc/mc-support-inspect.rst
+++ b/source/reference/minio-mc/mc-support-inspect.rst
@@ -89,7 +89,7 @@ The command has the following syntax:
 
    mc [GLOBALFLAGS] support inspect       \
                             [--legacy]   \
-                            ALIAS
+                            TARGET
 
 Parameters
 ~~~~~~~~~~
@@ -99,10 +99,11 @@ Parameters
 
    Use the older method of exporting inspection data, which does not encrypt data by default.
    
-.. mc-cmd:: ALIAS
+.. mc-cmd:: TARGET
    :required:
 
-   The :ref:`alias <alias>` of the MinIO deployment.
+   The path to the location or object to inspect.
+   The path should include the `alias <alias>` of the MinIO deployment and, if needed, the prefix and/or object name.
 
 
 Global Flags

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -373,6 +373,7 @@ MinIO Console:
 Key Management Service and Encryption
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+
 .. envvar:: MINIO_KMS_KES_ENDPOINT
 
    The endpoint for the MinIO Key Encryption Service (KES) process to use
@@ -418,6 +419,14 @@ Key Management Service and Encryption
 
    - The encryption key for Server-Side Encryption with
      :ref:`SSE-S3 <minio-encryption-sse-s3>`.
+
+.. envvar:: MINIO_KMS_KES_ENCLAVE
+
+   Use this optional environment variable to define the name of a KES enclave.
+   A KES enclave provides an isolated space for its associated keys separate from other enclaves on a stateful KES server.
+
+   If not set, MinIO does not send enclave information.
+   For a stateful KES server, this results in using the default enclave.
 
 .. _minio-server-envvar-storage-class:
 


### PR DESCRIPTION
## Updates for `console` early Dec22 releases

- Updated the instructions for registering for SUBNET from an airgapped Console environment
- Minor typo in IAM doc.

Closes #664

Two of the items in that issue did not actually impact the docs. One item is just a screenshot update that will be addressed later.

## Updates for `minio` early Dec22 releases
    
- Adds info about `mc` installed with container images
- Adds new envvar for KES enclaves
    
Closes #665

- Updates `mc support inspect` to correct alias to target in command syntax