### PR TITLE
DOCS-691: Fix replication tutorials for new syntax, other minor fixes

### DIFF
--- a/source/administration/batch-framework.rst
+++ b/source/administration/batch-framework.rst
@@ -45,7 +45,7 @@ MinIO Batch CLI
 ---------------
 
 - Install the :ref:`MinIO Client <minio-client>`
-- Define an :mc-cmd:`alias <mc alias set>` for the MinIO deployment
+- Define an :mc:`alias <mc alias set>` for the MinIO deployment
 
 The :mc:`mc batch` commands include
 
@@ -100,7 +100,7 @@ The advantages of Batch Replication over :mc:`mc mirror` include:
 Sample YAML Description File for a ``replicate`` Job Type
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Create a basic ``replicate`` job definition file you can edit with :mc-cmd:`mc batch generate`.
+Create a basic ``replicate`` job definition file you can edit with :mc:`mc batch generate`.
 
 .. code-block:: yaml
 

--- a/source/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.rst
@@ -152,36 +152,21 @@ Repeat this test on each deployment by copying a new unique file and checking th
 Configure Multi-Site Bucket Replication Using the Command Line (:mc:`mc`)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This procedure uses the placeholder ``ALIAS`` to reference the :ref:`alias <alias>` each MinIO deployment being configured for replication. Replace these values with the appropriate alias for each MinIO deployment.
+This procedure uses the placeholder ``ALIAS`` to reference the :ref:`alias <alias>` each MinIO deployment being configured for replication. 
+Replace these values with the appropriate alias for each MinIO deployment.
 
 This procedure assumes each alias corresponds to a user with the :ref:`necessary replication permissions <minio-bucket-replication-requirements>`.
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   :mc:`mc replicate add` automatically creates the necessary replication targets, removing the need for using the deprecated ``mc admin remote bucket add`` command.
+   This procedure only documents the procedure as of that release.
+
 .. _minio-bucket-replication-multi-site-minio-cli-create-remote-targets:
-
-1) Create Replication Remote Targets
-++++++++++++++++++++++++++++++++++++
-
-.. include:: /includes/common/bucket-replication.rst
-   :start-after: start-create-replication-remote-targets-cli-desc
-   :end-before: end-create-replication-remote-targets-cli-desc
-
-Repeat these instructions for each remote MinIO deployment participating in the multi-site replication configuration. 
-
-For example, a multi-site replication configuration consisting of three MinIO deployments ``minio1``, ``minio2``, and ``minio3`` requires repeating this step twice on each deployment. Specifically:
-
-- The ``minio1`` deployment requires defining separate remote targets for ``minio2`` and for ``minio3``. 
-
-- The ``minio2`` deployment requires defining separate remote targets for ``minio1`` and for ``minio3``.
-
-- The ``minio3`` deployment requires defining separate remote targets for ``minio1`` and for ``minio2``.
-
-More than three deployments requires additional remote targets on each deployment to create the required targets for each origin and destination bucket compination.
-
-Record the ARN generated for each remote and note which origin-destination bucket combination you generated the ARN for.
 
 .. _minio-bucket-replication-multi-site-minio-cli-create-replication-rules:
 
-2) Create New Bucket Replication Rules
+1) Create New Bucket Replication Rules
 ++++++++++++++++++++++++++++++++++++++
 
 .. include:: /includes/common/bucket-replication.rst
@@ -201,7 +186,7 @@ Specifically, in this scenario, perform this step twice on each deployment:
 
 .. _minio-bucket-replication-multi-site-minio-cli-verify-replication-config:
 
-3) Validate the Replication Configuration
+2) Validate the Replication Configuration
 +++++++++++++++++++++++++++++++++++++++++
 
 .. include:: /includes/common/bucket-replication.rst

--- a/source/administration/bucket-replication/enable-server-side-one-way-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-one-way-bucket-replication.rst
@@ -121,18 +121,16 @@ Replace these values with the appropriate alias for your target MinIO deployment
 
 This procedure assumes each alias corresponds to a user with the :ref:`necessary replication permissions <minio-bucket-replication-serverside-oneway-permissions>`.
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   :mc:`mc replicate add` automatically creates the necessary replication targets, removing the need for using the deprecated ``mc admin remote bucket add`` command.
+   This procedure only documents the procedure as of that release.
+
 .. _minio-bucket-replication-one-way-minio-cli-create-remote-targets:
-
-1) Create a Replication Remote Target
-+++++++++++++++++++++++++++++++++++++
-
-.. include:: /includes/common/bucket-replication.rst
-   :start-after: start-create-replication-remote-targets-cli-desc
-   :end-before: end-create-replication-remote-targets-cli-desc
 
 .. _minio-bucket-replication-one-way-minio-cli-create-replication-rules:
 
-2) Create a New Bucket Replication Rule
+1) Create a New Bucket Replication Rule
 +++++++++++++++++++++++++++++++++++++++
 
 .. include:: /includes/common/bucket-replication.rst
@@ -141,7 +139,7 @@ This procedure assumes each alias corresponds to a user with the :ref:`necessary
 
 .. _minio-bucket-replication-one-way-minio-cli-verify-replication-config:
 
-3) Validate the Replication Configuration
+2) Validate the Replication Configuration
 +++++++++++++++++++++++++++++++++++++++++
 
 .. include:: /includes/common/bucket-replication.rst

--- a/source/administration/bucket-replication/enable-server-side-two-way-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-two-way-bucket-replication.rst
@@ -157,23 +157,16 @@ This procedure creates two-way, active-active replication between two MinIO depl
 
 This procedure assumes you have already defined an alias for each deployment as a user with the :ref:`necessary replication permissions <minio-bucket-replication-serverside-twoway-permissions>`.
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   :mc:`mc replicate add` automatically creates the necessary replication targets, removing the need for using the deprecated ``mc admin remote bucket add`` command.
+   This procedure only documents the procedure as of that release.
+
 .. _minio-bucket-replication-two-way-minio-cli-create-remote-targets:
-
-1) Create Replication Remote Targets
-++++++++++++++++++++++++++++++++++++
-
-.. include:: /includes/common/bucket-replication.rst
-   :start-after: start-create-replication-remote-targets-cli-desc
-   :end-before: end-create-replication-remote-targets-cli-desc
-
-Repeat this step on the second MinIO deployment, reversing the origin and destination.
-
-You should have two ARNs at the conclusion of this step that point from each deployment to the other deployment's bucket. 
-Use :mc-cmd:`mc admin bucket remote ls` to verify the remote targets before proceeding.
 
 .. _minio-bucket-replication-two-way-minio-cli-create-replication-rules:
 
-2) Create a New Bucket Replication Rule on Each Deployment
+1) Create a New Bucket Replication Rule on Each Deployment
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. include:: /includes/common/bucket-replication.rst
@@ -181,15 +174,14 @@ Use :mc-cmd:`mc admin bucket remote ls` to verify the remote targets before proc
    :end-before: end-create-bucket-replication-rule-cli-desc
 
 Repeat this step on the other MinIO deployment.
-Change the alias for the different origin.
-Change the ARN to the ARN generated on the second deployment for the desired bucket.
+Change the ``ALIAS`` and ``--remote-bucket`` values to correspond to the first deployment.
 
 You should have two replication rules configured at the conclusion of this step - one created on each deployment that points to the bucket on the other deployment.
 Use the :mc:`mc replicate ls` command to verify the created replication rules.
 
 .. _minio-bucket-replication-two-way-minio-cli-verify-replication-config:
 
-3) Validate the Replication Configuration
+2) Validate the Replication Configuration
 +++++++++++++++++++++++++++++++++++++++++
 
 .. include:: /includes/common/bucket-replication.rst

--- a/source/administration/bucket-replication/server-side-replication-resynchronize-remote.rst
+++ b/source/administration/bucket-replication/server-side-replication-resynchronize-remote.rst
@@ -48,8 +48,7 @@ Resynchronization Requires Existing Replication Configuration
 
 Resynchronization requires the healthy source deployment have an existing replication configuration for the unhealthy target bucket. Additionally, resynchronization only applies to those replication rules created with the :ref:`existing object replication <minio-replication-behavior-existing-objects>` option. 
 
-- Use :mc-cmd:`mc admin bucket remote ls` to review the configured remote targets on the healthy source bucket.
-- Use :mc:`mc replicate ls` to review the configured replication rules on the healthy source bucket.
+Use :mc:`mc replicate ls` to review the configured replication rules and targets for the healthy source bucket.
 
 Replication Requires Matching Object Encryption Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,12 +106,12 @@ You can repeat this procedure for each bucket that requires resynchronization. Y
 1) List the Configured Replication Targets on the Healthy Source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Run the :mc-cmd:`mc admin bucket remote ls` command to list the configured remote targets on the healthy ``SOURCE`` deployment for the ``BUCKET`` that requires resynchronization.
+Run the :mc-cmd:`mc replicate ls` command to list the configured remote targets on the healthy ``SOURCE`` deployment for the ``BUCKET`` that requires resynchronization.
 
 .. code-block:: shell
    :class: copyable
 
-   mc admin bucket remote ls SOURCE/BUCKET
+   mc replicate ls SOURCE/BUCKET --json
 
 - Replace ``SOURCE`` with the :ref:`alias <alias>` of the source MinIO deployment.
 
@@ -121,12 +120,43 @@ Run the :mc-cmd:`mc admin bucket remote ls` command to list the configured remot
 The output resembles the following:
 
 .. code-block:: shell
+   :emphasize-lines: 16
 
-   Remote URL                        Source->Target ARN                                   SYNC      PROXY
-   https://minio-2.example.net:9000  data  ->data   arn:minio:replication::UUID:BUCKET              proxy
+   {
+      "op": "",
+      "status": "success",
+      "url": "",
+      "rule": {
+         "ID": "cer1tuk9a3p5j68crk60",
+         "Status": "Enabled",
+         "Priority": 0,
+         "DeleteMarkerReplication": {
+            "Status": "Enabled"
+         },
+         "DeleteReplication": {
+            "Status": "Enabled"
+         },
+         "Destination": {
+            "Bucket": "arn:minio:replication::UUID:BUCKET"
+         },
+         "Filter": {
+            "And": {},
+            "Tag": {}
+         },
+         "SourceSelectionCriteria": {
+            "ReplicaModifications": {
+               "Status": "Enabled"
+            }
+         },
+         "ExistingObjectReplication": {
+            "Status": "Enabled"
+         }
+      }
+   }
 
-
-Identify the ARN associated to the ``BUCKET`` on the unhealthy ``TARGET`` MinIO deployment for use in the next step.
+Each document in the output represents one configured replication rule.
+The ``Destination.Bucket`` field specifies the ARN for a given rule on the bucket.
+Identify the correct ARN for the Bucket from which you want to resynchronize objects.
 
 2) Start the Resynchronization Procedure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -40,7 +40,7 @@ You can then use the :mc-cmd:`mc ilm add --transition-days` command to transitio
 
 .. versionadded:: RELEASE.2022-11-10T18-20-21Z
 
-You can verify the tiering status of an object using :mc-cmd:`mc ls` against the bucket or bucket prefix.
+You can verify the tiering status of an object using :mc:`mc ls` against the bucket or bucket prefix.
 The output includes the storage tier of each object:
 
 .. code-block:: shell

--- a/source/includes/common/bucket-replication.rst
+++ b/source/includes/common/bucket-replication.rst
@@ -1,33 +1,3 @@
-.. start-create-replication-remote-targets-cli-desc
-
-Use the :mc-cmd:`mc admin bucket remote add` command to create a replication target from each deployment to the appropriate bucket on the destination deployment. 
-A bucket may have multiple remote targets to different target buckets.
-No two targets can resolve from one bucket to the same remote bucket. 
-
-.. code-block:: shell
-   :class: copyable
-
-   mc admin bucket remote add ALIAS/BUCKET                    \
-      https://RemoteUser:Password@HOSTNAME/BUCKETDESTINATION  \
-      --service "replication"
-
-- Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO deployment that acts as the origin for the replication.
-- Replace ``BUCKET`` with the name of the bucket to replicate from on the origin deployment.
-- Replacete ``RemoteUser`` with the user name that has the :ref:`necessary replication permissions <minio-bucket-replication-serverside-twoway-permissions>`
-- Replace ``Password`` with the secret key for the ``RemoteUser``.
-- Replace ``HOSTNAME`` with the URL of the destination deployment.
-- Replace ``BUCKETDESTINATION`` with the name of the bucket to replicate to on the destination deployment.
-
-The command returns an :abbr:`ARN <Amazon Resource Name>` similar to the following:
-
-.. code-block:: shell
-
-   Role ARN = 'arn:minio:replication::<UUID>:BUCKET'
-
-Copy the ARN to use in the next step, noting the MinIO deployment.
-
-.. end-create-replication-remote-targets-cli-desc
-
 .. start-create-bucket-replication-rule-console-desc
 
 A) Log in to the MinIO Console for the deployment
@@ -107,7 +77,7 @@ E) Complete the requested information:
           Otherwise, move the toggle to the :guilabel:`Off` position.
 
       * - Delete Markers
-        - Leave selected to also replicate MinIO's indication that an object has been deleted and should also be marked deleted at the ation bucket.
+        - Leave selected to also replicate MinIO's indication that an object has been deleted and should also be marked deleted at the action bucket.
           Otherwise, move the toggle to the :guilabel:`Off` position to prevent marking the object as deleted in the destination bucket.
 
       * - Deletes
@@ -121,13 +91,13 @@ F) Select :guilabel:`Save` to finish adding the replication rule
 
 .. start-create-bucket-replication-rule-cli-desc
 
-Use the :mc:`mc replicate add` command to add a new replication rule to each MinIO deployment. 
+Use the :mc:`mc replicate add` command to add a new replication rule to each MinIO deployment.
 
 .. code-block:: shell
    :class: copyable
 
    mc replicate add ALIAS/BUCKET \
-      --remote-bucket 'arn:minio:replication::<UUID>:DESTINATIONBUCKET' \
+      --remote-bucket 'https://USER:PASSWORD@HOSTNAME:PORT/BUCKET' \
       --replicate "delete,delete-marker,existing-objects"
 
 - Replace ``ALIAS`` with the :ref:`alias <alias>` of the origin MinIO deployment.  
@@ -135,9 +105,12 @@ Use the :mc:`mc replicate add` command to add a new replication rule to each Min
 
 - Replace ``BUCKET`` with the name of the bucket to replicate from on the origin deployment. 
 
-- Replace the ``--remote-bucket`` value with the ARN for the destination bucket determined in the first step. 
-  Ensure you specify the ARN created on the origin deployment. 
-  You can use :mc-cmd:`mc admin bucket remote ls` to list all remote ARNs configured on the deployment.
+- Replace the ``--remote-bucket`` to specify the remote MinIO deployment and bucket to which the ``ALIAS/BUCKET`` replicates.
+
+  The ``USER:PASSWORD`` must correspond to a user on the remote deployment with the :ref:`necessary replication permissions <minio-bucket-replication-serverside-twoway-permissions>`.
+
+  The ``HOSTNAME:PORT`` must resolve to a reachable MinIO instance on the remote deployment.
+  The ``BUCKET`` must exist and otherwise meet all other :ref:`replication requirements <minio-bucket-replication-requirements>`.
 
 - The ``--replicate "delete,delete-marker,existing-objects"`` flag enables the following replication features:
   

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -39,7 +39,7 @@ Procedure
 
 .. note:: 
    
-   You can set MinIO configuration settings in environment variables and using :mc-cmd:`mc admin config set <mc admin config>`.
+   You can set MinIO configuration settings in environment variables and using :mc-cmd:`mc admin config set <mc admin config set>`.
    Depending on your current deployment setup, you may need to retrieve the values for both.
 
    This procedure does not cover migrating environment variables due to the variety of configuration methods.
@@ -68,7 +68,7 @@ Procedure
 
 #. Export the existing deployment's **configurations**
 
-   Use the :mc-cmd:`mc admin config export <mc admin config>` export command to retrieve the configurations defined for the existing standalone MinIO deployment.
+   Use the :mc-cmd:`mc admin config export <mc admin config export>` export command to retrieve the configurations defined for the existing standalone MinIO deployment.
 
    .. code-block:: shell
       :class: copyable

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -85,7 +85,7 @@ Any MinIO deployment in the site replication configuration can resynchronize dam
 
 .. versionchanged:: RELEASE.2022-12-02T23-48-47Z
 
-   If one site loses data for any reason, resynchronize the data from another healthy site with :mc:`mc admin replicate resync`.
+   If one site loses data for any reason, resynchronize the data from another healthy site with :mc-cmd:`mc admin replicate resync`.
    This launches an active process that resynchronizes the data without waiting for the passive MinIO scanner to recognize the missing data.
 
 Prerequisites

--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -166,9 +166,9 @@ For more details about encrypting or decrypting such files, see :ref:`Encrypting
 Logs
 ----
 
-Use :mc:`mc support callhome enable` to start automatically uploading deployment logs to SUBNET for analysis.
-Use :mc:`mc support callhome status` to check the status of log upload.
-You can disable upload at any time using :mc:`mc support callhome disable`.
+Use :mc-cmd:`mc support callhome enable` to start automatically uploading deployment logs to SUBNET for analysis.
+Use :mc-cmd:`mc support callhome status` to check the status of log upload.
+You can disable upload at any time using :mc-cmd:`mc support callhome disable`.
 
 Use :mc:`mc admin logs` command to display logs from the command line.
 The command supports type and quantity filters for further limiting logs output.

--- a/source/reference/minio-mc/mc-replicate-resync.rst
+++ b/source/reference/minio-mc/mc-replicate-resync.rst
@@ -103,14 +103,10 @@ Parameters
 .. mc-cmd:: --remote-bucket
    :required:
 
-   Specify the ARN for the destination deployment and bucket. You
-   can retrieve the ARN using :mc-cmd:`mc admin bucket remote`:
-    
-   - Use the :mc-cmd:`mc admin bucket remote ls` to retrieve a list of 
-     ARNs for the bucket on the destination deployment.
-
-   - Use the :mc-cmd:`mc admin bucket remote add` to create a replication ARN
-     for the bucket on the destination deployment.
+   Specify the ARN for the destination deployment and bucket. 
+   
+   You can retrieve the ARN using :mc-cmd:`mc replicate ls` with the ``--json`` option.
+   The ``rule.Destination.Bucket`` field contains the ARN for any given replication rule.
 
 .. mc-cmd:: older-than
    :optional:


### PR DESCRIPTION
Partially addresses #691 

Follows up #692 

#. Summary

Updates replication tutorials to use latest syntax for `mc replicate add`, removing references to `mc admin bucket remote add`

Includes some build output fixes for non-Linux builds.

Staged:

- [One-Way Bucket Replication](http://192.241.195.202:9000/staging/DOCS-691-partial/linux/administration/bucket-replication/enable-server-side-one-way-bucket-replication.html#configure-one-way-bucket-replication-using-the-command-line-mc)
- [Two-Way Bucket Replication](http://192.241.195.202:9000/staging/DOCS-691-partial/linux/administration/bucket-replication/enable-server-side-two-way-bucket-replication.html#configure-two-way-bucket-replication-using-the-command-line-mc)
- [Three-Way Bucket Replication](http://192.241.195.202:9000/staging/DOCS-691-partial/linux/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.html#configure-multi-site-bucket-replication-using-the-command-line-mc)
- [Resynchronize Bucket](http://192.241.195.202:9000/staging/DOCS-691-partial/linux/administration/bucket-replication/server-side-replication-resynchronize-remote.html)