### PR TITLE
Updates mc replicate commands

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -200,7 +200,8 @@ Glossary
        Increase this target based on benchmarking and monitoring of real world workloads up to what the hardware can meaningfully handle. 
      - Deployments with high-performance or enterprise-grade :ref:`hardware <deploy-minio-distributed-recommendations>` can typically handle prefixes with millions of objects or more.
 
-|SUBNET| Enterprise accounts can utilize yearly architecture reviews as part of the deployment and maintenance strategy to ensure long-term performance and success of your MinIO-dependent projects.
+    |SUBNET| Enterprise accounts can utilize yearly architecture reviews as part of the deployment and maintenance strategy to ensure long-term performance and success of your MinIO-dependent projects.
+    
    RAID
      Initialism for "Redundant Array of Independent Disks".
      The technology merges multiple separate physical disks into a single storage unit or array.

--- a/source/reference/minio-mc-admin/mc-admin-bucket-remote.rst
+++ b/source/reference/minio-mc-admin/mc-admin-bucket-remote.rst
@@ -10,6 +10,13 @@
 
 .. mc:: mc admin bucket remote
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   - ``mc admin bucket remote add`` replaced by :mc-cmd:`mc replicate add`
+   - ``mc admin bucket remote update`` replaced by :mc-cmd:`mc replicate update`
+   - ``mc admin bucket remote rm`` replaced by :mc-cmd:`mc replicate rm`
+   - ``mc admin bucket remote ls`` replaced by :mc-cmd:`mc replicate ls`
+
 Description
 -----------
 
@@ -96,6 +103,10 @@ Syntax
 
 .. mc-cmd:: add
    :fullpath:
+
+   .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+      - ``mc admin bucket remote add`` replaced by :mc-cmd:`mc replicate add`
 
    Adds a remote target to a bucket on a MinIO deployment. The
    command has the following syntax:
@@ -184,6 +195,10 @@ Syntax
 .. mc-cmd:: ls
    :fullpath:
 
+   .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+      - ``mc admin bucket remote ls`` replaced by :mc-cmd:`mc replicate ls`
+
    Lists all remote targets associated to a bucket on the MinIO deployment. The
    command has the following syntax:
 
@@ -216,6 +231,10 @@ Syntax
 .. mc-cmd:: rm
    :fullpath:
 
+   .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+      - ``mc admin bucket remote rm`` replaced by :mc-cmd:`mc replicate rm`
+   
    Removes a remote target for a bucket on the MinIO deployment. The
    command has the following syntax:
 
@@ -241,7 +260,7 @@ Syntax
          mc admin bucket remote rm play/mybucket
 
    .. mc-cmd:: ARN
-      
+     
 
       *Required*
 

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -13,6 +13,13 @@
 .. mc:: mc replicate
 .. mc:: mc replicate add
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z 
+
+   ``mc replicate add`` replaces the ``mc admin bucket remote add`` command.
+
+   MinIO automatically creates remote targets based on a given file path or resource location (such as an IP or DNS address).
+   Users defining a remote target no longer need to determine an ARN for the remote bucket.
+
 Syntax
 ------
 
@@ -38,19 +45,17 @@ remote ARN as part of running :mc:`mc replicate add`.
 
    .. tab-item:: EXAMPLE
 
-      The following command adds a new replication rule for the ``mydata``
-      bucket on the ``myminio`` MinIO deployment:
+      The following command adds a new replication rule for the ``mydata`` bucket on the ``myminio`` MinIO deployment:
 
       .. code-block:: shell
          :class: copyable
 
-         mc replicate add                                                                        \
-            --remote-bucket "arn:minio:replication:aefc8b3a-1f6c-4d7a-86dc-1b0bdffa9100:mydata"  \
-            --replicate "delete,delete-marker,existing-objects"                                  \
+         mc replicate add                                                     \
+            --remote-bucket https://user:secret@minio.mysite.tld:9090/bucket  \
+            --replicate "delete,delete-marker,existing-objects"               \
             myminio/mydata
 
-      The replication rule synchronizes versioned delete operations, delete
-      markers, and existing objects to the remote MinIO deployment.
+      The replication rule synchronizes versioned delete operations, delete markers, and existing objects to the remote MinIO deployment.
 
    .. tab-item:: SYNTAX
 
@@ -59,14 +64,22 @@ remote ARN as part of running :mc:`mc replicate add`.
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] replicate add               \
-                          --remote-bucket "string"    \
-                          [--disable]                 \
-                          [--id "string"]             \
-                          [--replicate "string"]      \
-                          [--storage-class "string"]  \
-                          [--tags "string"]           \
-                          [--priority int]            \
+         mc [GLOBALFLAGS] replicate add                     \
+                          --remote-bucket string          \
+                          [--bandwidth "string"]            \
+                          [--disable]                       \
+                          [--disable-proxy]                 \
+                          [--healthcheck-seconds integer]   \
+                          [--id "string"]                   \
+                          [--limit-upload "string"]         \
+                          [--limit-download "string"]       \
+                          [--path "string"]                 \
+                          [--region "string"]               \
+                          [--replicate "string"]            \
+                          [--storage-class "string"]        \
+                          [--sync]                          \
+                          [--tags "string"]                 \
+                          [--priority int]                  \
                           ALIAS
 
       .. include:: /includes/common-minio-mc.rst
@@ -77,78 +90,186 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* the :ref:`alias <alias>` of the MinIO deployment and full path to
-   the bucket or bucket prefix on which to create the replication rule. For
-   example:
+   The :ref:`alias <alias>` of the MinIO deployment and full path to the bucket or bucket prefix on which to create the replication rule. 
+   For example:
 
    .. code-block:: none
 
-      mc replicate add --remote-bucket "arn:minio:replica::UUID" play/mybucket
-
+      mc replicate add --remote-bucket https://user:secret@myminio.cloudprovider.tld:9090/bucket play/mybucket
 
 .. mc-cmd:: --remote-bucket
-   
+   :required:
 
-   *Required* Specify the ARN for the destination deployment and bucket. You
-   can retrieve the ARN using :mc-cmd:`mc admin bucket remote`:
+   Specify the credentials, destination deployment, and bucket of the remote location. 
+
+   For example, a URL based target might look like the following:
+
+   .. code-block::
+
+      https://user:secret@myminio.cloudprovider.tld:9090/bucket
+
+.. mc-cmd:: --bandwidth
+   :optional:
+
+   Limit bandwidth rates to no more than the specified rate in KiB/s, MiB/s, or GiB/s.
+   Valid units include: 
+   
+   - ``B`` for bytes
+   - ``K`` for kilobytes
+   - ``G`` for gigabytes
+   - ``T`` for terabytes
+   - ``Ki`` for kibibytes
+   - ``Gi`` for gibibytes
+   - ``Ti`` for tebibytes
+
+   For example, to limit bandwidth rates to no more than 1 GiB/s, use the following:
+
+   .. code-block::
+
+      --limit-upload 1Gi
+
+   If not specified, MinIO does not limit the bandwidth rate.
+
     
-   - Use the :mc-cmd:`mc admin bucket remote ls` to retrieve a list of 
-     ARNs for the bucket on the destination deployment.
-
-   - Use the :mc-cmd:`mc admin bucket remote add` to create a replication ARN
-     for the bucket on the destination deployment. 
-
 .. mc-cmd:: --disable
-   
+   :optional:
 
-   *Optional* Creates the replication rule in the "disabled" state. MinIO does
-   not begin replicating objects using the rule until it is enabled using
-   :mc:`mc replicate update`.
+   Creates the replication rule in the "disabled" state. 
+   MinIO does not begin replicating objects using the rule until it is enabled using :mc:`mc replicate update`.
 
-   Objects created while replication is disabled are not
-   immediately eligible for replication after enabling the rule.
-   You must explicitly enable replication of existing
-   objects by including ``"existing-objects"`` to the list of
-   replication features specified to 
-   :mc-cmd:`mc replicate update --replicate`. See
-   :ref:`minio-replication-behavior-existing-objects` for more
-   information.
+   Objects created while replication is disabled are not immediately eligible for replication after enabling the rule.
+   You must explicitly enable replication of existing objects by including ``"existing-objects"`` to the list of replication features specified to :mc-cmd:`mc replicate update --replicate`. 
+   See :ref:`minio-replication-behavior-existing-objects` for more information.
+
+.. mc-cmd:: --disable-proxy
+   :optional:
+
+   When defining active-active replication between buckets, do not proxy.
+
+   By default, MinIO proxies.
+
+.. mc-cmd:: --healthcheck-seconds
+   :optional:
+
+   The length of time in seconds between checks on the health of the remote bucket.
+
+   If not specified, MinIO uses an interval of 60 seconds.
 
 .. mc-cmd:: --id
-   
+   :optional:
 
-   *Optional* Specify a unique ID for the replication rule. MinIO automatically
-   generates an ID if one is not specified.
+   Specify a unique ID for the replication rule. 
+   MinIO automatically generates an ID if one is not specified.
+
+.. mc-cmd:: --limit-download
+   :optional:
+
+   Limit download rates to no more than a specified rate in KiB/s, MiB/s, or GiB/s.
+   Valid units include: 
+   
+   - ``B`` for bytes
+   - ``K`` for kilobytes
+   - ``G`` for gigabytes
+   - ``T`` for terabytes
+   - ``Ki`` for kibibytes
+   - ``Gi`` for gibibytes
+   - ``Ti`` for tebibytes
+
+   For example, to limit download rates to no more than 1 GiB/s, use the following:
+
+   .. code-block::
+
+      --limit-download 1G
+
+   If not specified, MinIO uses an unlimited download rate.
+
+.. mc-cmd:: --limit-upload
+   :optional:
+
+   Limit upload rates to no more than the specified rate in KiB/s, MiB/s, or GiB/s.
+   Valid units include: 
+   
+   - ``B`` for bytes
+   - ``K`` for kilobytes
+   - ``G`` for gigabytes
+   - ``T`` for terabytes
+   - ``Ki`` for kibibytes
+   - ``Gi`` for gibibytes
+   - ``Ti`` for tebibytes
+
+   For example, to limit upload rates to no more than 1 GiB/s, use the following:
+
+   .. code-block::
+
+      --limit-upload 1G
+
+   If not specified, MinIO uses an unlimited upload rate.
+
+
+.. mc-cmd:: --path
+   :optional:
+
+   Enable path-style lookup support for the remote bucket.
+
+   Valid values include:
+
+   - ``on`` - use a path lookup to find the remote bucket
+   - ``off`` - use a resource locator style (such as a domain or IP address) lookup to find the remote bucket
+   - ``auto`` - ask MinIO to identify the correct type of lookup to use to find the remote bucket
+
+   When not defined, MinIO uses the ``auto`` value.
+
+.. mc-cmd:: --priority
+   :optional:
+
+   Specify the integer priority of the replication rule. 
+   The value *must* be unique among all other rules on the source bucket. 
+   Higher values imply a *higher* priority than all other rules.
+
+   The default value is ``0``. 
+
+.. mc-cmd:: --region
+   :optional:
+
+   The region of the destination bucket to replicate contents to.
 
 .. mc-cmd:: --replicate
-   
+   :optional:
 
-   *Optional* Specify a comma-separated list of the following values to enable
-   extended replication features. 
+   Specify a comma-separated list of the following values to enable extended replication features. 
 
-   - ``delete`` - Directs MinIO to replicate DELETE operations to the
-     destination bucket.
+   - ``delete`` - Directs MinIO to replicate DELETE operations to the destination bucket.
 
-   - ``delete-marker`` - Directs MinIO to replicate delete markers to the 
-     destination bucket. 
+   - ``delete-marker`` - Directs MinIO to replicate delete markers to the destination bucket. 
 
-   - ``existing-objects`` - Directs MinIO to replicate objects created
-     before replication was enabled *or* while replication was suspended.
+   - ``existing-objects`` - Directs MinIO to replicate objects created before replication was enabled *or* while replication was suspended.
+
+   - ``metadata-sync`` - Directs MinIO to replicate metadata for each object.
+     For active-active replication situations only.
+
+     Omitting this value directs MinIO to stop replicating metadata-only changes back to the source. 
+
+   If not specified, MinIO syncs all options.
 
 .. mc-cmd:: --storage-class
-   
+   :optional:
 
-   *Optional*
+   Specify the MinIO :ref:`storage class <minio-ec-storage-class>` to apply to replicated objects. 
 
-   Specify the MinIO :ref:`storage class <minio-ec-storage-class>` to 
-   apply to replicated objects. 
+.. mc-cmd:: --sync
+   :optional:
+
+   Enable synchronous replication for this remote target.
+
+   By default, MinIO uses asynchronous replication.
 
 .. mc-cmd:: --tags
-   
+   :optional:
 
-   *Optional* Specify one or more ampersand ``&`` separated key-value pair tags
-   which MinIO uses for filtering objects to replicate. For example:
+   Specify one or more ampersand ``&`` separated key-value pair tags which MinIO uses for filtering objects to replicate. 
+   For example:
 
    .. code-block:: shell
 
@@ -157,14 +278,6 @@ Parameters
    MinIO applies the replication rule to any object whose tag set
    contains the specified replication tags.
 
-.. mc-cmd:: --priority
-   
-
-   *Optional* Specify the integer priority of the replication rule. The value
-   *must* be unique among all other rules on the source bucket. Higher values
-   imply a *higher* priority than all other rules.
-
-   The default value is ``0``. 
 
 Global Flags
 ~~~~~~~~~~~~
@@ -179,59 +292,44 @@ Examples
 Configure Bucket Replication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following :mc:`mc replicate add` command creates a replication
-configuration that synchronizes all new objects, existing objects, delete
-operations, and delete markers to the remote target:
+The following :mc:`mc replicate add` command creates a replication configuration that synchronizes all new objects, existing objects, delete operations, and delete markers to the remote target:
 
 .. code-block:: shell
    :class: copyable
 
    mc replicate add myminio/mybucket \
-      --remote-bucket "arn:minio:replica::UUID" \
+      --remote-bucket https://user:secret@minio.mysite.tld/remotebucket \
       --replicate "delete,delete-marker,existing-objects"
 
-- Replace ``myminio/mybucket`` with the :mc-cmd:`~mc replicate add ALIAS` and
-  full bucket path for which to create the replication configuration.
+- Replace ``myminio/mybucket`` with the :mc-cmd:`~mc replicate add ALIAS` and full bucket path for which to create the replication configuration.
 
-- Replace the :mc-cmd:`~mc replicate add --remote-bucket` value with the 
-  ARN of the remote target. Use :mc-cmd:`mc admin bucket remote ls` to list
-  all configured remote replication targets.
+- Replace the :mc-cmd:`~mc replicate add --remote-bucket` value with the URL or path of the remote target. 
+  If using a file path format location, use the ``--path on`` option.
 
-- The :mc-cmd:`~mc replicate add --replicate` flag directs MinIO to
-  replicate all delete operations, delete markers, and existing objects to the
-  remote. See :ref:`minio-replication-behavior-delete` and
-  :ref:`minio-replication-behavior-existing-objects` for more information on
-  replication behavior.
+- The :mc-cmd:`~mc replicate add --replicate` flag directs MinIO to replicate all delete operations, delete markers, and existing objects to the remote. 
+  See :ref:`minio-replication-behavior-delete` and :ref:`minio-replication-behavior-existing-objects` for more information on replication behavior.
 
 Configure Bucket Replication for Historical Data Record
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following :mc:`mc replicate add` command creates a new bucket
-replication configuration that synchronizes all new and existing objects
-to the remote target:
+The following :mc:`mc replicate add` command creates a new bucket replication configuration that synchronizes all new and existing objects to the remote target:
 
 .. code-block:: shell
    :class: copyable
 
    mc replicate add myminio/mybucket \
-      --remote-bucket "arn:minio:replica::UUID" \
+      --remote-bucket https://user:secret@minio.mysite.tld/remotebucket \
       --replicate "existing-objects"
 
-- Replace ``myminio/mybucket`` with the :mc-cmd:`~mc replicate add ALIAS` and
-  full bucket path for which to create the replication configuration.
+- Replace ``myminio/mybucket`` with the :mc-cmd:`~mc replicate add ALIAS` and full bucket path for which to create the replication configuration.
 
-- Replace the :mc-cmd:`~mc replicate add --remote-bucket` value with the 
-  ARN of the remote target. Use :mc-cmd:`mc admin bucket remote ls` to list
-  all configured remote replication targets.
+- Replace the :mc-cmd:`~mc replicate add --remote-bucket` value with the location of the remote target. 
+  If using a file path format location, use the ``--path on`` option.
 
-- The :mc-cmd:`~mc replicate add --replicate` flag directs MinIO to
-  replicate all existing objects to the remote. See
-  :ref:`minio-replication-behavior-existing-objects` for more information on
-  replication behavior.
+- The :mc-cmd:`~mc replicate add --replicate` flag directs MinIO to replicate all existing objects to the remote. 
+  See :ref:`minio-replication-behavior-existing-objects` for more information on replication behavior.
 
-The resulting remote copy represents a historical record of objects on the
-remote, where delete operations on the source have no effect on the remote
-copy.
+The resulting remote copy represents a historical record of objects on the remote, where delete operations on the source have no effect on the remote copy.
 
 Behavior
 --------
@@ -239,181 +337,122 @@ Behavior
 Server-Side Replication Requires MinIO Source and Destination
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-MinIO server-side replication only works between MinIO deployments. Both the
-source and destination deployments *must* run MinIO. 
+MinIO server-side replication only works between MinIO deployments. 
+Both the source and destination deployments *must* run MinIO. 
 
-To configure replication between arbitrary S3-compatible services,
-use :mc:`mc mirror`.
+To configure replication between arbitrary S3-compatible services, use :mc:`mc mirror`.
 
 Enable Versioning on Source and Destination Buckets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-MinIO relies on the immutability protections provided by versioning to
-synchronize objects between the source and replication target.
+MinIO relies on the immutability protections provided by versioning to synchronize objects between the source and replication target.
 
-Use the :mc:`mc version suspend` command to enable versioning on 
-*both* the source and destination bucket before starting this procedure:
+Use the :mc:`mc version suspend` command to enable versioning on *both* the source and destination bucket before starting this procedure:
 
 .. code-block:: shell
    :class: copyable
 
    mc version ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the
-  :mc:`alias <mc alias>` of the MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of the MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which
-  to enable versioning.
+- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to enable versioning.
 
 Required Permissions
 ~~~~~~~~~~~~~~~~~~~~
 
-MinIO strongly recommends creating users specifically for supporting 
-bucket replication operations. See 
-:mc:`mc admin user` and :mc:`mc admin policy` for more complete
-documentation on adding users and policies to a MinIO deployment.
+MinIO strongly recommends creating users specifically for supporting bucket replication operations. 
+See :mc:`mc admin user` and :mc:`mc admin policy` for more complete documentation on adding users and policies to a MinIO deployment.
 
 .. tab-set::
 
    .. tab-item:: Replication Admin
 
-      The following policy provides permissions for configuring and enabling
-      replication on a deployment. 
+      The following policy provides permissions for configuring and enabling replication on a deployment. 
 
       .. literalinclude:: /extra/examples/ReplicationAdminPolicy.json
          :class: copyable
          :language: json
 
-      - The ``"EnableRemoteBucketConfiguration"`` statement grants permission
-        for creating a remote target for supporting replication.
+      - The ``"EnableRemoteBucketConfiguration"`` statement grants permission for creating a remote target for supporting replication.
 
-      - The ``"EnableReplicationRuleConfiguration"`` statement grants permission
-        for creating replication rules on a bucket. The ``"arn:aws:s3:::*``
-        resource applies the replication permissions to *any* bucket on the
-        source deployment. You can restrict the user policy to specific buckets
-        as-needed.
+      - The ``"EnableReplicationRuleConfiguration"`` statement grants permission for creating replication rules on a bucket. 
+        The ``"arn:aws:s3:::*`` resource applies the replication permissions to *any* bucket on the source deployment. 
+        You can restrict the user policy to specific buckets as-needed.
 
-      Use the :mc-cmd:`mc admin policy add` to add this policy to each
-      deployment acting as a replication source. Use :mc-cmd:`mc admin user add`
-      to create a user on the deployment and :mc-cmd:`mc admin policy set`
-      to associate the policy to that new user.
+      Use the :mc-cmd:`mc admin policy add` to add this policy to each deployment acting as a replication source. 
+      Use :mc-cmd:`mc admin user add` to create a user on the deployment and :mc-cmd:`mc admin policy set` to associate the policy to that new user.
 
    .. tab-item:: Replication Remote User
 
-      The following policy provides permissions for enabling synchronization of
-      replicated data *into* the deployment. 
+      The following policy provides permissions for enabling synchronization of replicated data *into* the deployment. 
 
       .. literalinclude:: /extra/examples/ReplicationRemoteUserPolicy.json
          :class: copyable
          :language: json
 
-      - The ``"EnableReplicationOnBucket"`` statement grants permission for 
-        a remote target to retrieve bucket-level configuration for supporting
-        replication operations on *all* buckets in the MinIO deployment. To
-        restrict the policy to specific buckets, specify those buckets as an
-        element in the ``Resource`` array similar to
-        ``"arn:aws:s3:::bucketName"``.
+      - The ``"EnableReplicationOnBucket"`` statement grants permission for a remote target to retrieve bucket-level configuration for supporting replication operations on *all* buckets in the MinIO deployment. 
+        To restrict the policy to specific buckets, specify those buckets as an element in the ``Resource`` array similar to ``"arn:aws:s3:::bucketName"``.
 
-      - The ``"EnableReplicatingDataIntoBucket"`` statement grants permission
-        for a remote target to synchronize data into *any* bucket in the MinIO
-        deployment. To restrict the policy to specific buckets, specify those 
-        buckets as an element in the ``Resource`` array similar to 
-        ``"arn:aws:s3:::bucketName/*"``.
+      - The ``"EnableReplicatingDataIntoBucket"`` statement grants permission for a remote target to synchronize data into *any* bucket in the MinIO deployment. 
+        To restrict the policy to specific buckets, specify those buckets as an element in the ``Resource`` array similar to ``"arn:aws:s3:::bucketName/*"``.
 
-      Use the :mc-cmd:`mc admin policy add` to add this policy to each
-      deployment acting as a replication target. Use :mc-cmd:`mc admin user add`
-      to create a user on the deployment and :mc-cmd:`mc admin policy set`
-      to associate the policy to that new user.
+      Use the :mc-cmd:`mc admin policy add` to add this policy to each deployment acting as a replication target. 
+      Use :mc-cmd:`mc admin user add` to create a user on the deployment and :mc-cmd:`mc admin policy set` to associate the policy to that new user.
 
 Replication of Existing Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting with :mc:`mc` 
-:minio-git:`RELEASE.2021-06-13T17-48-22Z <mc/releases/tag/RELEASE.2021-06-13T17-48-22Z>` 
-and :mc:`minio`
-:minio-git:`RELEASE.2021-06-07T21-40-51Z <minio/releases/tag/RELEASE.2021-06-07T21-40-51Z>`, 
+Starting with :mc:`mc` :minio-git:`RELEASE.2021-06-13T17-48-22Z <mc/releases/tag/RELEASE.2021-06-13T17-48-22Z>` and :mc:`minio` :minio-git:`RELEASE.2021-06-07T21-40-51Z <minio/releases/tag/RELEASE.2021-06-07T21-40-51Z>`, MinIO supports automatically replicating existing objects in a bucket. 
+MinIO existing object replication implements functionality similar to `AWS Replicating existing objects between S3 buckets <https://aws.amazon.com/blogs/storage/replicating-existing-objects-between-s3-buckets/>`__ without the overhead of contacting technical support. 
 
-MinIO supports automatically replicating existing objects in a bucket. MinIO
-existing object replication implements functionality similar to 
-`AWS Replicating existing objects between S3 buckets
-<https://aws.amazon.com/blogs/storage/replicating-existing-objects-between-s3-buckets/>`__
-without the overhead of contacting technical support. 
+- To enable replication of existing objects when creating a new replication rule, include ``"existing-objects"`` to the list of replication features specified to :mc-cmd:`mc replicate add --replicate`.
 
-- To enable replication of existing objects when creating a new replication
-  rule, include ``"existing-objects"`` to the list of replication features 
-  specified to :mc-cmd:`mc replicate add --replicate`.
+- To enable replication of existing objects for an existing replication rule, add ``"existing-objects"`` to the list of existing replication features using :mc-cmd:`mc replicate add --replicate`. 
+  You must specify *all* desired replication features when editing the replication rule. 
 
-- To enable replication of existing objects for an existing replication rule,
-  add ``"existing-objects"`` to the list of existing replication features using
-  :mc-cmd:`mc replicate add --replicate`. You must specify *all*
-  desired replication features when editing the replication rule. 
-
-See :ref:`minio-replication-behavior-existing-objects` for more complete
-documentation on this behavior.
+See :ref:`minio-replication-behavior-existing-objects` for more complete documentation on this behavior.
 
 Synchronization of Metadata Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-MinIO supports :ref:`two-way active-active
-<minio-bucket-replication-serverside-twoway>` replication configurations, where
-MinIO synchronizes new and modified objects between a bucket on two MinIO
-deployments. Starting with :mc:`mc` 
+MinIO supports :ref:`two-way active-active <minio-bucket-replication-serverside-twoway>` replication configurations, where MinIO synchronizes new and modified objects between a bucket on two MinIO deployments. 
+Starting with :mc:`mc` :minio-git:`RELEASE.2021-05-18T03-39-44Z <mc/releases/tag/RELEASE.2021-05-18T03-39-44Z>`, MinIO by default synchronizes metadata-only changes to a replicated object back to the "source" deployment. 
+Prior to the this update, MinIO did not support synchronizing metadata-only changes to a replicated object.
 
-:minio-git:`RELEASE.2021-05-18T03-39-44Z <mc/releases/tag/RELEASE.2021-05-18T03-39-44Z>`, 
-MinIO by default synchronizes metadata-only changes to a replicated object back
-to the "source" deployment. Prior to the this update, MinIO did not support
-synchronizing metadata-only changes to a replicated object.
+With metadata synchronization enabled, MinIO resets the object :ref:`replication status <minio-replication-process>` to indicate replication eligibility. 
+Specifically, when an application performs a metadata-only update to an object with the ``REPLICA`` status, MinIO marks the object as ``PENDING`` and eligible for replication.
 
-With metadata synchronization enabled, MinIO resets the object 
-:ref:`replication status <minio-replication-process>` to indicate 
-replication eligibility. Specifically, when an application performs a
-metadata-only update to an object with the ``REPLICA`` status, MinIO marks the
-object as ``PENDING`` and eligible for replication.
-
-To disable metadata synchronization, use the 
-:mc-cmd:`mc replicate update --replicate` command and omit 
-``replica-metadata-sync`` from the replication feature list. 
+To disable metadata synchronization, use the :mc-cmd:`mc replicate update --replicate` command and omit ``replica-metadata-sync`` from the replication feature list. 
 
 Replication of Delete Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 MinIO supports replicating delete operations onto the target bucket. 
-Specifically, MinIO can replicate both 
-:s3-docs:`Delete Markers <versioning-workflows.html>` *and* the deletion
-of specific versioned objects:
+Specifically, MinIO can replicate both :s3-docs:`Delete Markers <versioning-workflows.html>` *and* the deletion of specific versioned objects:
 
-- For delete operations on an object, MinIO replication also creates the delete
-  marker on the target bucket. 
+- For delete operations on an object, MinIO replication also creates the delete marker on the target bucket. 
 
-- For delete operations on versions of an object,
-  MinIO replication also deletes those versions on the target bucket.
+- For delete operations on versions of an object, MinIO replication also deletes those versions on the target bucket.
 
-MinIO does *not* replicate objects deleted due to
-:ref:`lifecycle management expiration rules
-<minio-lifecycle-management-expiration>`. MinIO only replicates explicit
-client-driven delete operations.
+MinIO does *not* replicate objects deleted due to :ref:`lifecycle management expiration rules <minio-lifecycle-management-expiration>`. 
+MinIO only replicates explicit client-driven delete operations.
 
-MinIO requires explicitly enabling replication of delete operations using the
-:mc-cmd:`mc replicate add --replicate` flag. This procedure includes the
-required flags for enabling replication of delete operations and delete markers.
-See :ref:`minio-replication-behavior-delete` for more complete documentation
-on this behavior.
+MinIO requires explicitly enabling replication of delete operations using the :mc-cmd:`mc replicate add --replicate` flag. 
+This procedure includes the required flags for enabling replication of delete operations and delete markers.
+See :ref:`minio-replication-behavior-delete` for more complete documentation on this behavior.
 
 Replication of Encrypted Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-MinIO supports replicating objects encrypted with automatic 
-Server-Side Encryption (SSE-S3). Both the source and destination buckets
-*must* have automatic SSE-S3 enabled for MinIO to replicate an encrypted object.
+MinIO supports replicating objects encrypted with automatic Server-Side Encryption (SSE-S3). 
+Both the source and destination buckets *must* have automatic SSE-S3 enabled for MinIO to replicate an encrypted object.
 
-As part of the replication process, MinIO *decrypts* the object on the source
-bucket and transmits the unencrypted object. The destination MinIO deployment then
-re-encrypts the object using the destination bucket SSE-S3 configuration. MinIO
-*strongly recommends* :ref:`enabling TLS <minio-TLS>` on both source and
-destination deployments to ensure the safety of objects during transmission.
+As part of the replication process, MinIO *decrypts* the object on the source bucket and transmits the unencrypted object. 
+The destination MinIO deployment then re-encrypts the object using the destination bucket SSE-S3 configuration.
+MinIO *strongly recommends* :ref:`enabling TLS <minio-TLS>` on both source and destination deployments to ensure the safety of objects during transmission.
 
-MinIO does *not* support replicating client-side encrypted objects 
-(SSE-C).
+MinIO does *not* support replicating client-side encrypted objects (SSE-C).
 
 S3 Compatibility
 ~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-replicate-ls.rst
+++ b/source/reference/minio-mc/mc-replicate-ls.rst
@@ -12,6 +12,10 @@
 
 .. mc:: mc replicate ls
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z 
+
+   ``mc replicate ls`` replaces the ``mc admin bucket remote ls`` command.
+
 Syntax
 ------
 

--- a/source/reference/minio-mc/mc-replicate-rm.rst
+++ b/source/reference/minio-mc/mc-replicate-rm.rst
@@ -12,6 +12,11 @@
 
 .. mc:: mc replicate rm
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z 
+
+   ``mc replicate rm`` replaces the ``mc admin bucket remote rm`` command.
+   Removing the replication automatically removes the underlying remote target.
+
 Syntax
 ------
 

--- a/source/reference/minio-mc/mc-replicate-status.rst
+++ b/source/reference/minio-mc/mc-replicate-status.rst
@@ -17,9 +17,8 @@ Syntax
 
 .. start-mc-replicate-status-desc
 
-The :mc:`mc replicate status` command displays the 
-:ref:`replication status <minio-bucket-replication-serverside>` of a
-MinIO bucket.
+The :mc:`mc replicate status` command displays the :ref:`replication status <minio-bucket-replication-serverside>` of a MinIO bucket.
+The status also lists the remote target path or location.
 
 .. end-mc-replicate-status-desc
 
@@ -42,7 +41,9 @@ MinIO bucket.
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] replicate status ALIAS
+         mc [GLOBALFLAGS] replicate status TARGET
+                                    [--limit-upload value]
+                                    [--limit-download value]
 
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
@@ -53,14 +54,59 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* the :ref:`alias <alias>` of the MinIO deployment and full path to
-   the bucket or bucket prefix for which to display the replication status. For
-   example:
+   The :ref:`alias <alias>` of the MinIO deployment and full path to the bucket or bucket prefix for which to display the replication status. 
+   For example:
 
    .. code-block:: none
 
       mc replicate status myminio/mybucket
+
+.. mc-cmd:: --limit-download
+   :optional:
+
+   Limit download rates to no more than a specified rate in KiB/s, MiB/s, or GiB/s.
+   Valid units include: 
+   
+   - ``B`` for bytes
+   - ``K`` for kilobytes
+   - ``G`` for gigabytes
+   - ``T`` for terabytes
+   - ``Ki`` for kibibytes
+   - ``Gi`` for gibibytes
+   - ``Ti`` for tebibytes
+
+   For example, to limit download rates to no more than 1 GiB/s, use the following:
+
+   .. code-block::
+
+      --limit-download 1G
+
+   If not specified, MinIO uses an unlimited download rate.
+
+.. mc-cmd:: --limit-upload
+   :optional:
+
+   Limit upload rates to no more than the specified rate in KiB/s, MiB/s, or GiB/s.
+   Valid units include: 
+   
+   - ``B`` for bytes
+   - ``K`` for kilobytes
+   - ``G`` for gigabytes
+   - ``T`` for terabytes
+   - ``Ki`` for kibibytes
+   - ``Gi`` for gibibytes
+   - ``Ti`` for tebibytes
+
+   For example, to limit upload rates to no more than 1 GiB/s, use the following:
+
+   .. code-block::
+
+      --limit-upload 1G
+
+   If not specified, MinIO uses an unlimited upload rate.
+
 
 Global Flags
 ~~~~~~~~~~~~
@@ -82,8 +128,6 @@ Use :mc:`mc replicate status` to show bucket replication status:
 
    mc replicate status ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc replicate status ALIAS>` with the 
-  :mc:`alias <mc alias>` of the MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc replicate status ALIAS>` with the :mc:`alias <mc alias>` of the MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc replicate status ALIAS>` with the path to the 
-  bucket or bucket prefix.
+- Replace :mc-cmd:`PATH <mc replicate status ALIAS>` with the path to the bucket or bucket prefix.


### PR DESCRIPTION
- Dec 24 2022 mc release moves `mc admin bucket remote` commands to mc replicate
- Updates `mc replicate add | update | ls | rm | status` commands
- Adds pointers from `mc admin bucket remote` command to relevant new pages

Closes #681

Partially addresses #691

- Corrects minor formatting error in glossary to address build errors