### PR TITLE
Updates to mc docs for December 2022 releases

### DIFF
--- a/source/administration/identity-access-management/policy-based-access-control.rst
+++ b/source/administration/identity-access-management/policy-based-access-control.rst
@@ -769,12 +769,12 @@ services:
 .. policy-action:: admin:SetTier
 
    Allows creating and modifying remote storage tiers using the 
-   :mc:`mc admin tier` command.
+   :mc:`mc ilm tier` commands.
 
 .. policy-action:: admin:ListTier
 
    Allows listing configured remote storage tiers using the
-   :mc:`mc admin tier` command.
+   :mc:`mc ilm tier` commands.
 
 .. policy-action:: admin:BandwidthMonitor
 

--- a/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
+++ b/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
@@ -62,51 +62,51 @@ transition lifecycle management rules on any bucket in the cluster:.
 Expire Objects after Number of Days
 -----------------------------------
 
-Use :mc:`mc ilm add` with :mc-cmd:`~mc ilm add --expire-days` to
+Use :mc:`mc ilm rule add` with :mc-cmd:`~mc ilm rule add --expire-days` to
 expire bucket contents a number of days after object creation:
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm add ALIAS/PATH --expire-days "DAYS" 
+   mc ilm rule add ALIAS/PATH --expire-days "DAYS" 
 
-- Replace :mc-cmd:`ALIAS <mc ilm add ALIAS>` with the 
+- Replace :mc-cmd:`ALIAS <mc ilm rule add ALIAS>` with the 
   :mc:`alias <mc alias>` of the S3-compatible host.
 
-- Replace :mc-cmd:`PATH <mc ilm add ALIAS>` with the path to the bucket on the
+- Replace :mc-cmd:`PATH <mc ilm rule add ALIAS>` with the path to the bucket on the
   S3-compatible host.
 
-- Replace :mc-cmd:`DAYS <mc ilm add --expire-days>` with the number of days after
+- Replace :mc-cmd:`DAYS <mc ilm rule add --expire-days>` with the number of days after
   which to expire the object. For example, specify ``30`` to expire the
   object 30 days after creation.
 
 Expire Versioned Objects
 ------------------------
 
-Use :mc:`mc ilm add` to expiring noncurrent object versions and object
+Use :mc:`mc ilm rule add` to expiring noncurrent object versions and object
 delete markers: 
 
 - To expire noncurrent object versions after a specific duration in days,
-  include :mc-cmd:`~mc ilm add --noncurrent-expire-days`.
+  include :mc-cmd:`~mc ilm rule add --noncurrent-expire-days`.
 
 - To expire delete markers for objects with no remaining versions, 
-  include :mc-cmd:`~mc ilm add --expire-delete-marker`.
+  include :mc-cmd:`~mc ilm rule add --expire-delete-marker`.
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm add ALIAS/PATH \ 
+   mc ilm rule add ALIAS/PATH \ 
       --noncurrent-expire-days NONCURRENT_DAYS \
       --expire-delete-marker
 
-- Replace :mc-cmd:`ALIAS <mc ilm add ALIAS>` with the 
+- Replace :mc-cmd:`ALIAS <mc ilm rule add ALIAS>` with the 
   :mc:`alias <mc alias>` of the S3-compatible host.
 
-- Replace :mc-cmd:`PATH <mc ilm add ALIAS>` with the path to the bucket on the
+- Replace :mc-cmd:`PATH <mc ilm rule add ALIAS>` with the path to the bucket on the
   S3-compatible host.
 
 - Replace :mc-cmd:`NONCURRENT_DAYS 
-  <mc ilm add --noncurrent-expire-days>` with the number of days after
+  <mc ilm rule add --noncurrent-expire-days>` with the number of days after
   which to expire noncurrent object versions. For example, specify ``30d`` to
   expire a version after it has been noncurrent for at least 30 days.
 

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -35,8 +35,8 @@ MinIO supports any of the following remote tier targets:
 MinIO object transition supports use cases like moving aged data from MinIO clusters in private or public cloud infrastructure to low-cost private or public cloud storage solutions. 
 MinIO manages retrieving tiered objects on-the-fly without any additional application-side logic. 
 
-Use the :mc:`mc admin tier` command to create a remote target for tiering data that target. 
-You can then use the :mc-cmd:`mc ilm add --transition-days` command to transition objects to that tier after a specified number of calendar days.
+Use the :mc:`mc ilm tier add` command to create a remote target for tiering data to that target. 
+You can then use the :mc-cmd:`mc ilm rule add --transition-days` command to transition objects to that tier after a specified number of calendar days.
 
 .. versionadded:: RELEASE.2022-11-10T18-20-21Z
 
@@ -72,7 +72,7 @@ Versioned Buckets
 MinIO adopts :s3-docs:`S3 behavior <intro-lifecycle-rules.html#intro-lifecycle-rules-actions>` for transition rules on :ref:`versioned buckets <minio-bucket-versioning>`. 
 Specifically, MinIO by default applies the transition operation to the *current* object version. 
 
-To transition noncurrent object versions, specify the :mc-cmd:`~mc ilm add --noncurrent-transition-days` and :mc-cmd:`~mc ilm add --noncurrent-transition-tier` options when creating the transition rule. 
+To transition noncurrent object versions, specify the :mc-cmd:`~mc ilm rule add --noncurrent-transition-days` and :mc-cmd:`~mc ilm rule add --noncurrent-transition-tier` options when creating the transition rule. 
 
 .. _minio-lifecycle-management-expiration:
 
@@ -85,7 +85,7 @@ For example, you can create a lifecycle management rule to expire any object old
 
 .. todo: Diagram of MinIO Expiration
 
-Use :mc-cmd:`mc ilm add --expire-days` to expire objects after a specified number of calendar days.
+Use :mc-cmd:`mc ilm rule add --expire-days` to expire objects after a specified number of calendar days.
 
 For buckets with :ref:`replication <minio-bucket-replication>` configured, MinIO does not replicate objects deleted by a lifecycle management expiration rule.
 See :ref:`minio-replication-behavior-delete` for more information.
@@ -98,11 +98,11 @@ MinIO has two specific default behaviors for versioned buckets:
 
 - MinIO applies the expiration option to only the *current* object version by creating a ``DeleteMarker`` as is normal with versioned delete.
 
-  To expire noncurrent object versions, specify the :mc-cmd:`~mc ilm add --noncurrent-expire-days` option when creating the expiration rule. 
+  To expire noncurrent object versions, specify the :mc-cmd:`~mc ilm rule add --noncurrent-expire-days` option when creating the expiration rule. 
 
 - MinIO does not expire ``DeleteMarkers`` *even if* no other versions of that object exist.
 
-  To expire delete markers when there are no remaining versions for that object, specify the :mc-cmd:`~mc ilm add --expire-delete-marker` option when creating the expiration rule.
+  To expire delete markers when there are no remaining versions for that object, specify the :mc-cmd:`~mc ilm rule add --expire-delete-marker` option when creating the expiration rule.
 
 .. _minio-lifecycle-management-scanner:
 

--- a/source/administration/object-management/transition-objects-to-azure.rst
+++ b/source/administration/object-management/transition-objects-to-azure.rst
@@ -117,18 +117,16 @@ Procedure
 2) Configure the Remote Storage Tier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc-cmd:`mc admin tier add` command to add a new remote storage tier:
+Use the :mc-cmd:`mc ilm tier add` command to add a new remote storage tier:
 
 .. code-block:: shell
    :class: copyable
 
-   mc admin tier add azure TARGET TIER_NAME \
-      --endpoint https://HOSTNAME
-      --bucket BUCKET \
-      --prefix PREFIX
+   mc ilm tier add azure TARGET TIER_NAME \
       --account-name ACCOUNT \
       --account-key KEY \
-      --region REGION
+      --bucket BUCKET \
+      --prefix PREFIX
 
 
 The example above uses the following arguments:
@@ -141,24 +139,20 @@ The example above uses the following arguments:
    * - Argument
      - Description
    
-   * - :mc-cmd:`TARGET <mc admin tier add TARGET>`
+   * - :mc-cmd:`TARGET <mc ilm tier add TARGET>`
      - The :mc:`alias <mc alias>` of the MinIO deployment on which to configure
        the remote tier.
    
-   * - :mc-cmd:`TIER_NAME <mc admin tier add TIER_NAME>`
+   * - :mc-cmd:`TIER_NAME <mc ilm tier add TIER_NAME>`
      - The name to associate with the new :abbr:`Azure (Microsoft Azure)` blob
        remote storage tier. Specify the name in all-caps, e.g. ``AZURE_TIER``.
        This value is required in the next step.
 
-   * - :mc-cmd:`HOSTNAME <mc admin tier add --endpoint>`
-     - The URL endpoint for the :abbr:`Azure (Microsoft Azure)` storage
-       backend.
-
-   * - :mc-cmd:`BUCKET <mc admin tier add --bucket>`
+   * - :mc-cmd:`BUCKET <mc ilm tier add --bucket>`
      - The name of the bucket on the :abbr:`Azure (Microsoft Azure)` storage
        backend to which MinIO transitions objects.
 
-   * - :mc-cmd:`PREFIX <mc admin tier add --prefix>`
+   * - :mc-cmd:`PREFIX <mc ilm tier add --prefix>`
      - The optional bucket prefix within which MinIO transitions objects.
 
        MinIO stores all transitioned objects in the specified ``BUCKET`` under a
@@ -171,7 +165,7 @@ The example above uses the following arguments:
        source MinIO deployment to faciliate ease of operations related to
        diagnostics, maintenance, or disaster recovery.
 
-   * - :mc-cmd:`ACCOUNT <mc admin tier add --account-name>`
+   * - :mc-cmd:`ACCOUNT <mc ilm tier add --account-name>`
      - The account name MinIO uses to access the bucket. The account name
        *must* correspond to an :abbr:`Azure (Microsoft Azure)` user with the
        required :ref:`permissions
@@ -179,13 +173,9 @@ The example above uses the following arguments:
 
        You cannot change this account name after creating the tier.
 
-   * - :mc-cmd:`KEY <mc admin tier add --account-key>`
+   * - :mc-cmd:`KEY <mc ilm tier add --account-key>`
      - The corresponding key for the specified ``ACCOUNT``.
 
-   * - :mc-cmd:`REGION <mc admin tier add --region>`
-     - The :abbr:`Azure (Microsoft Azure)` blob storage region of the specified
-       ``BUCKET``. You can safely omit this option if the ``HOSTNAME`` includes
-       the region.
 
 3) Create and Apply the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -198,16 +188,15 @@ The example above uses the following arguments:
 4) Verify the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc:`mc ilm ls` command to review the configured transition
-rules:
+Use the :mc:`mc ilm rule ls` command to review the configured transition rules:
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm ls ALIAS/PATH --transition
+   mc ilm rule ls ALIAS/PATH --transition
 
-- Replace :mc-cmd:`ALIAS <mc ilm ls ALIAS>` with the :mc:`alias <mc alias>`
+- Replace :mc-cmd:`ALIAS <mc ilm rule ls ALIAS>` with the :mc:`alias <mc alias>`
   of the MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc ilm ls ALIAS>` with the name of the bucket for
+- Replace :mc-cmd:`PATH <mc ilm rule ls ALIAS>` with the name of the bucket for
   which to retrieve the configured lifecycle management rules.

--- a/source/administration/object-management/transition-objects-to-gcs.rst
+++ b/source/administration/object-management/transition-objects-to-gcs.rst
@@ -115,18 +115,16 @@ Procedure
 2) Configure the Remote Storage Tier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc-cmd:`mc admin tier add` command to add a new Google Cloud Storage
+Use the :mc-cmd:`mc ilm tier add` command to add a new Google Cloud Storage
 service as the remote storage tier:
 
 .. code-block:: shell
    :class: copyable
 
-   mc admin tier add gcs TARGET TIER_NAME \
-      --endpoint https://HOSTNAME \
+   mc ilm tier add gcs TARGET TIER_NAME \
       --bucket BUCKET \
       --prefix PREFIX \
-      --credentials-file CREDENTIALS \
-      --region REGION
+      --credentials-file CREDENTIALS
 
 The example above uses the following arguments:
 
@@ -138,24 +136,28 @@ The example above uses the following arguments:
    * - Argument
      - Description
 
-   * - :mc-cmd:`TARGET <mc admin tier add TARGET>`
+   * - :mc-cmd:`TARGET <mc ilm tier add TARGET>`
      - The :mc:`alias <mc alias>` of the MinIO deployment on which to configure
        the :abbr:`GCS (Google Cloud Storage)` remote tier.
    
-   * - :mc-cmd:`TIER_NAME <mc admin tier add TIER_NAME>`
+   * - :mc-cmd:`TIER_NAME <mc ilm tier add TIER_NAME>`
      - The name to associate with the new :abbr:`GCS (Google Cloud Storage)` 
        remote storage tier. Specify the name in all-caps, e.g. ``GCS_TIER``.
        This value is required in the next step.
 
-   * - :mc-cmd:`HOSTNAME <mc admin tier add --endpoint>`
-     - The URL endpoint for the :abbr:`GCS (Google Cloud Storage)` storage
-       backend.
+   * - :mc-cmd:`CREDENTIALS <mc ilm tier add --credentials-file>`
+     - The `credential file
+       <https://cloud.google.com/docs/authentication/getting-started>`__ for a
+       user on the remote GCS tier. The specified user credentials *must*
+       correspond to a GCS user with the required
+       :ref:`permissions 
+       <minio-lifecycle-management-transition-to-gcs-permissions-remote>`.
 
-   * - :mc-cmd:`BUCKET <mc admin tier add --bucket>`
+   * - :mc-cmd:`BUCKET <mc ilm tier add --bucket>`
      - The name of the bucket on the :abbr:`GCS (Google Cloud Storage)` storage
        backend to which MinIO transitions objects.
 
-   * - :mc-cmd:`PREFIX <mc admin tier add --prefix>`
+   * - :mc-cmd:`PREFIX <mc ilm tier add --prefix>`
      - The optional bucket prefix within which MinIO transitions objects.
 
        MinIO stores all transitioned objects in the specified ``BUCKET`` under a
@@ -168,18 +170,6 @@ The example above uses the following arguments:
        source MinIO deployment to faciliate ease of operations related to
        diagnostics, maintenance, or disaster recovery.
 
-   * - :mc-cmd:`CREDENTIALS <mc admin tier add --credentials-file>`
-     - The `credential file
-       <https://cloud.google.com/docs/authentication/getting-started>`__ for a
-       user on the remote GCS tier. The specified user credentials *must*
-       correspond to a GCS user with the required
-       :ref:`permissions 
-       <minio-lifecycle-management-transition-to-gcs-permissions-remote>`.
-
-   * - :mc-cmd:`REGION <mc admin tier add --region>`
-     - The :abbr:`GCS (Google Cloud Storage)` region of the specified
-       ``BUCKET``. You can safely omit this
-       option if the ``HOSTNAME`` includes the region.
 
 3) Create and Apply the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -192,16 +182,16 @@ The example above uses the following arguments:
 4) Verify the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc:`mc ilm ls` command to review the configured transition
+Use the :mc:`mc ilm rule ls` command to review the configured transition
 rules:
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm ls ALIAS/PATH --transition
+   mc ilm rule ls ALIAS/PATH --transition
 
-- Replace :mc-cmd:`ALIAS <mc ilm ls ALIAS>` with the :mc:`alias <mc alias>`
+- Replace :mc-cmd:`ALIAS <mc ilm rule ls ALIAS>` with the :mc:`alias <mc alias>`
   of the MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc ilm ls ALIAS>` with the name of the bucket for
+- Replace :mc-cmd:`PATH <mc ilm rule ls ALIAS>` with the name of the bucket for
   which to retrieve the configured lifecycle management rules.

--- a/source/administration/object-management/transition-objects-to-s3.rst
+++ b/source/administration/object-management/transition-objects-to-s3.rst
@@ -124,20 +124,20 @@ Procedure
 2) Configure the Remote Storage Tier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc-cmd:`mc admin tier add` command to add an Amazon S3 service as the
+Use the :mc-cmd:`mc ilm tier add` command to add an Amazon S3 service as the
 new remote storage tier:
 
 .. code-block:: shell
    :class: copyable
 
-   mc admin tier add s3 TARGET TIER_NAME \
-      --endpoint https://HOSTNAME \
-      --bucket BUCKET \
-      --prefix PREFIX
-      --access-key ACCESS_KEY \
-      --secret-key SECRET_KEY \
-      --region REGION \
-      --storage-class STORAGE_CLASS
+   mc ilm tier add s3 TARGET TIER_NAME  \
+      --endpoint https://HOSTNAME       \
+      --access-key ACCESS_KEY           \
+      --secret-key SECRET_KEY           \
+      --bucket BUCKET                   \
+      --prefix PREFIX                   \
+      --storage-class STORAGE_CLASS     \
+      --region REGION 
 
 The example above uses the following arguments:
 
@@ -149,23 +149,33 @@ The example above uses the following arguments:
    * - Argument
      - Description
    
-   * - :mc-cmd:`TARGET <mc admin tier add TARGET>`
+   * - :mc-cmd:`TARGET <mc ilm tier add TARGET>`
      - The :mc:`alias <mc alias>` of the MinIO deployment on which to configure
        the S3 remote tier.
    
-   * - :mc-cmd:`TIER_NAME <mc admin tier add TIER_NAME>`
+   * - :mc-cmd:`TIER_NAME <mc ilm tier add TIER_NAME>`
      - The name to associate with the new S3 remote storage tier. Specify the
        name in all-caps, e.g. ``S3_TIER``. This value is required in the next
        step.
 
-   * - :mc-cmd:`HOSTNAME <mc admin tier add --endpoint>`
+   * - :mc-cmd:`HOSTNAME <mc ilm tier add --endpoint>`
      - The URL endpoint for the S3 storage backend.
 
-   * - :mc-cmd:`BUCKET <mc admin tier add --bucket>`
+   * - :mc-cmd:`ACCESS_KEY <mc ilm tier add --access-key>`
+     - The S3 access key MinIO uses to access the bucket. The
+       access key *must* correspond to an IAM user with the 
+       required 
+       :ref:`permissions 
+       <minio-lifecycle-management-transition-to-s3-permissions-remote>`.
+
+   * - :mc-cmd:`SECRET_KEY <mc ilm tier add --secret-key>`
+     - The corresponding secret key for the specified ``ACCESS_KEY``.
+
+   * - :mc-cmd:`BUCKET <mc ilm tier add --bucket>`
      - The name of the bucket on the S3 storage backend to which MinIO
        transitions objects.
 
-   * - :mc-cmd:`PREFIX <mc admin tier add --prefix>`
+   * - :mc-cmd:`PREFIX <mc ilm tier add --prefix>`
      - The optional bucket prefix within which MinIO transitions objects.
 
        MinIO stores all transitioned objects in the specified ``BUCKET`` under a
@@ -178,26 +188,16 @@ The example above uses the following arguments:
        source MinIO deployment to faciliate ease of operations related to
        diagnostics, maintenance, or disaster recovery.
 
-   * - :mc-cmd:`ACCESS_KEY <mc admin tier add --access-key>`
-     - The S3 access key MinIO uses to access the bucket. The
-       access key *must* correspond to an IAM user with the 
-       required 
-       :ref:`permissions 
-       <minio-lifecycle-management-transition-to-s3-permissions-remote>`.
-
-   * - :mc-cmd:`SECRET_KEY <mc admin tier add --secret-key>`
-     - The corresponding secret key for the specified ``ACCESS_KEY``.
-
-   * - :mc-cmd:`REGION <mc admin tier add --region>`
-     - The AWS S3 region of the specified ``BUCKET``. You can safely omit this
-       option if the ``HOSTNAME`` includes the region.
-
-   * - :mc-cmd:`STORAGE_CLASS <mc admin tier add --storage-class>`
+   * - :mc-cmd:`STORAGE_CLASS <mc ilm tier add --storage-class>`
      - The S3 storage class to which MinIO transitions objects. Specify
        one of the following supported storage classes:
 
        - ``STANDARD``
        - ``REDUCED``
+
+   * - :mc-cmd:`REGION <mc ilm tier add --region>`
+     - The AWS S3 region of the specified ``BUCKET``. You can safely omit this
+       option if the ``HOSTNAME`` includes the region.
 
 3) Create and Apply the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -210,16 +210,16 @@ The example above uses the following arguments:
 4) Verify the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc:`mc ilm ls` command to review the configured transition
+Use the :mc:`mc ilm rule ls` command to review the configured transition
 rules:
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm ls ALIAS/PATH --transition
+   mc ilm rule ls ALIAS/PATH --transition
 
-- Replace :mc-cmd:`ALIAS <mc ilm ls ALIAS>` with the :mc:`alias <mc alias>`
+- Replace :mc-cmd:`ALIAS <mc ilm rule ls ALIAS>` with the :mc:`alias <mc alias>`
   of the MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc ilm ls ALIAS>` with the name of the bucket for
+- Replace :mc-cmd:`PATH <mc ilm rule ls ALIAS>` with the name of the bucket for
   which to retrieve the configured lifecycle management rules.

--- a/source/includes/common-minio-tiering.rst
+++ b/source/includes/common-minio-tiering.rst
@@ -1,13 +1,13 @@
 .. start-create-transition-rule-desc
 
-Use the :mc:`mc ilm add` command to create a new transition rule
+Use the :mc:`mc ilm rule add` command to create a new transition rule
 for the bucket. The following example configures transition after the
 specified number of calendar days:
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm add ALIAS/BUCKET \
+   mc ilm rule add ALIAS/BUCKET \
    --transition-tier TIERNAME \
    --transition-days DAYS \
    --noncurrent-transition-days NONCURRENT_DAYS
@@ -23,28 +23,28 @@ The example above specifies the following arguments:
    * - Argument
      - Description
 
-   * - :mc-cmd:`ALIAS <mc ilm add ALIAS>`
+   * - :mc-cmd:`ALIAS <mc ilm rule add ALIAS>`
      - Specify the :mc:`alias <mc alias>` of the MinIO deployment for which
        you are creating the lifecycle management rule.
 
-   * - :mc-cmd:`BUCKET <mc ilm add ALIAS>`
+   * - :mc-cmd:`BUCKET <mc ilm rule add ALIAS>`
      - Specify the full path to the bucket for which you are
        creating the lifecycle management rule.
 
-   * - :mc-cmd:`TIERNAME <mc ilm add --transition-tier>`
+   * - :mc-cmd:`TIERNAME <mc ilm rule add --transition-tier>`
      - The remote storage tier to which MinIO transitions objects. 
        Specify the remote storage tier name created in the previous step.
 
        If you want to transition noncurrent object versions to a distinct
        remote tier, specify a different tier name for 
-       :mc-cmd:`~mc ilm add --noncurrent-transition-tier`.
+       :mc-cmd:`~mc ilm rule add --noncurrent-transition-tier`.
 
-   * - :mc-cmd:`DAYS <mc ilm add --transition-days>`
+   * - :mc-cmd:`DAYS <mc ilm rule add --transition-days>`
      - The number of calendar days after which MinIO marks an object as 
        eligible for transition. Specify the number of days as an integer,
        e.g. ``30`` for 30 days.
 
-   * - :mc-cmd:`NONCURRENT_DAYS <mc ilm add --noncurrent-transition-days>`
+   * - :mc-cmd:`NONCURRENT_DAYS <mc ilm rule add --noncurrent-transition-days>`
      - The number of calendar days after which MinIO marks a noncurrent
        object version as eligible for transition. MinIO specifically measures
        the time since an object *became* non-current instead of the object

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -135,12 +135,12 @@ Procedure
 
 #. *(Optional)* Duplicate **tiers** from existing standalone deployment to new deployment
 
-   Use :mc-cmd:`mc admin tier ls` with the ``--json`` flag to retrieve a list of the tiers that exist on the standalone deployment.
+   Use :mc-cmd:`mc ilm tier ls` with the ``--json`` flag to retrieve a list of the tiers that exist on the standalone deployment.
 
    .. code-block:: shell
       :class: copyable
 
-      mc admin tier ls ALIAS --json
+      mc ilm tier ls ALIAS --json
 
    - Replace ``ALIAS`` with the alias for the existing standalone deployment.
    

--- a/source/reference/deprecated/mc-admin-bucket-quota.rst
+++ b/source/reference/deprecated/mc-admin-bucket-quota.rst
@@ -10,6 +10,10 @@
 
 .. mc:: mc admin bucket quota
 
+.. versionchanged:: RELEASE.2022-12-13T00-23-28Z
+
+   ``mc admin bucket quota`` replaced by :mc-cmd:`mc quota set`, :mc-cmd:`mc quota info`, and :mc-cmd:`mc quota clear`.
+
 Description
 -----------
 

--- a/source/reference/deprecated/mc-admin-tier.rst
+++ b/source/reference/deprecated/mc-admin-tier.rst
@@ -10,6 +10,10 @@
 
 .. mc:: mc admin tier
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc admin tier`` replaced by :mc-cmd:`mc ilm tier`.
+
 Description
 -----------
 

--- a/source/reference/deprecated/mc-ilm-add.rst
+++ b/source/reference/deprecated/mc-ilm-add.rst
@@ -1,0 +1,378 @@
+.. _minio-mc-ilm-add:
+
+==============
+``mc ilm add``
+==============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm add
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm add`` replaced by :mc-cmd:`mc ilm rule add`
+
+Syntax
+------
+
+.. start-mc-ilm-add-desc
+
+The :mc:`mc ilm add` command adds an object lifecycle management rule to a bucket.
+
+.. end-mc-ilm-add-desc
+
+The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-management-tiering>` and :ref:`Expiration <minio-lifecycle-management-expiration>` lifecycle management rules.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command adds new lifecycle management rules to the ``mydata`` bucket on the ``myminio`` deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm add --expire-days 90 --noncurrent-expire-days 30  mydata/myminio
+         
+         mc ilm add --expire-delete-marker mydata/myminio
+
+         mc ilm add --transition-days 30 --transition-tier "COLDTIER" mydata/myminio
+         
+         mc ilm add --noncurrent-transition-days 7 --noncurrent-transition-tier "COLDTIER" 
+
+      The configured rules have the following effect:
+
+      - Delete objects more than 90 days old
+      - Delete objects 30 days after they become non-current
+      - Delete ``DeleteMarker`` tombstones if that object has no other versions remaining.
+      - Transition objects more than 30 days old to the ``COLDTIER`` remote tier.
+      - Transition objects 7 days after they become non-current to the ``COLDTIER`` remote tier.
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] ilm add                                    \
+                          [--prefix string]                          \
+                          [--tags string]                            \
+                          --expire-days "integer"                    \
+                          [--expire-delete-marker]                   \
+                          [--transition-days "string"]               \
+                          [--transition-tier "string"]               \
+                          [--noncurrent-expire-days "integer"]       \
+                          [--noncurrent-expire-newer "integer"]      \
+                          [--noncurrent-transition-days "integer"]   \
+                          [--noncurrent-transition-newer "integer"]  \
+                          [--noncurrent-transition-tier "string"]    \
+                          ALIAS
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+   
+   The :ref:`alias <alias>` and bucket on the MinIO deployment to which to add the object lifecycle management rule. 
+   
+   For example:
+
+   .. code-block:: none
+
+      mc ilm add myminio/mydata
+
+.. mc-cmd:: --prefix
+   :optional:
+   
+   Restrict the management rule to a specific object prefix.
+   
+   For example:
+
+   .. code-block:: none
+
+      mc ilm add --prefix "meetingnotes/" myminio/mydata/ --expire-days "90"
+
+   The command creates a rule that expires objects in the ``mydata`` bucket of the ``myminio`` ALIAS after 90 days for any object with the ``meetingnotes/`` prefix.
+
+.. mc-cmd:: --tags
+   :optional:
+
+   One or more ampersand ``&``-delimited key-value pairs describing the object tags to use for filtering objects to which the lifecycle configuration rule applies.
+
+   This option is mutually exclusive with the following option:
+
+   - :mc-cmd:`~mc ilm add --expire-delete-marker`
+
+.. mc-cmd:: --expire-days
+   :required:   
+
+   The number of days to retain an object after being created. 
+   MinIO marks the object for deletion after the specified number of days pass. 
+   Specify the number of days as an integer, e.g. ``30`` for 30 days.
+
+   For versioned buckets, the expiry rule applies only to the *current* object version. 
+   Use the :mc-cmd:`~mc ilm add --noncurrent-expire-days` option to apply expiration behavior to noncurrent object versions.
+
+   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
+   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
+   See :ref:`minio-lifecycle-management-scanner` for more information.
+
+   Mutually exclusive with the following options:
+
+   - :mc-cmd:`~mc ilm add --expire-delete-marker`
+
+   For more complete documentation on object expiration, see :ref:`minio-lifecycle-management-expiration`.
+
+.. mc-cmd:: --expire-delete-marker
+   :optional:
+
+   Specify this option to direct MinIO to remove delete markers for objects with no remaining object versions. 
+   Specifically, the delete marker is the *only* remaining "version" of the given object.
+
+   This option is mutually exclusive with the following option:
+   
+   - :mc-cmd:`~mc ilm add --tags`
+   - :mc-cmd:`~mc ilm add --expire-days`
+
+   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
+   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
+   See :ref:`minio-lifecycle-management-scanner` for more information.
+
+   For more complete documentation on object expiration, see
+   :ref:`minio-lifecycle-management-expiration`.
+
+.. mc-cmd:: --transition-days
+   :optional:
+   
+   The number of calendar days from object creation after which MinIO marks an object as eligible for transition. 
+   MinIO transitions the object to the configured remote tier specified to the :mc-cmd:`~mc ilm add --transition-tier`. 
+   Specify the number of days as an integer, e.g. ``30`` for 30 days.
+
+   For versioned buckets, the transition rule applies only to the *current* object version. 
+   Use the :mc-cmd:`~mc ilm add --noncurrent-transition-days` option to apply transition behavior to noncurrent object versions.
+
+   Requires specifying :mc-cmd:`~mc ilm add --transition-tier`.
+
+   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
+   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
+   See :ref:`minio-lifecycle-management-scanner` for more information.
+
+   For more complete documentation on object transition, see :ref:`minio-lifecycle-management-tiering`.
+
+.. mc-cmd:: --transition-tier
+   :optional:
+
+   The remote tier to which MinIO :ref:`transition objects <minio-lifecycle-management-tiering>`.
+   Specify an existing remote tier created by :mc:`mc admin tier`. 
+
+   Required if specifying :mc-cmd:`~mc ilm add --transition-days`.
+
+.. mc-cmd:: --noncurrent-expire-days
+   :optional:
+
+   The number of days to retain an object version after becoming *non-current* (i.e. a different version of that object is now the `HEAD`).
+   MinIO marks noncurrent object versions for deletion after the specified number of days pass.
+
+   This option has the same behavior as the S3 ``NoncurrentVersionExpiration`` action.
+
+   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
+   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
+   See :ref:`minio-lifecycle-management-scanner` for more information.
+
+.. mc-cmd:: --noncurrent-transition-days
+   :optional:
+
+   The number of days an object has been non-current (i.e. replaced by a newer version of that same object) after which MinIO marks the object version as eligible for transition. 
+   MinIO transitions the object to the configured remote tier specified to the :mc-cmd:`~mc ilm add --transition-tier` once the system host datetime passes that calendar date.
+
+   This option has no effect on non-versioned buckets. 
+   Requires specifying :mc-cmd:`~mc ilm add --noncurrent-transition-tier`.
+
+   This option has the same behavior as the S3 ``NoncurrentVersionTransition`` action.
+
+   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
+   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
+   See :ref:`minio-lifecycle-management-scanner` for more information.
+
+.. mc-cmd:: --noncurrent-transition-tier
+   :optional:
+
+   The remote tier to which MinIO :ref:`transitions noncurrent objects versions <minio-lifecycle-management-tiering>`. 
+   Specify a remote tier created by :mc:`mc admin tier`.
+
+.. mc-cmd:: --noncurrent-expire-newer
+   :optional:
+
+   The maximum number of non-current object versions to retain, ordered from newest to oldest.
+   
+   Use this flag to retain a certain number of past versions of a file in a first in, first out fashion.
+   After retaining the maximum number of non-current versions, MinIO marks any remaining older non-current object versions as eligible for expiration.
+   
+   The following table lists a number of object versions and their expiration eligibility based on ``--noncurrent-expire-newer 3``:
+
+   .. list-table::
+      :widths: 50 50
+      :width: 100% 
+
+      * - v5 (current version)
+        - Current version not affected by ILM rules.
+      * - v4
+        - retained
+      * - v3
+        - retained
+      * - v2
+        - retained
+      * - v1
+        - marked for expiry
+
+   MinIO retains the current version, v5.
+   MinIO also retains the next ``3`` non-current versions, starting with the newest.
+   This means MinIO marks ``v4``, ``v3``, and ``v2`` for the three non-current version to retain.
+
+   ``v1`` would be a fourth non-current version, which falls outside the limit of non-current versions to retain, so MinIO marks ``v1`` for expiration.
+
+   Updating the number for this flag only impacts the unmarked versions of objects.
+   Any versions already marked for expiration do not change if you increase the number to retain.
+
+   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
+   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
+   See :ref:`minio-lifecycle-management-scanner` for more information.
+   
+.. mc-cmd:: --noncurrent-transition-newer
+   :optional:
+   
+   The maximum number of non-current object versions to retain on the current tier.
+   Older object versions beyond the number to retain transition to a different, specified tier.
+
+   Use this flag to keep a certain number of non-current versions of an object accessible on the tier in a first in, first out order.
+
+   If not specified, all non-current object versions transition to the different tier.
+
+   The following table lists a number of object versions and their transition eligibility based on ``--noncurrent-transition-newer 3``:
+
+   .. list-table::
+      :widths: 50 50
+      :width: 100% 
+
+      * - v5 (current version)
+        - Current version not affected by ILM rules.
+      * - v4
+        - kept on current tier
+      * - v3
+        - kept on current tier
+      * - v2
+        - kept on current tier
+      * - v1
+        - marked for transition to other tier
+
+   MinIO retains the current version, v5, on the tier.
+   MinIO also retains the next ``3`` non-current versions on the tier, starting with the newest.
+   This means MinIO leaves ``v4``, ``v3``, and ``v2`` for the three non-current version to keep on the current tier.
+
+   ``v1`` would be a fourth non-current version, which falls outside the limit of non-current versions to retain, so MinIO marks ``v1`` for transition.
+
+   Updating the number for this flag only impacts the unmarked versions of objects.
+   Any versions already marked for transition do not change if you increase the number, and any object versions already transitioned do not transition back to the tier.
+
+   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
+   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
+   See :ref:`minio-lifecycle-management-scanner` for more information.
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Expire All Bucket Contents After Number of Days
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc ilm add` with :mc-cmd:`~mc ilm add --expire-days` to mark bucket contents for expiration after a number of days pass from the object's creation:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm add ALIAS/PATH --expire-days "DAYS" 
+
+- Replace :mc-cmd:`ALIAS <mc ilm add ALIAS>` with the :mc:`alias <mc alias>` of the S3-compatible host.
+
+- Replace :mc-cmd:`PATH <mc ilm add ALIAS>` with the path to the bucket on the S3-compatible host.
+
+- Replace :mc-cmd:`DATE <mc ilm add --expire-days>` with the number of days after which to expire the object. 
+  For example, specify ``30`` to expire the object 30 days after creation.
+
+Transition Non-Current Object Versions at a Prefix to a Different Tier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc:`mc ilm add` with :mc-cmd:`~mc ilm add --prefix` and :mc-cmd:`~mc ilm add --transition-tier` to transition older non-current versions of an object to a different storage tier.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm add --prefix "doc/" --transition-days "90" --trasition-tier "MINIOTIER-1"                  \
+          --noncurrent-transition-days "45" --noncurrent-transition-tier "MINIOTIER-2"  \
+          myminio/mybucket/
+
+This command looks at the contents with the ``doc/`` prefix in the ``mybucket`` bucket on the ``myminio`` deployment.
+
+- Current objects in the prefix older than 90 days move to the ``MINIOTIER-1`` storage tier.
+- Non-current objects in the prefix older than 45 days move to the ``MINIOTIER-2`` storage tier.
+- Both ``MINIOTIER-1`` and ``MINIOTIER-2`` have already been created with :mc:`mc admin tier add`.
+
+Expire All Objects at a Prefix, Retain Current Object Versions Longer Than Non-Current Object Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc:`mc ilm add` command with :mc-cmd:`~mc ilm add --prefix`, :mc-cmd:`~mc ilm add --expire-days`, and :mc-cmd:`~mc ilm add --noncurrent-expire-days` to expire current and non-current versions of an object at different times.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm add --prefix "doc/" --expire-days "300" --noncurrent-expire-days "100" myminio/mybucket/
+
+This command looks at the contents with the ``doc/`` prefix in the ``mybucket`` bucket on the ``myminio`` deployment.
+
+- Current objects expire after 300 days.
+- Non-current objects expire after 100 days.
+
+Behavior
+--------
+
+Lifecycle Management Object Scanner
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MinIO uses a scanner process to check objects against all configured
+lifecycle management rules. Slow scanning due to high IO workloads or
+limited system resources may delay application of lifecycle management
+rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+Expiry vs Transition
+~~~~~~~~~~~~~~~~~~~~
+
+MinIO supports specifying both expiry and transition rules in the same
+bucket or bucket prefix. MinIO can execute an expiration rule on an object
+regardless of its transition status. Use
+:mc:`mc ilm ls` to review the currently configured object lifecycle
+management rules for any potential interactions between expiry and transition
+rules.
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/deprecated/mc-ilm-edit.rst
+++ b/source/reference/deprecated/mc-ilm-edit.rst
@@ -12,6 +12,11 @@
 
 .. mc:: mc ilm edit
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm edit`` replaced by :mc-cmd:`mc ilm rule edit`
+
+
 Syntax
 ------
 
@@ -86,7 +91,7 @@ Parameters
 .. mc-cmd:: --id
    :required:
 
-   The unique ID of the rule. Use :mc:`mc ilm ls` to list bucket
+   The unique ID of the rule. Use :mc:`mc ilm rule ls` to list bucket
    rules and retrieve the ``id`` for the rule you want to modify.
 
 .. mc-cmd:: --disable
@@ -295,7 +300,7 @@ an existing object expiration rule:
 
 - Replace ``RULEID`` with the unique ID of the object lifecycle management
   rule.
-  Use :mc:`mc ilm ls` to find the ``RULEID``.
+  Use :mc:`mc ilm rule ls` to find the ``RULEID``.
 
 - Specify any additional flags to add or modify the lifecycle management
   rule. For example, specify
@@ -313,7 +318,7 @@ Use :mc:`mc ilm edit` with :mc-cmd:`~mc ilm edit --disable` to stop using an exi
    mc ilm edit --id "RULEID" --disable myminio/mybucket
 
 - Replace ``RULEID`` with the unique ID of the object lifecycle management rule.
-  Use :mc:`mc ilm ls` to find the ``RULEID``.
+  Use :mc:`mc ilm rule ls` to find the ``RULEID``.
 - Replace ``myminio`` with the ALIAS of the deployment where the rule exists.
 - Replace ``mybucket`` with the bucket for the rule.
 

--- a/source/reference/deprecated/mc-ilm-export.rst
+++ b/source/reference/deprecated/mc-ilm-export.rst
@@ -1,0 +1,124 @@
+.. _minio-mc-ilm-export:
+
+=================
+``mc ilm export``
+=================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm export
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm export`` replaced by :mc-cmd:`mc ilm rule export`
+
+
+Syntax
+------
+
+.. start-mc-ilm-export-desc
+
+The :mc:`mc ilm export` command exports the object lifecycle management
+configuration for a MinIO bucket.
+
+.. end-mc-ilm-export-desc
+
+The :mc:`mc ilm export` command outputs to ``STDOUT`` by default. You can
+output the contents to a ``.json`` file for archival or ingestion using
+:mc:`mc ilm import`.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command exports the lifecycle management configuration
+      of the ``mydata`` bucket on the ``myminio`` deployment to the
+      ``mydata-lifecycle-config.json`` file:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm export myminio/mydata > mydata-lifecycle-config.json
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] ilm export ALIAS > STDOUT
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   
+   *Required* The :ref:`alias <alias>` and full path to the bucket on the MinIO
+   deployment for which to export object lifecycle management rules. For
+   example:
+
+   .. code-block:: none
+
+      mc ilm export myminio/mydata > bucket-lifecycle.json
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Export the Bucket Lifecycle Management Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tab-set::
+
+   .. tab-item:: Example
+
+      The following command exports the bucket lifecycle management
+      configuration to the ``bucket-lifecycle.json`` file:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm export myminio/mybucket > bucket-lifecycle.json
+
+   .. tab-item:: Syntax
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm export ALIAS > file.json
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO 
+        deployment and the bucket for which to export object lifecycle
+        management rules:
+
+        ``myminio/mydata``
+
+      - Replace ``file.json`` with the name of the file to which to export the
+        lifecycle management rules.
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/deprecated/mc-ilm-import.rst
+++ b/source/reference/deprecated/mc-ilm-import.rst
@@ -12,6 +12,11 @@
 
 .. mc:: mc ilm import
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm import`` replaced by :mc-cmd:`mc ilm rule import`
+
+
 Syntax
 ------
 

--- a/source/reference/deprecated/mc-ilm-ls.rst
+++ b/source/reference/deprecated/mc-ilm-ls.rst
@@ -12,6 +12,11 @@
 
 .. mc:: mc ilm ls
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm ls`` replaced by :mc-cmd:`mc ilm rule ls`
+
+
 Syntax
 ------
 

--- a/source/reference/deprecated/mc-ilm-rm.rst
+++ b/source/reference/deprecated/mc-ilm-rm.rst
@@ -12,6 +12,11 @@
 
 .. mc:: mc ilm rm
 
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm rm`` replaced by :mc-cmd:`mc ilm rule rm`
+
+
 Syntax
 ------
 
@@ -77,7 +82,7 @@ Parameters
 
 .. mc-cmd:: id
 
-   *Required* The unique ID of the rule. Use :mc:`mc ilm ls` to list bucket
+   *Required* The unique ID of the rule. Use :mc:`mc ilm rule ls` to list bucket
    rules and retrieve the ``id`` for the rule you want to remove.
 
    Mutually exclusive with :mc:`mc ilm rm all`

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -40,11 +40,6 @@ The following table lists :mc:`mc admin` commands:
           :start-after: start-mc-admin-bucket-remote-desc
           :end-before: end-mc-admin-bucket-remote-desc
 
-   * - :mc-cmd:`mc admin bucket quota`
-     - .. include:: /reference/minio-mc-admin/mc-admin-bucket-quota.rst
-          :start-after: start-mc-admin-bucket-quota-desc
-          :end-before: end-mc-admin-bucket-quota-desc
-
    * - :mc-cmd:`mc admin console`
      - .. include:: /reference/minio-mc-admin/mc-admin-console.rst
           :start-after: start-mc-admin-console-desc
@@ -129,11 +124,6 @@ The following table lists :mc:`mc admin` commands:
      - .. include:: /reference/minio-mc-admin/mc-admin-speedtest.rst
           :start-after: start-mc-admin-speedtest-desc
           :end-before: end-mc-admin-speedtest-desc
-
-   * - :mc:`mc admin tier`
-     - .. include:: /reference/minio-mc-admin/mc-admin-tier.rst
-          :start-after: start-mc-admin-tier-desc
-          :end-before: end-mc-admin-tier-desc
 
    * - :mc-cmd:`mc admin top`
      - .. include:: /reference/minio-mc-admin/mc-admin-top.rst

--- a/source/reference/minio-mc-admin/mc-admin-idp-ldap-policy.rst
+++ b/source/reference/minio-mc-admin/mc-admin-idp-ldap-policy.rst
@@ -31,11 +31,116 @@ The :mc-cmd:`mc admin idp ldap policy` command has the following subcommands:
    * - Subcommand
      - Description
 
+   * - :mc-cmd:`mc admin idp ldap policy attach`
+     - Attach a policy to an entity
+
+   * - :mc-cmd:`mc admin idp ldap policy detach`
+     - Detach a policy from an entity
+
    * - :mc-cmd:`mc admin idp ldap policy entities`
      - List policy entity mappings
 
 Syntax
 ------
+
+.. mc-cmd:: attach
+
+   Attach one or more polices to entity.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLES
+
+         The following example attaches two policies, ``policy1`` and ``policy2``, to the ``projectb`` group on the ``myminio`` deployment. 
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc admin idp ldap policy attach myminio/                                               \
+                                             policy1                                                \
+                                             policy2                                                \
+                                             --group='cn=projectb,ou=groups,ou=swengg,dc=min,dc=io'
+
+
+         The following example attaches the policy, ``userpolicy``, to the user ``bobfisher`` on the ``myminio`` deployment. 
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc admin idp ldap policy attach myminio/                                               \
+                                             mypolicy                                               \
+                                             policy2                                                \
+                                             --user='uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io'
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+ 
+            mc [GLOBALFLAGS] admin idp ldap policy attach     \
+                                            POLICYNAME        \
+                                            [POLICY2] ...     \
+                                            ALIAS             \
+                                            [--user=`USER`]   \
+                                            [--group=`GROUP`]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``POLICYNAME`` with the policy to attach to the entity.
+           You may list multiple policies to attach to the entity.
+         - Use must use one of either the ``--user`` or ``--group`` flag.
+           You may only use the flag once in the command.
+           You cannot use both flags in the same command.
+
+
+.. mc-cmd:: detach
+
+   Detach one or more policies from an entity.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLES
+
+         The following example detaches two policies, ``policy1`` and ``policy2``, from the ``projectb`` group on the ``myminio`` deployment. 
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc admin idp ldap policy detach myminio/                                               \
+                                             policy1                                                \
+                                             policy2                                                \
+                                             --group='cn=projectb,ou=groups,ou=swengg,dc=min,dc=io'
+
+
+         The following example detaches the policy, ``userpolicy``, from the user ``bobfisher`` on the ``myminio`` deployment. 
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc admin idp ldap policy detach myminio/                                               \
+                                             mypolicy                                               \
+                                             policy2                                                \
+                                             --user='uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io'
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+ 
+            mc [GLOBALFLAGS] admin idp ldap policy detach     \
+                                            POLICYNAME        \
+                                            [POLICY2] ...     \
+                                            ALIAS             \
+                                            [--user=`USER`]   \
+                                            [--group=`GROUP`]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``POLICYNAME`` with the policy to detach from the entity.
+           You may list multiple policies to detach from the entity.
+         - Use must use one of either the ``--user`` or ``--group`` flag.
+           You may only use the flag once in the command.
+           You cannot use both flags in the same command.
 
 .. mc-cmd:: entities
 

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -66,6 +66,31 @@ Use :mc-cmd:`mc admin trace` to monitor activity for a specific path:
 - Replace :mc-cmd:`ALIAS <mc admin trace TARGET>` with the :mc-cmd:`alias <mc alias>` of the MinIO deployment.
 - Replace ``my-bucket/my-prefix/*`` with the bucket, prefix, and object name or wildcard you wish to trace.
 
+See Console Trace for a Response Size Greater than 1Mb
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc-cmd:`mc admin trace` to monitor responses over a specific size:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin trace --filter-response --filter-size 1Mb ALIAS
+
+- Replace :mc-cmd:`ALIAS <mc admin trace TARGET>` with the :mc-cmd:`alias <mc alias>` of the MinIO deployment.
+- Replace ``1Mb`` with the desired response size.
+
+See Console Trace for a Request Operation Durations Greater than 5ms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc-cmd:`mc admin trace` to monitor long operations:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin trace --filter-duration --filter-size 5ms ALIAS
+
+- Replace :mc-cmd:`ALIAS <mc admin trace TARGET>` with the :mc-cmd:`alias <mc alias>` of the MinIO deployment.
+
 Syntax
 ------
 
@@ -97,47 +122,117 @@ Syntax
 
    Valid call types include:
 
-   - ``s3``
-   - ``internal``
-   - ``storage``
-   - ``os``
-   - ``scanner``
+   - ``batch-replication``
    - ``decommission``
    - ``healing``
+   - ``internal``
+   - ``os``
+   - ``rebalance``
+   - ``replication-resync``
+   - ``s3``
+   - ``storage``
 
-.. mc-cmd:: --verbose
-   
-   Returns verbose output.
+   If not specified, MinIO returns call types of ``s3``.
 
 .. mc-cmd:: --errors, e
    
    Returns failed API operations only.
+
+.. mc-cmd:: --filter-request
+
+   Trace calls with request size greater than the specified :mc-cmd:`~mc admin trace --filter-size` value.
+
+   Must be used with :mc-cmd:`~mc admin trace --filter-size` flag.
+
+.. mc-cmd:: --filter-response
+
+   Trace calls with response size greater than the specified :mc-cmd:`~mc admin trace --filter-size` value.
+
+   Must be used with :mc-cmd:`~mc admin trace --filter-size` flag.
+
+.. mc-cmd:: --filter-size
+
+   Size limit of a filtered call.
+
+   Must be used with either :mc-cmd:`~mc admin trace --filter-request` or :mc-cmd:`~mc admin trace --filter-response` flag.
+
+   Valid units include:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 80
+      :width: 100%
+   
+      * - Suffix
+        - Unit Size
+   
+      * - ``k``
+        - KB (Kilobyte, 1000 Bytes)
+   
+      * - ``m``
+        - MB (Megabyte, 1000 Kilobytes)
+   
+      * - ``g``
+        - GB (Gigabyte, 1000 Megabytes)
+   
+      * - ``t``
+        - TB (Terrabyte, 1000 Gigabytes)
+   
+      * - ``ki``
+        - KiB (Kibibyte, 1024 Bites)
+   
+      * - ``mi``
+        - MiB (Mebibyte, 1024 Kibibytes)
+   
+      * - ``gi``
+        - GiB (Gibibyte, 1024 Mebibytes)
+   
+      * - ``ti``
+        - TiB (Tebibyte, 1024 Gibibytes)
+
+.. mc-cmd:: --funcname
+
+   Returns calls for the entered function name.
+
+.. mc-cmd:: --method
+
+   Returns call of the specified HTTP method.
+
+.. mc-cmd:: --node
+
+   Returns calls for the specified server.
+
+.. mc-cmd:: --path
+
+   Returns calls for the specified path.
+
+.. mc-cmd:: --request-header
+
+   Returns calls matching the supplied request header.
+
+.. mc-cmd:: --response-duration
+
+   Trace calls with response duration greater than the specified value.
 
 .. mc-cmd:: --response-threshold
 
    Takes a time string as a value, such as ``5ms``.
    Returns only calls with a response time greater than the supplied threshold.
 
+   If not specified, MinIO returns calls with a response time greater than 5ms.
+
 .. mc-cmd:: --status-code
 
    Returns calls of the specified HTTP status code.
 
-.. mc-cmd:: --method
+.. mc-cmd:: --verbose
+   
+   Returns verbose output.
 
-   Returns call of the specified HTTP method.
 
-.. mc-cmd:: --funcname
+Global Flags
+~~~~~~~~~~~~
 
-   Returns calls for the entered function name.
-
-.. mc-cmd:: --path
-
-   Returns calls for the specified path.
-
-.. mc-cmd:: --node
-
-   Returns calls for the specified server.
-
-.. mc-cmd:: --request-header
-
-   Returns calls matching the supplied request header.
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc-admin/mc-admin-update.rst
+++ b/source/reference/minio-mc-admin/mc-admin-update.rst
@@ -15,9 +15,8 @@ Description
 
 .. start-mc-admin-update-desc
 
-The :mc-cmd:`mc admin update` command updates all MinIO servers in the
-deployment. The command also supports using a private mirror server for
-environments where the deployment does not have public internet access.
+The :mc-cmd:`mc admin update` command updates all MinIO servers in the deployment. 
+The command also supports using a private mirror server for environments where the deployment does not have public internet access.
 
 .. end-mc-admin-update-desc
 
@@ -35,27 +34,25 @@ Considerations
 Updates are Non-Disruptive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:mc-cmd:`mc admin update` updates the binary and restarts all MinIO servers in
-the deployment simultaneously. MinIO operations are atomic and strictly
-consistent and as such the restart process is non-disruptive to applications.
+:mc-cmd:`mc admin update` updates the binary and restarts all MinIO servers in the deployment simultaneously. 
+MinIO operations are atomic and strictly consistent and as such the restart process is non-disruptive to applications.
 
-MinIO strongly recommends only performing simultaneous upgrade-and-restart
-procedures. Do not perform "rolling" (e.g one node at a time) upgrade 
-procedures.
+MinIO strongly recommends only performing simultaneous upgrade-and-restart procedures. 
+Do not perform "rolling" (that is, one node at a time) upgrade procedures.
 
 Examples
 --------
 
-Use :mc-cmd:`mc admin update` to update each :mc:`minio` server process in the
-MinIO deployment:
+Use :mc-cmd:`mc admin update` to update each :mc:`minio` server process in the MinIO deployment:
 
 .. code-block:: shell
    :class: copyable
 
    mc admin update ALIAS
 
-Replace :mc-cmd:`ALIAS <mc admin update ALIAS>` with the 
-:mc-cmd:`alias <mc alias>` of the MinIO deployment.
+Replace :mc-cmd:`ALIAS <mc admin update ALIAS>` with the :mc-cmd:`alias <mc alias>` of the MinIO deployment.
+
+After running the command, answer yes to the prompt to confirm and process the update.
 
 Syntax
 ------
@@ -73,15 +70,11 @@ Syntax
 
    The :mc-cmd:`alias <mc alias>` of the MinIO deployment to update. 
 
-   If the specified ``ALIAS`` corresponds to a distributed MinIO
-   deployment, :mc-cmd:`mc admin update` updates *all* MinIO servers
-   in the deployment at the same time. 
+   If the specified ``ALIAS`` corresponds to a distributed MinIO deployment, :mc-cmd:`mc admin update` updates *all* MinIO servers in the deployment at the same time. 
 
-   Use :mc:`mc alias list` to review the configured aliases and their
-   corresponding MinIO deployment endpoints.
+   Use :mc:`mc alias list` to review the configured aliases and their corresponding MinIO deployment endpoints.
 
 .. mc-cmd:: MIRROR_URL
    
-   The mirror URL of the ``minio`` server binary to use for updating MinIO
-   servers in the :mc-cmd:`~mc admin update ALIAS` deployment.
+   The mirror URL of the ``minio`` server binary to use for updating MinIO servers in the :mc-cmd:`~mc admin update ALIAS` deployment.
 

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -1,0 +1,112 @@
+===================
+Deprecated Commands
+===================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+The following table lists the commands deprecated by MinIO.
+The table includes:
+
+- Deprecated Command
+- Replacement command (if applicable)
+- Version of deprecation
+
+Table of Deprecated Commands
+----------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+   :width: 100%
+
+   * - Deprecated Command
+     - Replacement Command
+     - Version of Change
+
+   * - ``mc ilm add``
+     - :mc-cmd:`mc ilm rule add`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc ilm edit``
+     - :mc-cmd:`mc ilm rule edit`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc ilm export``
+     - :mc-cmd:`mc ilm rule export`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc ilm import``
+     - :mc-cmd:`mc ilm rule import`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc ilm ls``
+     - :mc-cmd:`mc ilm rule ls`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc ilm rm``
+     - :mc-cmd:`mc ilm rule rm`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+
+Table of Deprecated Admin Commands
+----------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+   :width: 100%
+
+   * - Deprecated Command
+     - Replacement Command
+     - Version of Change
+
+   * - ``mc admin tier add``
+     - :mc-cmd:`mc ilm tier add`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin tier edit``
+     - :mc-cmd:`mc ilm tier update`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin tier ls``
+     - :mc-cmd:`mc ilm tier ls`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket remote add``
+     - :mc-cmd:`mc replicate add`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket remote rm``
+     - :mc-cmd:`mc replicate rm`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket remote ls``
+     - :mc-cmd:`mc replicate ls`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket remote update``
+     - :mc-cmd:`mc replicate update`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket quota``
+     - :mc-cmd:`mc quota clear`, :mc-cmd:`mc quota info`, :mc-cmd:`mc quota set`
+     - mc RELEASE.2022-12-13T00-23-28Z
+
+
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/deprecated/mc-ilm-add
+   /reference/deprecated/mc-ilm-edit
+   /reference/deprecated/mc-ilm-export
+   /reference/deprecated/mc-ilm-import
+   /reference/deprecated/mc-ilm-ls
+   /reference/deprecated/mc-ilm-rm
+   /reference/deprecated/mc-admin-tier
+   /reference/deprecated/mc-admin-bucket-quota

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -227,18 +227,12 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-head-desc
           :end-before: end-mc-head-desc
      
-   * - | :mc:`mc ilm add`
-       | :mc:`mc ilm ls`
-       | :mc:`mc ilm edit`
-       | :mc:`mc ilm rm`
-       | :mc:`mc ilm export`
-       | :mc:`mc ilm import`
-     - The ``mc ilm`` command supports managing
-       :ref:`object lifecycle management rules <minio-lifecycle-management>`
-       on a MinIO deployment. 
+   * - | :mc:`mc ilm tier`
+       | :mc:`mc ilm rule`
+       | :mc:`mc ilm restore`
+     - The ``mc ilm`` commands manage :ref:`object lifecycle management rules <minio-lifecycle-management>` on a MinIO deployment. 
 
-       Use this command to set both :ref:`minio-lifecycle-management-tiering` 
-       and :ref:`minio-lifecycle-management-expiration` rules on a bucket.
+       Use these command to create tiers, create :ref:`tiering <minio-lifecycle-management-tiering>` rules, and manage :ref:`expiration <minio-lifecycle-management-expiration>` rules for objects on a bucket.
      
    * - | :mc:`mc legalhold set`
        | :mc:`mc legalhold info`
@@ -283,6 +277,13 @@ The following table lists :mc-cmd:`mc` commands:
      - .. include:: /reference/minio-mc/mc-pipe.rst
           :start-after: start-mc-pipe-desc
           :end-before: end-mc-pipe-desc  
+
+   * - | :mc:`mc quota set`
+       | :mc:`mc quota info`
+       | :mc:`mc quota clear`
+
+     - The ``mc quota`` commands configure, display, or remove a hard quota limit on a bucket. 
+       When a bucket with a quota configured reaches the specified limit, MinIO rejects further ``PUT`` requests for the bucket. 
      
    * - :mc:`mc rb`
      - .. include:: /reference/minio-mc/mc-rb.rst
@@ -449,6 +450,52 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
 
       mc --JSON ls play 
 
+.. mc-cmd:: --limit-download
+   :optional:
+
+   Limit client-side download rates to no more than a specified rate in KiB/s, MiB/s, or GiB/s.
+   This affects only the download to the local device running the MinIO Client.
+   Valid units include: 
+   
+   - ``B`` for bytes
+   - ``K`` for kilobytes
+   - ``G`` for gigabytes
+   - ``T`` for terabytes
+   - ``Ki`` for kibibytes
+   - ``Gi`` for gibibytes
+   - ``Ti`` for tebibytes
+
+   For example, to limit download rates to no more than 1 GiB/s, use the following:
+
+   .. code-block::
+
+      --limit-download 1G
+
+   If not specified, MinIO uses an unlimited download rate.
+
+.. mc-cmd:: --limit-upload
+   :optional:
+
+   Limit client-side upload rates to no more than the specified rate in KiB/s, MiB/s, or GiB/s.
+   This affects only the upload from the local device running the MinIO Client.
+   Valid units include: 
+   
+   - ``B`` for bytes
+   - ``K`` for kilobytes
+   - ``G`` for gigabytes
+   - ``T`` for terabytes
+   - ``Ki`` for kibibytes
+   - ``Gi`` for gibibytes
+   - ``Ti`` for tebibytes
+
+   For example, to limit upload rates to no more than 1 GiB/s, use the following:
+
+   .. code-block::
+
+      --limit-upload 1G
+
+   If not specified, MinIO uses an unlimited upload rate.
+
 .. option:: --no-color
 
    Disables the built-in color theme for console output. Useful for dumb
@@ -502,13 +549,9 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-event-remove
    /reference/minio-mc/mc-find
    /reference/minio-mc/mc-head
-   /reference/minio-mc/mc-ilm-add
-   /reference/minio-mc/mc-ilm-edit
-   /reference/minio-mc/mc-ilm-ls
    /reference/minio-mc/mc-ilm-restore
-   /reference/minio-mc/mc-ilm-rm
-   /reference/minio-mc/mc-ilm-export
-   /reference/minio-mc/mc-ilm-import
+   /reference/minio-mc/mc-ilm-rule
+   /reference/minio-mc/mc-ilm-tier
    /reference/minio-mc/mc-legalhold-set
    /reference/minio-mc/mc-legalhold-info
    /reference/minio-mc/mc-legalhold-clear
@@ -522,6 +565,9 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-mv
    /reference/minio-mc/mc-od
    /reference/minio-mc/mc-pipe
+   /reference/minio-mc/mc-quota-clear
+   /reference/minio-mc/mc-quota-info
+   /reference/minio-mc/mc-quota-set
    /reference/minio-mc/mc-rb
    /reference/minio-mc/mc-replicate-add
    /reference/minio-mc/mc-replicate-diff
@@ -556,3 +602,4 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-update
    /reference/minio-mc/mc-version
    /reference/minio-mc/mc-watch
+   /reference/minio-mc-deprecated

--- a/source/reference/minio-mc/mc-cp.rst
+++ b/source/reference/minio-mc/mc-cp.rst
@@ -71,6 +71,7 @@ similar results to the ``cp`` commandline tool.
                           [--storage-class "string"]                                \
                           [--tags "string"]                                         \
                           [--version-id "string"]                                   \
+                          [--zip]                                                   \
                           SOURCE [SOURCE ...]                                       \
                           TARGET
 
@@ -82,41 +83,39 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: SOURCE
+   :required:
 
-   *Required* The object or objects to copy. 
+   The object or objects to copy. 
 
-   For copying an object from MinIO,
-   specify the :ref:`alias <alias>` and the full path to that 
-   object (e.g. bucket and path to object). For example:
+   For copying an object from MinIO, specify the :ref:`alias <alias>` and the full path to that object (e.g. bucket and path to object). 
+   For example:
 
    .. code-block:: none
 
       mc cp play/mybucket/object.txt ~/mydata/object.txt
 
-   Specify multiple ``SOURCE`` paths to copy multiple objects to the 
-   specified :mc-cmd:`~mc cp TARGET`. :mc:`mc cp` treats the 
-   *last* specified alias or filesystem path as the ``TARGET``. For example:
+   Specify multiple ``SOURCE`` paths to copy multiple objects to the specified :mc-cmd:`~mc cp TARGET`. 
+   :mc:`mc cp` treats the *last* specified alias or filesystem path as the ``TARGET``. 
+   For example:
 
    .. code-block:: none
 
       mc cp ~/data/object.txt myminio/mydata/object.txt play/mydata/object.txt
 
-   For copying an object from a local filesystem, specify the full
-   path to that object. For example:
+   For copying an object from a local filesystem, specify the full path to that object. 
+   For example:
 
    .. code-block:: none
 
       mc cp ~/mydata/object.txt play/mybucket/object.txt
    
-   If you specify a directory or bucket to :mc-cmd:`~mc cp SOURCE`, you must
-   also specify :mc-cmd:`~mc cp --recursive` to recursively copy the
-   contents of that directory or bucket. If you omit the ``--recursive``
-   argument, :mc:`~mc cp` only copies objects in the top level of the specified
-   directory or bucket.
+   If you specify a directory or bucket to :mc-cmd:`~mc cp SOURCE`, you must also specify :mc-cmd:`~mc cp --recursive` to recursively copy the contents of that directory or bucket. 
+   If you omit the ``--recursive`` argument, :mc:`~mc cp` only copies objects in the top level of the specified directory or bucket.
 
 .. mc-cmd:: TARGET
+   :required:
 
-   *Required* The full path to which :mc:`mc cp` copies the object.
+   The full path to which :mc:`mc cp` copies the object.
 
    For copying an object to MinIO,
    specify the :mc:`alias <mc alias>` and the full path to that object
@@ -135,45 +134,40 @@ Parameters
       mc cp play/mybucket/object.txt ~/mydata/object.txt
 
 .. mc-cmd:: --attr
-   
+   :optional:
 
-   *Optional* Add custom metadata for the object. Specify key-value pairs as
-   ``KEY=VALUE\;``. For example, ``--attr
-   key1=value1\;key2=value2\;key3=value3``.
+   Add custom metadata for the object. 
+   Specify key-value pairs as ``KEY=VALUE\;``. 
+   For example, ``--attr key1=value1\;key2=value2\;key3=value3``.
 
 .. mc-cmd:: --continue, c
-   
+   :optional:
 
-   *Optional* Create or resume a copy session. 
+   Create or resume a copy session. 
 
 .. mc-cmd:: --disable-multipart
-   
+   :optional:
 
-   *Optional* Disables multipart upload for the copy session.
+   Disables multipart upload for the copy session.
 
 .. mc-cmd:: --encrypt
-   
+   :optional:
 
-   *Optional* Encrypt or decrypt objects using 
-   :ref:`server-side encryption <minio-sse>` with
-   server-managed keys. Specify key-value pairs as ``KEY=VALUE``.
+   Encrypt or decrypt objects using :ref:`server-side encryption <minio-sse>` with server-managed keys. 
+   Specify key-value pairs as ``KEY=VALUE``.
    
    - Each ``KEY`` represents a bucket or object. 
-   - Each ``VALUE`` represents the data key to use for encrypting 
-      object(s).
+   - Each ``VALUE`` represents the data key to use for encrypting object(s).
 
-   Enclose the entire list of key-value pairs passed to
-   :mc-cmd:`~mc cp --encrypt` in double-quotes ``"``.
+   Enclose the entire list of key-value pairs passed to :mc-cmd:`~mc cp --encrypt` in double-quotes ``"``.
 
-   :mc-cmd:`~mc cp --encrypt` can use the ``MC_ENCRYPT`` environment
-   variable for retrieving a list of encryption key-value pairs as an
-   alternative to specifying them on the command line.
+   :mc-cmd:`~mc cp --encrypt` can use the ``MC_ENCRYPT`` environment variable for retrieving a list of encryption key-value pairs as an alternative to specifying them on the command line.
 
 .. mc-cmd:: --encrypt-key
-   
+   :optional:
 
-   *Optional* Encrypt or decrypt objects using server-side encryption with
-   client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
+   Encrypt or decrypt objects using server-side encryption with client-specified keys. 
+   Specify key-value pairs as ``KEY=VALUE``.
    
    - Each ``KEY`` represents a bucket or object. 
    - Each ``VALUE`` represents the data key to use for encrypting 
@@ -187,64 +181,60 @@ Parameters
    as an alternative to specifying them on the command line.
 
 .. mc-cmd:: --legal-hold
-   
+   :optional:
 
-   *Optional* Enables indefinite :ref:`Legal Hold 
-   <minio-object-locking-legalhold>` object locking on the copied objects.
+   Enables indefinite :ref:`Legal Hold <minio-object-locking-legalhold>` object locking on the copied objects.
 
    Specify ``on``.
 
-.. mc-cmd:: md5
-   
+.. mc-cmd:: --md5
+   :optional:
 
-   *Optional* Forces all uploads to calculate MD5 checksums. 
+   Forces all uploads to calculate MD5 checksums. 
 
 .. mc-cmd:: --newer-than
-   
+   :optional:
 
-   *Optional* Remove object(s) newer than the specified number of days.  Specify
-   a string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``
+   Remove object(s) newer than the specified number of days.  
+   Specify a string in ``#d#hh#mm#ss`` format. 
+   For example: ``--older-than 1d2hh3mm4ss``
 
    Defaults to ``0`` (all objects).
 
 .. mc-cmd:: --older-than
-   
+   :optional:
 
-   *Optional* Remove object(s) older than the specified time limit. Specify a
-   string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``
+   Remove object(s) older than the specified time limit. 
+   Specify a string in ``#d#hh#mm#ss`` format. 
+   For example: ``--older-than 1d2hh3mm4ss``
       
    Defaults to ``0`` (all objects).
 
 .. mc-cmd:: --preserve, a
-   
+   :optional:
 
-   *Optional* Preserve file system attributes and bucket policy rules of the
-   :mc-cmd:`~mc cp SOURCE` directories, buckets, and objects on the 
-   :mc-cmd:`~mc cp TARGET` bucket(s).
+   Preserve file system attributes and bucket policy rules of the :mc-cmd:`~mc cp SOURCE` directories, buckets, and objects on the :mc-cmd:`~mc cp TARGET` bucket(s).
 
 
 .. mc-cmd:: --recursive, r
+   :optional:
    
-   
-   *Optional* Recursively copy the contents of each bucket or directory
-   :mc-cmd:`~mc cp SOURCE` to the :mc-cmd:`~mc cp TARGET` bucket.
+   Recursively copy the contents of each bucket or directory :mc-cmd:`~mc cp SOURCE` to the :mc-cmd:`~mc cp TARGET` bucket.
 
 .. mc-cmd:: --retention-duration
-   
+   :optional:
 
-   *Optional* The duration of the :ref:`WORM retention mode 
-   <minio-object-locking-retention-modes>` to apply to the copied object(s).
+   The duration of the :ref:`WORM retention mode <minio-object-locking-retention-modes>` to apply to the copied object(s).
 
-   Specify the duration as a string in
-   ``#d#hh#mm#ss`` format. For example: ``--retention-duration "1d2hh3mm4ss"``.
+   Specify the duration as a string in ``#d#hh#mm#ss`` format. 
+   For example: ``--retention-duration "1d2hh3mm4ss"``.
 
    Requires specifying :mc-cmd:`~mc cp --retention-mode`.
 
 .. mc-cmd:: --retention-mode
-   
+   :optional:
 
-   *Optional* enables :ref:`object locking mode
-   <minio-object-locking-retention-modes>` on the copied object(s).
+   Enables :ref:`object locking mode <minio-object-locking-retention-modes>` on the copied object(s).
    Supports the following values:
 
    - ``GOVERNANCE``
@@ -260,18 +250,17 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: storage-class, sc
-   
+   :optional:
 
-   *Optional* Set the storage class for the new object(s) on the 
-   :mc-cmd:`~mc cp TARGET`. 
+   Set the storage class for the new object(s) on the :mc-cmd:`~mc cp TARGET`. 
          
    See :aws-docs:`AmazonS3/latest/dev/storage-class-intro.html` for
    more information on S3 storage classes.
 
 .. mc-cmd:: --tags
-   
+   :optional:
 
-   *Optional* Applies one or more tags to the copied objects.
+   Applies one or more tags to the copied objects.
 
    Specify an ampersand-separated list of key-value pairs as 
    ``KEY1=VALUE1&KEY2=VALUE2``, where each pair represents one tag to
@@ -283,6 +272,12 @@ Parameters
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
       :end-before: end-version-id-desc
+
+.. mc-cmd:: --zip
+   :optional:
+
+   During copy, extract files from a `.zip` archive.
+   Only functional when the source archive file exists on a MinIO deployment.
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-find.rst
+++ b/source/reference/minio-mc/mc-find.rst
@@ -53,6 +53,7 @@ deployment. You can also use the command to search for files on a filesystem.
                           [--print "string"]      \
                           [--regex "string"]      \
                           [--smaller "string"]    \
+                          [--versions]            \
                           [--watch]               \
                           ALIAS
 
@@ -65,19 +66,17 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
-
-   *Required* 
+   :required:
    
-   For objects on  MinIO or an S3-compatible host, specify the  
-   :ref:`alias <alias>` and the full path to search
-   (e.g. bucket and prefixes). For example:
+   For objects on  MinIO or an S3-compatible host, specify the :ref:`alias <alias>` and the full path to search (e.g. bucket and prefixes). 
+   For example:
 
    .. code-block:: none
 
       mc find play/mydata/
 
-   For objects on a filesyste, specify the full path to search. For 
-   example:
+   For objects on a filesyste, specify the full path to search. 
+   For example:
 
    .. code-block:: shell
 
@@ -87,76 +86,79 @@ Parameters
    *all* objects or files at the specified path, similar to :mc:`mc ls`.
 
 .. mc-cmd:: --exec
+   :optional:
    
-   
-   *Optional* Spawns an external process for each object returned by 
-   :mc:`mc find`. Supports :ref:`substitution formatting
-   <mc-find-substitution-format>` of the output.
+   Spawns an external process for each object returned by :mc:`mc find`. 
+   Supports :ref:`substitution formatting <mc-find-substitution-format>` of the output.
 
 .. mc-cmd:: --ignore
-   
+   :optional:
 
-   *Optional* Exclude objects whose names match the specified wildcard pattern.
-
+   Exclude objects whose names match the specified wildcard pattern.
 
 .. mc-cmd:: --larger
-   
+   :optional:
 
-   *Optional* Match all objects larger than the specified size in 
-   :ref:`units <mc-find-units>`.
+   Match all objects larger than the specified size in :ref:`units <mc-find-units>`.
 
 .. mc-cmd:: --maxdepth
-   
+   :optional:
 
-   *Optional* Limits directory navigation to the specified depth.
+   Limits directory navigation to the specified depth.
 
 .. mc-cmd:: --name
-   
+   :optional:
 
-   *Optional* Return objects whose names match the specified wildcard pattern.
+   Return objects whose names match the specified wildcard pattern.
 
 .. mc-cmd:: --newer-than
-   
+   :optional:
 
-   *Optional* Mirror object(s) newer than the specified number of days.  Specify
-   a string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``
+   Mirror object(s) newer than the specified number of days.  
+   Specify a string in ``#d#hh#mm#ss`` format. 
+   For example: ``--older-than 1d2hh3mm4ss``
 
 .. mc-cmd:: --older-than
-   
+   :optional:
 
-   *Optional* Mirror object(s) older than the specified time limit. Specify a
-   string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``
+   Mirror object(s) older than the specified time limit. Specify a
+   string in ``#d#hh#mm#ss`` format. 
+   For example: ``--older-than 1d2hh3mm4ss``
       
    Defaults to ``0`` (all objects).
 
 .. mc-cmd:: --path
-   
+   :optional:
 
-   *Optional* Return the contents of directories whose names match the specified
-   wildcard pattern.
+   Return the contents of directories whose names match the specified wildcard pattern.
 
 .. mc-cmd:: --print
-   
+   :optional:
 
-   *Optional* Prints results to ``STDOUT``.  Supports 
-   :ref:`substitution formatting <mc-find-substitution-format>` of the output.
+   Prints results to ``STDOUT``.  
+   Supports :ref:`substitution formatting <mc-find-substitution-format>` of the output.
 
 .. mc-cmd:: --regex
-   
+   :optional:
 
-   *Optional* Returns objects or the contents of directories whose names match
+   Returns objects or the contents of directories whose names match
    the specified PCRE regex pattern.
 
 .. mc-cmd:: --smaller
-   
+   :optional:
 
-   *Optional* Match all objects smaller than the specifized size in 
+   Match all objects smaller than the specifized size in 
    :ref:`units <mc-find-units>`.
 
-.. mc-cmd:: --watch
-   
+.. mc-cmd:: --versions
+   :optional:
 
-   *Optional* Continuously monitor the :mc-cmd:`~mc find ALIAS` and return any
+   Include all object versions in the results.
+
+.. mc-cmd:: --watch
+   :optional:
+
+   Continuously monitor the :mc-cmd:`~mc find ALIAS` and return any
    new objects which match the specified criteria.
 
 Global Flags

--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -1,8 +1,8 @@
-.. _minio-mc-ilm-add:
+.. _minio-mc-ilm-rule-add:
 
-==============
-``mc ilm add``
-==============
+===================
+``mc ilm rule add``
+===================
 
 .. default-domain:: minio
 
@@ -10,16 +10,21 @@
    :local:
    :depth: 2
 
-.. mc:: mc ilm add
+.. mc:: mc ilm rule add
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm rule rm`` replaces ``mc ilm add``.
+
 
 Syntax
 ------
 
-.. start-mc-ilm-add-desc
+.. start-mc-ilm-rule-add-desc
 
-The :mc:`mc ilm add` command adds an object lifecycle management rule to a bucket.
+The :mc:`mc ilm rule add` command adds an object lifecycle management rule to a bucket.
 
-.. end-mc-ilm-add-desc
+.. end-mc-ilm-rule-add-desc
 
 The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-management-tiering>` and :ref:`Expiration <minio-lifecycle-management-expiration>` lifecycle management rules.
 
@@ -32,13 +37,13 @@ The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-man
       .. code-block:: shell
          :class: copyable
 
-         mc ilm add --expire-days 90 --noncurrent-expire-days 30  mydata/myminio
+         mc ilm rule add --expire-days 90 --noncurrent-expire-days 30  mydata/myminio
          
-         mc ilm add --expire-delete-marker mydata/myminio
+         mc ilm rule add --expire-delete-marker mydata/myminio
 
-         mc ilm add --transition-days 30 --transition-tier "COLDTIER" mydata/myminio
+         mc ilm rule add --transition-days 30 --transition-tier "COLDTIER" mydata/myminio
          
-         mc ilm add --noncurrent-transition-days 7 --noncurrent-transition-tier "COLDTIER" 
+         mc ilm rule add --noncurrent-transition-days 7 --noncurrent-transition-tier "COLDTIER" 
 
       The configured rules have the following effect:
 
@@ -55,10 +60,10 @@ The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-man
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] ilm add                                    \
+         mc [GLOBALFLAGS] ilm rule add                               \
                           [--prefix string]                          \
                           [--tags string]                            \
-                          --expire-days "integer"                    \
+                          [--expire-days "integer"]                  \
                           [--expire-delete-marker]                   \
                           [--transition-days "string"]               \
                           [--transition-tier "string"]               \
@@ -85,7 +90,7 @@ Parameters
 
    .. code-block:: none
 
-      mc ilm add myminio/mydata
+      mc ilm rule add myminio/mydata
 
 .. mc-cmd:: --prefix
    :optional:
@@ -96,7 +101,7 @@ Parameters
 
    .. code-block:: none
 
-      mc ilm add --prefix "meetingnotes/" myminio/mydata/ --expire-days "90"
+      mc ilm rule add --prefix "meetingnotes/" myminio/mydata/ --expire-days "90"
 
    The command creates a rule that expires objects in the ``mydata`` bucket of the ``myminio`` ALIAS after 90 days for any object with the ``meetingnotes/`` prefix.
 
@@ -107,7 +112,7 @@ Parameters
 
    This option is mutually exclusive with the following option:
 
-   - :mc-cmd:`~mc ilm add --expire-delete-marker`
+   - :mc-cmd:`~mc ilm rule add --expire-delete-marker`
 
 .. mc-cmd:: --expire-days
    :required:   
@@ -117,7 +122,7 @@ Parameters
    Specify the number of days as an integer, e.g. ``30`` for 30 days.
 
    For versioned buckets, the expiry rule applies only to the *current* object version. 
-   Use the :mc-cmd:`~mc ilm add --noncurrent-expire-days` option to apply expiration behavior to noncurrent object versions.
+   Use the :mc-cmd:`~mc ilm rule add --noncurrent-expire-days` option to apply expiration behavior to noncurrent object versions.
 
    MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
    Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
@@ -125,7 +130,7 @@ Parameters
 
    Mutually exclusive with the following options:
 
-   - :mc-cmd:`~mc ilm add --expire-delete-marker`
+   - :mc-cmd:`~mc ilm rule add --expire-delete-marker`
 
    For more complete documentation on object expiration, see :ref:`minio-lifecycle-management-expiration`.
 
@@ -137,8 +142,8 @@ Parameters
 
    This option is mutually exclusive with the following option:
    
-   - :mc-cmd:`~mc ilm add --tags`
-   - :mc-cmd:`~mc ilm add --expire-days`
+   - :mc-cmd:`~mc ilm rule add --tags`
+   - :mc-cmd:`~mc ilm rule add --expire-days`
 
    MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
    Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
@@ -151,13 +156,13 @@ Parameters
    :optional:
    
    The number of calendar days from object creation after which MinIO marks an object as eligible for transition. 
-   MinIO transitions the object to the configured remote tier specified to the :mc-cmd:`~mc ilm add --transition-tier`. 
+   MinIO transitions the object to the configured remote tier specified to the :mc-cmd:`~mc ilm rule add --transition-tier`. 
    Specify the number of days as an integer, e.g. ``30`` for 30 days.
 
    For versioned buckets, the transition rule applies only to the *current* object version. 
-   Use the :mc-cmd:`~mc ilm add --noncurrent-transition-days` option to apply transition behavior to noncurrent object versions.
+   Use the :mc-cmd:`~mc ilm rule add --noncurrent-transition-days` option to apply transition behavior to noncurrent object versions.
 
-   Requires specifying :mc-cmd:`~mc ilm add --transition-tier`.
+   Requires specifying :mc-cmd:`~mc ilm rule add --transition-tier`.
 
    MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
    Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
@@ -169,9 +174,9 @@ Parameters
    :optional:
 
    The remote tier to which MinIO :ref:`transition objects <minio-lifecycle-management-tiering>`.
-   Specify an existing remote tier created by :mc:`mc admin tier`. 
+   Specify an existing remote tier created by :mc:`mc ilm tier add`. 
 
-   Required if specifying :mc-cmd:`~mc ilm add --transition-days`.
+   Required if specifying :mc-cmd:`~mc ilm rule add --transition-days`.
 
 .. mc-cmd:: --noncurrent-expire-days
    :optional:
@@ -189,10 +194,10 @@ Parameters
    :optional:
 
    The number of days an object has been non-current (i.e. replaced by a newer version of that same object) after which MinIO marks the object version as eligible for transition. 
-   MinIO transitions the object to the configured remote tier specified to the :mc-cmd:`~mc ilm add --transition-tier` once the system host datetime passes that calendar date.
+   MinIO transitions the object to the configured remote tier specified to the :mc-cmd:`~mc ilm rule add --transition-tier` once the system host datetime passes that calendar date.
 
    This option has no effect on non-versioned buckets. 
-   Requires specifying :mc-cmd:`~mc ilm add --noncurrent-transition-tier`.
+   Requires specifying :mc-cmd:`~mc ilm rule add --noncurrent-transition-tier`.
 
    This option has the same behavior as the S3 ``NoncurrentVersionTransition`` action.
 
@@ -204,7 +209,7 @@ Parameters
    :optional:
 
    The remote tier to which MinIO :ref:`transitions noncurrent objects versions <minio-lifecycle-management-tiering>`. 
-   Specify a remote tier created by :mc:`mc admin tier`.
+   Specify a remote tier created by :mc:`mc ilm tier add`.
 
 .. mc-cmd:: --noncurrent-expire-newer
    :optional:
@@ -298,30 +303,30 @@ Examples
 Expire All Bucket Contents After Number of Days
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc ilm add` with :mc-cmd:`~mc ilm add --expire-days` to mark bucket contents for expiration after a number of days pass from the object's creation:
+Use :mc:`mc ilm rule add` with :mc-cmd:`~mc ilm rule add --expire-days` to mark bucket contents for expiration after a number of days pass from the object's creation:
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm add ALIAS/PATH --expire-days "DAYS" 
+   mc ilm rule add ALIAS/PATH --expire-days "DAYS" 
 
-- Replace :mc-cmd:`ALIAS <mc ilm add ALIAS>` with the :mc:`alias <mc alias>` of the S3-compatible host.
+- Replace :mc-cmd:`ALIAS <mc ilm rule add ALIAS>` with the :mc:`alias <mc alias>` of the S3-compatible host.
 
-- Replace :mc-cmd:`PATH <mc ilm add ALIAS>` with the path to the bucket on the S3-compatible host.
+- Replace :mc-cmd:`PATH <mc ilm rule add ALIAS>` with the path to the bucket on the S3-compatible host.
 
-- Replace :mc-cmd:`DATE <mc ilm add --expire-days>` with the number of days after which to expire the object. 
+- Replace :mc-cmd:`DATE <mc ilm rule add --expire-days>` with the number of days after which to expire the object. 
   For example, specify ``30`` to expire the object 30 days after creation.
 
 Transition Non-Current Object Versions at a Prefix to a Different Tier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc:`mc ilm add` with :mc-cmd:`~mc ilm add --prefix` and :mc-cmd:`~mc ilm add --transition-tier` to transition older non-current versions of an object to a different storage tier.
+Use the :mc:`mc ilm rule add` with :mc-cmd:`~mc ilm rule add --prefix` and :mc-cmd:`~mc ilm rule add --transition-tier` to transition older non-current versions of an object to a different storage tier.
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm add --prefix "doc/" --transition-days "90" --trasition-tier "MINIOTIER-1"                  \
-          --noncurrent-transition-days "45" --noncurrent-transition-tier "MINIOTIER-2"  \
+   mc ilm rule add --prefix "doc/" --transition-days "90" --trasition-tier "MINIOTIER-1"  \
+          --noncurrent-transition-days "45" --noncurrent-transition-tier "MINIOTIER-2"    \
           myminio/mybucket/
 
 This command looks at the contents with the ``doc/`` prefix in the ``mybucket`` bucket on the ``myminio`` deployment.
@@ -333,17 +338,23 @@ This command looks at the contents with the ``doc/`` prefix in the ``mybucket`` 
 Expire All Objects at a Prefix, Retain Current Object Versions Longer Than Non-Current Object Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc:`mc ilm add` command with :mc-cmd:`~mc ilm add --prefix`, :mc-cmd:`~mc ilm add --expire-days`, and :mc-cmd:`~mc ilm add --noncurrent-expire-days` to expire current and non-current versions of an object at different times.
+Use the :mc:`mc ilm rule add` command with :mc-cmd:`~mc ilm rule add --prefix`, :mc-cmd:`~mc ilm rule add --expire-days`, and :mc-cmd:`~mc ilm rule add --noncurrent-expire-days` to expire current and non-current versions of an object at different times.
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm add --prefix "doc/" --expire-days "300" --noncurrent-expire-days "100" myminio/mybucket/
+   mc ilm rule add --prefix "doc/" --expire-days "300" --noncurrent-expire-days "100" myminio/mybucket/
 
 This command looks at the contents with the ``doc/`` prefix in the ``mybucket`` bucket on the ``myminio`` deployment.
 
 - Current objects expire after 300 days.
 - Non-current objects expire after 100 days.
+
+Required Permissions
+--------------------
+
+For permissions required to add a rule, refer to the :ref:`required permissions <minio-mc-ilm-rule-permissions>` on the parent command.
+
 
 Behavior
 --------
@@ -362,7 +373,7 @@ Expiry vs Transition
 MinIO supports specifying both expiry and transition rules in the same
 bucket or bucket prefix. MinIO can execute an expiration rule on an object
 regardless of its transition status. Use
-:mc:`mc ilm ls` to review the currently configured object lifecycle
+:mc:`mc ilm rule ls` to review the currently configured object lifecycle
 management rules for any potential interactions between expiry and transition
 rules.
 

--- a/source/reference/minio-mc/mc-ilm-rule-edit.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-edit.rst
@@ -1,0 +1,372 @@
+.. _minio-mc-ilm-rule-edit:
+
+====================
+``mc ilm rule edit``
+====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm rule edit
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm rule edit`` replaces ``mc ilm edit``.
+
+Syntax
+------
+
+.. start-mc-ilm-rule-edit-desc
+
+The :mc:`mc ilm rule edit` command modifies an existing object lifecycle management
+rule on a MinIO bucket.
+
+.. end-mc-ilm-rule-edit-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command modifies existing lifecycle management rules for
+      the ``mydata`` bucket on the ``myminio`` deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm rule edit --id "c79ntj94b0t6rukh6lr0" --expiry-days 90  mydata/myminio
+         
+         mc ilm rule edit --id "c79nu2p4b0t6qko19rgg" --expired-object-delete-marker mydata/myminio
+
+         mc ilm rule edit --id "c79n19dn10dnab109fg1" --transition-days 30 --tier "COLDTIER"
+         
+      The command modifies the specified rules as follows:
+
+      - Delete objects more than 90 days old.
+      - Delete ``DeleteMarker`` tombstones if that object has no other versions remaining.
+      - Transition objects more than 30 days old to the ``COLDTIER`` remote tier.
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] ilm rule edit                                       \
+                          --id "string"                                       \
+                          [--prefix "string"]                                 \
+                          [--enable]                                          \
+                          [--disable]                                         \
+                          [--expire-days "string"]                            \ 
+                          [--expire-delete-marker]                            \
+                          [--transition-days "string"]                        \
+                          [--transition-tier "string"]                        \
+                          [--noncurrent-expire-days "string"]                 \
+                          [--noncurrent-expire-newer "string"]                \
+                          [--noncurrent-transition-days "string"]             \
+                          [--noncurrent-transition-newer value]               \
+                          [--noncurrent-transition-tier "string"]             \
+                          [--tags]                                            \
+                          ALIAS
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` and full path to the bucket on the MinIO
+   deployment to which to modify the object lifecycle management rule. For
+   example:
+
+   .. code-block:: none
+
+      mc ilm rule edit myminio/mydata
+
+.. mc-cmd:: --id
+   :required:
+
+   The unique ID of the rule. Use :mc:`mc ilm rule ls` to list bucket
+   rules and retrieve the ``id`` for the rule you want to modify.
+
+.. mc-cmd:: --disable
+   :optional:
+
+   Stop using the rule, but retain the rule for future use.
+   Objects do not transition or expire when a rule is disabled.
+
+.. mc-cmd:: --enable
+   :optional:
+
+   Use a rule to transition or expire objects.
+
+.. mc-cmd:: --prefix
+   :optional:
+   
+   Restrict the management rule to a specific bucket prefix.
+   
+   For example:
+
+   .. code-block:: none
+
+      mc ilm rule edit --prefix "meetingnotes/" myminio/mydata/ --expire-days "90"
+
+   The command modifies a rule that expires objects in the ``mydata`` bucket of the ``myminio`` ALIAS after 90 days for any object with the ``meetingnotes/`` prefix.
+
+.. mc-cmd:: --expire-days
+   :optional:
+
+   The number of days to retain an object after being created. MinIO
+   marks the object for deletion after the specified number of days pass.
+
+   Exercise caution when using this option, as its behavior can result in
+   immediate expiration of uploaded objects. Any objects created *after* 
+   the specified expiration date are automatically eligible for expiration. 
+   Similarly, specifying a calendar date that is *prior* to the current 
+   system host datetime marks all objects covered by the rule for deletion. 
+   Consider immediately removing any ILM rule using this option once the
+   specified calendar date has passed.
+
+   For versioned buckets, the expiry rule applies only to the *current*
+   object version. Use the 
+   :mc-cmd:`~mc ilm rule edit --noncurrent-expire-days` option
+   to apply expiration behavior to noncurrent object versions.
+
+   MinIO uses a scanner process to check objects against all configured
+   lifecycle management rules. Slow scanning due to high IO workloads or
+   limited system resources may delay application of lifecycle management
+   rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+   Mutually exclusive with the following options:
+
+   - :mc-cmd:`~mc ilm rule edit --expire-delete-marker`
+
+.. mc-cmd:: --expire-delete-marker
+   :optional:
+
+   Specify this option to direct MinIO to remove delete markers for
+   objects with no remaining object versions. Specifically, the delete marker is
+   the *only* remaining "version" of the given object.
+
+   This option is mutually exclusive with the following options:
+   
+   - :mc-cmd:`~mc ilm rule edit --tags`
+   - :mc-cmd:`~mc ilm rule edit --expire-days`
+
+   MinIO uses a scanner process to check objects against all configured
+   lifecycle management rules. Slow scanning due to high IO workloads or
+   limited system resources may delay application of lifecycle management
+   rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+.. mc-cmd:: --noncurrent-expire-days
+   :optional:
+
+   The number of days to retain an object version after becoming
+   *non-current* (i.e. a different version of that object is now the `HEAD`).
+   MinIO marks noncurrent object versions for deletion after the specified
+   number of days pass.
+
+   This option has the same behavior as the 
+   S3 ``NoncurrentVersionExpiration`` action.
+
+   MinIO uses a scanner process to check objects against all configured
+   lifecycle management rules. Slow scanning due to high IO workloads or
+   limited system resources may delay application of lifecycle management
+   rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+.. mc-cmd:: --noncurrent-expire-newer
+   :optional:
+
+   The number of non-current versions of an object to retain before applying expiration.
+   Older non-current versions beyond the specified number expire.
+   
+   By default, MinIO does not retain any non-current versions when an expiration rule applies.
+
+.. mc-cmd:: --noncurrent-transition-days
+   :optional:
+
+   The number of days an object has been non-current (i.e. replaced
+   by a newer version of that same object) after which MinIO marks the object
+   version as eligible for transition. MinIO transitions the object to the
+   configured remote storage tier specified to the 
+   :mc-cmd:`~mc ilm rule edit --transition-tier` once the system host datetime
+   passes that calendar date.
+
+   This option has no effect on non-versioned buckets. Requires specifying
+   :mc-cmd:`~mc ilm rule edit --noncurrent-transition-tier`.
+
+   This option has the same behavior as the 
+   S3 ``NoncurrentVersionTransition`` action.
+
+   MinIO uses a scanner process to check objects against all configured
+   lifecycle management rules. Slow scanning due to high IO workloads or
+   limited system resources may delay application of lifecycle management
+   rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+.. mc-cmd:: --noncurrent-transition-newer
+   :optional:
+
+   The maximum number of non-current object versions to retain on the current tier.
+   Older object versions beyond the number to retain transition to a different, specified tier.
+
+   Use this flag to keep a certain number of non-current versions of an object accessible on the tier in a first in, first out order.
+
+   If not specified, all non-current object versions transition to the different tier.
+
+   The following table lists a number of object versions and their transition eligibility based on ``--noncurrent-transition-newer 3``:
+
+   .. list-table::
+      :widths: 50 50
+      :width: 100% 
+
+      * - v5 (current version)
+        - Current version not affected by ILM rules.
+      * - v4
+        - kept on current tier
+      * - v3
+        - kept on current tier
+      * - v2
+        - kept on current tier
+      * - v1
+        - marked for transition to other tier
+
+   MinIO retains the current version, v5, on the tier.
+   MinIO also retains the next ``3`` non-current versions on the tier, starting with the newest.
+   This means MinIO leaves ``v4``, ``v3``, and ``v2`` for the three non-current version to keep on the current tier.
+
+   ``v1`` would be a fourth non-current version, which falls outside the limit of non-current versions to retain, so MinIO marks ``v1`` for transition.
+
+   Updating the number for this flag only impacts the unmarked versions of objects.
+   Any versions already marked for transition do not change if you increase the number, and any object versions already transitioned do not transition back to the tier.
+
+   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
+   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
+   See :ref:`minio-lifecycle-management-scanner` for more information.
+
+
+.. mc-cmd:: --noncurrent-transition-tier
+   :optional:
+
+   The remote storage tier to which MinIO :ref:`transitions noncurrent objects versions <minio-lifecycle-management-tiering>`. 
+   Specify a remote storage tier created by :mc:`mc ilm tier add`.
+
+   MinIO does *not* automatically migrate objects from the previously
+   specified remote tier to the new remote tier. MinIO continues to
+   route requests for objects stored on the old remote tier.
+
+
+.. mc-cmd:: --tags
+   :optional:
+
+   One or more ampersand ``&``-delimited key-value pairs describing
+   the object tags to which to apply the lifecycle configuration rule.
+
+   This option is mutually exclusive with the following option:
+
+   - :mc-cmd:`~mc ilm rule edit --expire-delete-marker`
+
+.. mc-cmd:: --transition-days
+   :optional:
+   
+   The number of calendar days from object creation after which MinIO
+   marks an object as eligible for transition. MinIO transitions the object to
+   the configured remote storage tier specified to the 
+   :mc-cmd:`~mc ilm rule edit --transition-tier`. 
+
+   For versioned buckets, the transition rule applies only to the *current*
+   object version. Use the 
+   :mc-cmd:`~mc ilm rule edit --noncurrent-transition-days` option
+   to apply transition behavior to noncurrent object versions.
+
+   Requires specifying :mc-cmd:`~mc ilm rule edit --transition-tier`.
+
+   MinIO uses a scanner process to check objects against all configured
+   lifecycle management rules. Slow scanning due to high IO workloads or
+   limited system resources may delay application of lifecycle management
+   rules. See :ref:`minio-lifecycle-management-scanner` for more information.
+
+.. mc-cmd:: --transition-tier
+   :optional:
+
+   The remote storage tier to which MinIO 
+   :ref:`transition objects <minio-lifecycle-management-tiering>`. Specify a
+   remote storage tier created by :mc:`mc ilm tier add`. 
+
+   Required if specifying :mc-cmd:`~mc ilm rule edit --transition-days`.
+
+   MinIO does *not* automatically migrate objects from the previously
+   specified remote tier to the new remote tier. MinIO continues to
+   route requests for objects stored on the old remote tier.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Modify an Existing Lifecycle Management Rule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc ilm rule edit` with :mc-cmd:`~mc ilm rule edit --id` to modify
+an existing object expiration rule:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm rule edit ALIAS/PATH --id "RULEID" [FLAGS]
+
+- Replace :mc-cmd:`ALIAS <mc ilm rule edit ALIAS>` with the 
+  :mc:`alias <mc alias>` of the S3-compatible host.
+
+- Replace :mc-cmd:`PATH <mc ilm rule edit ALIAS>` with the path to the bucket on the
+  S3-compatible host.
+
+- Replace ``RULEID`` with the unique ID of the object lifecycle management rule.
+  Use :mc:`mc ilm rule ls` to find the ``RULEID``.
+
+- Specify any additional flags to add or modify the lifecycle management
+  rule. For example, specify
+  :mc-cmd:`~mc ilm rule edit --transition-days` to override the existing 
+  transition days value for the rule.
+
+Disable a Lifecycle Management Rule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc ilm rule edit` with :mc-cmd:`~mc ilm rule edit --disable` to stop using an existing management rule.
+
+.. code-block:: shell
+   :class: copyable
+   
+   mc ilm rule edit --id "RULEID" --disable myminio/mybucket
+
+- Replace ``RULEID`` with the unique ID of the object lifecycle management rule.
+  Use :mc:`mc ilm rule ls` to find the ``RULEID``.
+- Replace ``myminio`` with the ALIAS of the deployment where the rule exists.
+- Replace ``mybucket`` with the bucket for the rule.
+
+Required Permissions
+--------------------
+
+For permissions required to edit a rule, refer to the :ref:`required permissions <minio-mc-ilm-rule-permissions>` on the parent command.
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-ilm-rule-export.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-export.rst
@@ -1,8 +1,8 @@
-.. _minio-mc-ilm-export:
+.. _minio-mc-ilm-rule-export:
 
-=================
-``mc ilm export``
-=================
+======================
+``mc ilm rule export``
+======================
 
 .. default-domain:: minio
 
@@ -10,21 +10,23 @@
    :local:
    :depth: 2
 
-.. mc:: mc ilm export
+.. mc:: mc ilm rule export
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm rule export`` replaces ``mc ilm export``.
 
 Syntax
 ------
 
-.. start-mc-ilm-export-desc
+.. start-mc-ilm-rule-export-desc
 
-The :mc:`mc ilm export` command exports the object lifecycle management
-configuration for a MinIO bucket.
+The :mc:`mc ilm rule export` command exports the object lifecycle management configuration for a MinIO bucket.
 
-.. end-mc-ilm-export-desc
+.. end-mc-ilm-rule-export-desc
 
-The :mc:`mc ilm export` command outputs to ``STDOUT`` by default. You can
-output the contents to a ``.json`` file for archival or ingestion using
-:mc:`mc ilm import`.
+The :mc:`mc ilm rule export` command outputs to ``STDOUT`` by default. 
+You can output the contents to a ``.json`` file for archival or ingestion using :mc:`mc ilm rule import`.
 
 .. tab-set::
 
@@ -37,7 +39,7 @@ output the contents to a ``.json`` file for archival or ingestion using
       .. code-block:: shell
          :class: copyable
 
-         mc ilm export myminio/mydata > mydata-lifecycle-config.json
+         mc ilm rule export myminio/mydata > mydata-lifecycle-config.json
 
    .. tab-item:: SYNTAX
 
@@ -46,7 +48,7 @@ output the contents to a ``.json`` file for archival or ingestion using
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] ilm export ALIAS > STDOUT
+         mc [GLOBALFLAGS] ilm rule export ALIAS
 
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
@@ -57,14 +59,14 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
    
-   *Required* The :ref:`alias <alias>` and full path to the bucket on the MinIO
-   deployment for which to export object lifecycle management rules. For
-   example:
+   The :ref:`alias <alias>` and full path to the bucket on the MinIO deployment for which to export object lifecycle management rules. 
+   For example:
 
    .. code-block:: none
 
-      mc ilm export myminio/mydata > bucket-lifecycle.json
+      mc ilm rule export myminio/mydata > bucket-lifecycle.json
 
 Global Flags
 ~~~~~~~~~~~~
@@ -89,14 +91,14 @@ Export the Bucket Lifecycle Management Configuration
       .. code-block:: shell
          :class: copyable
 
-         mc ilm export myminio/mybucket > bucket-lifecycle.json
+         mc ilm rule export myminio/mybucket > bucket-lifecycle.json
 
    .. tab-item:: Syntax
 
       .. code-block:: shell
          :class: copyable
 
-         mc ilm export ALIAS > file.json
+         mc ilm rule export ALIAS > file.json
 
       - Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO 
         deployment and the bucket for which to export object lifecycle
@@ -106,6 +108,11 @@ Export the Bucket Lifecycle Management Configuration
 
       - Replace ``file.json`` with the name of the file to which to export the
         lifecycle management rules.
+
+Required Permissions
+--------------------
+
+For permissions required to export a rule, refer to the :ref:`required permissions <minio-mc-ilm-rule-permissions>` on the parent command.
 
 
 Behavior

--- a/source/reference/minio-mc/mc-ilm-rule-import.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-import.rst
@@ -1,0 +1,134 @@
+.. _minio-mc-ilm-rule-import:
+
+======================
+``mc ilm rule import``
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm rule import
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm rule import`` replaces ``mc ilm import``.
+
+Syntax
+------
+
+.. start-mc-ilm-rule-import-desc
+
+The :mc:`mc ilm rule import` command imports an object lifecycle management
+configuration and applies it to a MinIO bucket.
+
+.. end-mc-ilm-rule-import-desc
+
+The :mc:`mc ilm rule import` command imports from ``STDIN`` by default. 
+You can input the contents from a ``.json`` file, such as one produced by :mc:`mc ilm rule export`.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command imports the lifecycle management configuration from
+      ``mydata-lifecycle-config.json`` and applies it to the ``mydata`` bucket on the ``myminio`` deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm rule import myminio/mydata < mydata-lifecycle-config.json
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] ilm rule import ALIAS < STDIN
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+   
+   The :ref:`alias <alias>` and full path to the bucket on the MinIO deployment into which to import object lifecycle management rules. 
+   For example:
+
+   .. code-block:: none
+
+      mc ilm rule import myminio/mydata < bucket-lifecycle.json
+
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Import the Bucket Lifecycle Management Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tab-set::
+
+   .. tab-item:: Example
+
+      The following command imports the bucket lifecycle management
+      configuration from the ``bucket-lifecycle.json`` file:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm rule import myminio/mybucket < bucket-lifecycle.json
+
+   .. tab-item:: Syntax
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm rule import ALIAS < file.json
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of the MinIO 
+        deployment and the bucket into which to import object lifecycle
+        management rules:
+
+        ``myminio/mydata``
+
+      - Replace ``file.json`` with the name of the file from which to import the
+        lifecycle management rules.
+
+
+Required Permissions
+--------------------
+
+For permissions required to import rules, refer to the :ref:`required permissions <minio-mc-ilm-rule-permissions>` on the parent command.
+
+
+Behavior
+--------
+
+Importing Configuration Overrides Existing Rules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:mc:`mc ilm rule import` replaces the current bucket lifecycle management
+rules with those defined in the imported JSON configuration.
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-ilm-rule-ls.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-ls.rst
@@ -1,0 +1,156 @@
+.. _minio-mc-ilm-rule-ls:
+
+==================
+``mc ilm rule ls``
+==================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm rule ls
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm rule ls`` replaces ``mc ilm ls``.
+
+Syntax
+------
+
+.. start-mc-ilm-rule-ls-desc
+
+The :mc:`mc ilm rule ls` command summarizes all configured object lifecycle management rules on a MinIO bucket in a tabular format.
+
+.. end-mc-ilm-rule-ls-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command lists all lifecycle management rules for the ``mydata`` bucket on the ``myminio`` MinIO deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm rule ls myminio/mydata
+
+      The output of the command might resemble the following:
+
+      .. code-block:: shell
+      
+         ┌───────────────────────────────────────────────────────────────────────────────┐
+         │ Transition for latest version (Transition)                                    │
+         ├────────┬─────────┬────────┬─────────────────────┬──────────────┬──────────────┤
+         │ ID     │ STATUS  │ PREFIX │ TAGS                │ DAYS TO TIER │ TIER         │
+         ├────────┼─────────┼────────┼─────────────────────┼──────────────┼──────────────┤
+         │ rule-1 │ Enabled │ doc/   │ key1=val1&key2=val2 │            0 │ WARM-MINIO-1 │
+         └────────┴─────────┴────────┴─────────────────────┴──────────────┴──────────────┘
+         ┌────────────────────────────────────────────────────────────────┐
+         │ Transition for older versions (NoncurrentVersionTransition)    │
+         ├────────┬─────────┬────────┬──────┬──────────────┬──────────────┤
+         │ ID     │ STATUS  │ PREFIX │ TAGS │ DAYS TO TIER │ TIER         │
+         ├────────┼─────────┼────────┼──────┼──────────────┼──────────────┤
+         │ rule-2 │ Enabled │ logs/  │ -    │           10 │ WARM-MINIO-1 │
+         └────────┴─────────┴────────┴──────┴──────────────┴──────────────┘
+         ┌────────────────────────────────────────────────────────────────────────────────────────┐
+         │ Expiration for latest version (Expiration)                                             │
+         ├────────┬─────────┬────────┬─────────────────────┬────────────────┬─────────────────────┤
+         │ ID     │ STATUS  │ PREFIX │ TAGS                │ DAYS TO EXPIRE │ EXPIRE DELETEMARKER │
+         ├────────┼─────────┼────────┼─────────────────────┼────────────────┼─────────────────────┤
+         │ rule-1 │ Enabled │ doc/   │ key1=val1&key2=val2 │             30 │ false               │
+         └────────┴─────────┴────────┴─────────────────────┴────────────────┴─────────────────────┘
+         ┌──────────────────────────────────────────────────────────────────────────────────┐
+         │ Expiration for older versions (NoncurrentVersionExpiration)                      │
+         ├────────┬─────────┬────────┬─────────────────────┬────────────────┬───────────────┤
+         │ ID     │ STATUS  │ PREFIX │ TAGS                │ DAYS TO EXPIRE │ KEEP VERSIONS │
+         ├────────┼─────────┼────────┼─────────────────────┼────────────────┼───────────────┤
+         │ rule-1 │ Enabled │ doc/   │ key1=val1&key2=val2 │             15 │             0 │
+         │ rule-2 │ Enabled │ logs/  │ -                   │              1 │             3 │
+         └────────┴─────────┴────────┴─────────────────────┴────────────────┴───────────────┘
+
+   .. tab-item:: SYNTAX
+
+      The :mc:`mc ilm rule ls` command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] ilm rule ls     \
+                          [--expiry]      \
+                          [--transition]
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+   
+   The :ref:`alias <alias>` and full path to the bucket on the MinIO deployment for which to list the object lifecycle management rules. 
+   For example:
+
+   .. code-block:: none
+
+      mc ilm rule ls myminio/mydata
+
+
+.. mc-cmd:: --expiry
+   :optional:
+   
+   :mc:`mc ilm rule ls` returns only fields related to lifecycle rule expiration.
+
+   Mutually exclusive with :mc-cmd:`~mc ilm rule ls --transition`.
+
+.. mc-cmd:: --transition
+   :optional:
+
+   :mc:`mc ilm rule ls` returns only fields related to lifecycle rule transition.
+
+   Mutually exclusive with :mc-cmd:`~mc ilm rule ls --expiry`.
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+List Bucket Lifecycle Management Rules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc ilm rule ls` to list a bucket's lifecycle management rules:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm rule ls ALIAS/PATH
+
+- Replace :mc-cmd:`ALIAS <mc ilm rule ls ALIAS>` with the 
+  :mc:`alias <mc alias>` of the S3-compatible host.
+
+- Replace ``PATH`` with the path to the bucket on the S3-compatible host.
+
+Required Permissions
+--------------------
+
+For permissions required to list rules, refer to the :ref:`required permissions <minio-mc-ilm-rule-permissions>` on the parent command.
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-ilm-rule-rm.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-rm.rst
@@ -1,0 +1,129 @@
+.. _minio-mc-ilm-rule-rm:
+
+==================
+``mc ilm rule rm``
+==================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm rule rm
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   ``mc ilm rule rm`` replaces ``mc ilm rm``.
+
+Syntax
+------
+
+.. start-mc-ilm-rule-rm-desc
+
+The :mc:`mc ilm rule rm` command removes an object lifecycle management rule from a MinIO Bucket.
+
+.. end-mc-ilm-rule-rm-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command removes a single lifecycle management rule from the ``mydata`` bucket on the ``myminio`` MinIO deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm rule rm --id "bgrt1ghju" myminio/mydata
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] ilm rule rm                         \
+                              --id "string" | (--all --force) \
+                              ALIAS                           \
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+   
+   The :ref:`alias <alias>` and full path to the bucket on the MinIO deployment to which to remove the object lifecycle management rule. 
+   For example:
+
+   .. code-block:: none
+
+      mc ilm rule rm myminio/mydata
+
+.. mc-cmd:: --all
+   :optional:
+
+   Removes all rules in the bucket. 
+   Requires including :mc-cmd:`~mc ilm rule rm --force`.
+
+   Mutually exclusive with :mc:`~mc ilm rule rm --id`.
+
+.. mc-cmd:: --force
+   :optional:
+
+   Required if specifying :mc-cmd:`~mc ilm rule rm --all`.
+
+.. mc-cmd:: --id
+   :optional:
+
+   The unique ID of the rule. 
+   Use :mc:`mc ilm rule ls` to list bucket rules and retrieve the ``id`` for the rule you want to remove.
+
+   Mutually exclusive with :mc:`mc ilm rule rm --all`
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Remove a Bucket Lifecycle Management Rule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc ilm rule rm` to remove a bucket lifecycle management rule:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm rule rm --id "RULE" ALIAS/PATH
+
+- Replace ``RULE`` with the unique identifier of the lifecycle  management rule.
+  Use :mc-cmd:`mc ilm rule ls` to find the ID to use.
+
+- Replace :mc-cmd:`ALIAS <mc ilm rule rm ALIAS>` with the :mc:`alias <mc alias>` of the S3-compatible host.
+
+- Replace ``PATH`` with the path to the bucket on the S3-compatible host.
+
+Required Permissions
+--------------------
+
+For permissions required to remove a rule, refer to the :ref:`required permissions <minio-mc-ilm-rule-permissions>` on the parent command.
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-ilm-rule.rst
+++ b/source/reference/minio-mc/mc-ilm-rule.rst
@@ -1,0 +1,132 @@
+===============
+``mc ilm rule``
+===============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm rule
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   The following commands have moved to subcommands under :mc-cmd:`mc ilm rule`:
+
+   - :mc-cmd:`mc ilm add`
+   - :mc-cmd:`mc ilm edit`
+   - :mc-cmd:`mc ilm export`
+   - :mc-cmd:`mc ilm import`
+   - :mc-cmd:`mc ilm ls`
+   - :mc-cmd:`mc ilm rm`
+
+
+Description
+-----------
+
+.. start-mc-ilm-rule-desc
+
+The :mc:`mc ilm rule` command and its subcommands configure the rules used to transition objects between storage tiers in MinIO's Lifecycle Management. 
+
+.. end-mc-ilm-rule-desc
+
+Before creating rules with this command, use :mc-cmd:`mc ilm tier` and its subcommands to create the tier or tiers of other object storage locations where objects move.
+
+For more information, see the overview of :ref:`lifecycle management <minio-lifecycle-management>`.
+
+
+Subcommands
+-----------
+
+:mc-cmd:`mc ilm rule` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc ilm rule add`
+     - .. include:: /reference/minio-mc/mc-ilm-rule-add.rst
+          :start-after: start-mc-ilm-rule-add-desc
+          :end-before: end-mc-ilm-rule-add-desc
+
+   * - :mc:`~mc ilm rule edit`
+     - .. include:: /reference/minio-mc/mc-ilm-rule-edit.rst
+          :start-after: start-mc-ilm-rule-edit-desc
+          :end-before: end-mc-ilm-rule-edit-desc
+
+   * - :mc:`~mc ilm rule export`
+     - .. include:: /reference/minio-mc/mc-ilm-rule-export.rst
+          :start-after: start-mc-ilm-rule-export-desc
+          :end-before: end-mc-ilm-rule-export-desc
+
+   * - :mc:`~mc ilm rule import`
+     - .. include:: /reference/minio-mc/mc-ilm-rule-import.rst
+          :start-after: start-mc-ilm-rule-import-desc
+          :end-before: end-mc-ilm-rule-import-desc
+
+   * - :mc:`~mc ilm rule ls`
+     - .. include:: /reference/minio-mc/mc-ilm-rule-ls.rst
+          :start-after: start-mc-ilm-rule-ls-desc
+          :end-before: end-mc-ilm-rule-ls-desc
+
+   * - :mc:`~mc ilm rule rm`
+     - .. include:: /reference/minio-mc/mc-ilm-rule-rm.rst
+          :start-after: start-mc-ilm-rule-rm-desc
+          :end-before: end-mc-ilm-rule-rm-desc
+
+.. _minio-mc-ilm-rule-permissions:
+
+Permissions
+-----------
+
+MinIO requires the following permissions scoped to to the bucket or buckets for which you create lifecycle management rules.
+
+- :policy-action:`s3:PutLifecycleConfiguration`
+- :policy-action:`s3:GetLifecycleConfiguration`
+
+For example, the following policy provides permission for configuring object
+transition lifecycle management rules on any bucket in the cluster:.
+
+.. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
+   :language: json
+   :class: copyable
+
+Transition Permissions
+~~~~~~~~~~~~~~~~~~~~~~
+
+Object transition lifecycle management rules require additional permissions
+on the remote storage tier. Specifically, MinIO requires the remote
+tier credentials provide read, write, list, and delete permissions.
+
+For example, if the remote storage tier implements AWS IAM policy-based
+access control, the following policy provides the necessary permission
+for transitioning objects into and out of the remote tier:
+
+.. literalinclude:: /extra/examples/LifecycleManagementUser.json
+   :language: json
+   :class: copyable
+
+Modify the ``Resource`` for the bucket into which MinIO tiers objects.
+
+Defer to the documentation for the supported tiering targets for more complete
+information on configuring users and permissions to support MinIO tiering:
+
+- :aws-docs:`Amazon S3 Permissions <service-authorization/latest/reference/list_amazons3.html#amazons3-actions-as-permissions>`
+- `Google Cloud Storage Access Control <https://cloud.google.com/storage/docs/access-control>`__
+- `Authorizing access to data in Azure storage <https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json>`__
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-ilm-rule-add
+   /reference/minio-mc/mc-ilm-rule-edit
+   /reference/minio-mc/mc-ilm-rule-export
+   /reference/minio-mc/mc-ilm-rule-import
+   /reference/minio-mc/mc-ilm-rule-ls
+   /reference/minio-mc/mc-ilm-rule-rm

--- a/source/reference/minio-mc/mc-ilm-tier-add.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-add.rst
@@ -1,0 +1,355 @@
+.. _minio-mc-ilm-tier-add:
+
+===================
+``mc ilm tier add``
+===================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm tier add
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   :mc-cmd:`mc ilm tier add` replaces ``mc admin tier add``.
+
+Description
+-----------
+
+.. start-mc-ilm-tier-add-desc
+
+The :mc:`mc ilm tier add` command creates a new remote storage tier to a supported storage services.
+
+.. end-mc-ilm-tier-add-desc
+
+See :ref:`Object Transition <minio-lifecycle-management-tiering>` for a complete list.
+
+Supported S3 Services
+~~~~~~~~~~~~~~~~~~~~~
+
+:mc:`mc ilm tier add` supports *only* the following S3-compatible services as a remote target for object tiering:
+
+- MinIO
+- Amazon S3
+- Google Cloud Storage
+- Azure Blob Storage
+
+Permissions
+~~~~~~~~~~~
+
+MinIO requires the following administrative permissions on the cluster in which you create remote tiers for object transition lifecycle management rules:
+
+- :policy-action:`admin:SetTier`
+- :policy-action:`admin:ListTier`
+
+For example, the following policy provides permission for configuring object transition lifecycle management rules on any bucket in the cluster: 
+
+.. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
+   :language: json
+   :class: copyable
+
+Syntax
+------
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following example creates a new remote tier called ``WARM-MINIO-TIER`` on the ``myminio`` deployment.
+      The command creates a tier for a remote MinIO deployment located at the hostname ``https://warm-minio.com``.
+      
+      .. code-block:: shell
+         :class: copyable
+
+          mc ilm tier add minio myminio WARM-MINIO-TIER                     \
+                                        --endpoint https://warm-minio.com   \                       
+                                        --access-key ACCESSKEY              \
+                                        --secret-key SECRETKEY              \
+                                        --bucket mybucket                   \
+                                        --prefix myprefix/ 
+
+      Lifecycle management rules on the ``myminio`` deployment can use the new tier to transition objects into the remote location's ``myprefix/`` prefix in the ``mybucket`` bucket.
+
+   .. tab-item:: SYNTAX
+   
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm tier add TIER_TYPE                    \
+                         TARGET                       \
+                         TIER_NAME                    \
+                         --bucket value               \
+                         [--endpoint string]          \
+                         [--region string]            \
+                         [--access-key value^]        \
+                         [--secret-key value^]        \
+                         [--use-aws-role^]            \
+                         [--account-name value^]      \
+                         [--account-key value^]       \
+                         [--credentials-file value^]  \
+                         [--prefix value]             \
+                         [--storage-class value]
+
+      **^Note:** Each supported storage vendor authenticates with different methods.
+      The flags to use for authentication vary by storage vendor.
+      See details under :mc-cmd:`~mc ilm tier add TIER_TYPE` below. 
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+The command accepts the following arguments:
+
+.. mc-cmd:: TIER_TYPE
+   :required:
+
+   The Cloud Service Provider storage backend ("Tier") to which MinIO transitions objects. 
+   Specify *one* of the following supported values:
+
+   .. list-table::
+      :stub-columns: 1
+      :width: 100%
+      :widths: 30 70
+
+      * - ``minio``
+        - Use a remote MinIO deployment as the storage backend for the new Tier.
+
+          Requires also specifying the following parameters:
+
+          - :mc-cmd:`~mc ilm tier add --access-key`
+          - :mc-cmd:`~mc ilm tier add --secret-key`
+
+      * - ``s3``
+        - Use AWS S3 as the storage backend for the new Tier.
+
+          Requires also specifying the following parameters:
+
+          - :mc-cmd:`~mc ilm tier add --access-key`
+          - :mc-cmd:`~mc ilm tier add --secret-key`
+
+      * - ``azure``
+        - Use :abbr:`Azure (Microsoft Azure)` Blob Storage as the storage backend for the new Tier.
+
+          Requires also specifying the following parameters:
+
+          - :mc-cmd:`~mc ilm tier add --account-name`
+          - :mc-cmd:`~mc ilm tier add --account-key`
+         
+      * - ``gcs`` 
+        - Use :abbr:`GCP (Google Cloud Platform)` Cloud Storage as the storage backend for the new Tier.
+
+          Requires also specifying the following parameter:
+
+          - :mc-cmd:`~mc ilm tier add --credentials-file`
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment on which the command creates the new remote tier.
+   You can then create new rules with :mc:`mc ilm rule add` specifying the new remote tier.
+      
+.. mc-cmd:: TIER_NAME
+   :required:
+
+   The name to associate with the new remote tier. 
+   The name **must** be unique across all configured tiers on the MinIO cluster.
+
+   You **must** specify the tier in all-caps, e.g. ``WARM_TIER``.
+   
+.. mc-cmd:: --endpoint
+   :optional:
+
+   The URL endpoint for the S3 or MinIO storage. 
+   The URL endpoint **must** resolve to the provider specified to :mc-cmd:`~mc ilm tier add TIER_TYPE`. 
+
+   Required for ``s3`` or ``minio`` tier types.
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --access-key
+   :optional:
+      
+   The access key for a user on the remote ``S3`` or ``minio`` tier types. 
+   The user must have permission to perform read/write/list/delete operations on the remote bucket or bucket prefix.
+      
+   Required if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``. 
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --secret-key
+   :optional:
+
+   The secret key for a user on the remote ``s3`` or ``minio`` tier types.
+
+   Required if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``. 
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --account-name
+   :optional:
+
+   The account name for a user on the remote Azure tier. 
+   The user must have permission to perform read/write/list/delete operations on the remote bucket or bucket prefix.
+      
+   Required if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+   MinIO does *not* support changing the account name associated to an Azure remote tier. 
+   Azure storage backends are tied to the account, such that changing the account would change the storage backend and prevent access to any objects transitioned to the original account/backend.
+
+.. mc-cmd:: --account-key
+   :optional:
+
+   The account key for the :mc-cmd:`~mc ilm tier add --account-name` associated to the remote Azure tier.
+
+   Required if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --credentials-file
+   :optional:
+
+   The `credential file <https://cloud.google.com/docs/authentication/getting-started>`__ for a user on the remote Google Cloud Storage tier. 
+   The user must have permission to perform read/write/list/delete operations on the remote bucket or bucket prefix.
+      
+   Required if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``gcs``. 
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --bucket
+   :required:
+
+   The bucket on the remote tier to which MinIO transitions objects.
+
+.. mc-cmd:: --prefix
+   :optional:
+
+   The prefix path for the specified :mc-cmd:`~mc ilm tier add --bucket` to which MinIO transitions objects.
+
+   Omit this field to transition objects into the bucket root.
+
+.. mc-cmd:: --storage-class
+   :optional:
+
+   The AWS storage class to use for objects transitioned by MinIO. 
+   MinIO supports only the following storage classes:
+
+   - ``STANDARD``
+   - ``REDUCED_REDUNDANCY``
+
+   Defaults to ``STANDARD`` if omitted. 
+
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``.
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --region
+   :optional:
+
+   The S3 backend region for the specified :mc-cmd:`~mc ilm tier add TIER_TYPE`, such as ``us-west-1``.
+
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``. 
+   This option has no effect for any other value of ``TIER_TYPE``.
+      
+.. mc-cmd:: --use-aws-role
+   :optional:
+
+   Use the access permission for the locally configured :iam-docs:`AWS Role <id_roles.html>`.
+
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``.
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Configure a Tier to Transition Objects to a MinIO Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example creates a new tier on a local deployment that a configured rule can use to transition objects to a separate, remote MinIO deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm tier add minio myminio WARM-MINIO-TIER --endpoint https://warm-minio.com \                       
+        --access-key ACCESSKEY --secret-key SECRETKEY --bucket mybucket --prefix myprefix/  
+
+This command creates a new tier called ``WARM-MINIO-TIER`` for a ``minio`` type of remote storage on the ``myminio`` deployment.
+
+- The remote MinIO storage is located at ``https://warm-minio.com``.
+- The command includes credentials for a user with read, write, list, and delete privileges to the bucket and prefix.
+- The tier transitions objects to the ``mybucket`` bucket and the ``myprefix`` prefix on the remote MinIO storage.
+
+Configure a Tier to Transition Objects to an Azure Blob Storage Location
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example creates a new tier on a local deployment that a configured rule can use to transition objects to Azure Blob Storage.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm tier add azure myminio AZTIER --account-name ACCOUNT-NAME --account-key ACCOUNT-KEY \            
+        --bucket myazurebucket --prefix myazureprefix/                                                         
+                                                        
+
+This command creates a new tier called ``AZTIER`` for an ``azure`` type of remote storage on the ``myminio`` deployment.
+
+- The remote Azure storage is accessed by the provided account name and key.
+- The tier transitions objects to the ``myazurebucket`` bucket and the ``myazureprefix`` prefix on the Azure storage.
+
+Configure a Tier to Transition Objects to Google Cloud Storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example creates a new tier on a local deployment that a configured rule can use to transition objects to Google Cloud Storage.
+
+.. code-block:: shell
+   :class: copyable
+
+    mc ilm tier add gcs myminio GCSTIER --credentials-file /path/to/credentials.json \                      
+        --bucket mygcsbucket  --prefix mygcsprefix/                                                            
+
+This command creates a new tier called ``GCSTIER`` for a ``gcs`` type of remote storage on the ``myminio`` deployment.
+
+- The remote GCS storage is accessed by the provided credentials file.
+- The tier transitions objects to the ``mygcsbucket`` bucket and the ``mygcsprefix`` prefix on the GCS storage.
+
+Configure a Tier to Transition Objects to Amazon Simple Storage Service (S3)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example creates a new tier on a local deployment that a configured rule can use to transition objects to a STANDARD storage on S3.
+
+.. code-block:: shell
+   :class: copyable
+
+    mc ilm tier add s3 myminio S3TIER --endpoint https://s3.amazonaws.com \                                 
+        --access-key ACCESSKEY --secret-key SECRETKEY --bucket mys3bucket --prefix mys3prefix/ \               
+        --storage-class "STANDARD" --region us-west-2                                                             
+
+This command creates a new tier called ``S3TIER`` for a ``s3`` type of remote storage on the ``myminio`` deployment.
+
+- The S3 storage is located at the provided endpoint.
+- The remotes S3 storage is accessed by the provided access key and secret key.
+- The tier transitions objects to the ``mys3bucket`` bucket and the ``mys3prefix`` prefix on the GCS storage.
+- The tier utilizes S3 ``STANDARD`` storage class located in the ``us-west-2`` S3 region.
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility
+
+
+Required Permissions
+--------------------
+
+For permissions required to add a tier, refer to the :ref:`required permissions <minio-mc-ilm-tier-permissions>` on the parent command.

--- a/source/reference/minio-mc/mc-ilm-tier-check.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-check.rst
@@ -1,0 +1,103 @@
+.. _minio-mc-ilm-tier-check:
+
+=====================
+``mc ilm tier check``
+=====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm tier check
+
+Description
+-----------
+
+.. start-mc-ilm-tier-check-desc
+
+The :mc:`mc ilm tier check` command displays the configuration for remote tier on a deployment. 
+
+.. end-mc-ilm-tier-check-desc
+
+Syntax
+------
+
+The command has the following syntax:
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following example displays the configuration for an existing remote tier called ``WARM-TIER`` on the ``myminio`` deployment.
+      
+      .. code-block:: shell
+         :class: copyable
+
+          mc ilm tier check myminio WARM-TIER                    
+
+
+   .. tab-item:: SYNTAX
+   
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm tier add TARGET TIER_NAME 
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+The command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment on which the desired tier exists.
+      
+.. mc-cmd:: TIER_NAME
+   :required:
+
+   The name of an existing remote tier to display. 
+
+   You **must** specify the tier in all-caps, e.g. ``WARM_TIER``.
+   
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Example
+-------
+
+Display the Configuration for an Existing Tier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example displays the configuration of the tier ``WARM-TIER`` on the ``myminio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm tier check myminio WARM-TIER 
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility
+
+Required Permissions
+--------------------
+
+For permissions required to review a tier, refer to the :ref:`required permissions <minio-mc-ilm-tier-permissions>` on the parent command.

--- a/source/reference/minio-mc/mc-ilm-tier-info.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-info.rst
@@ -1,0 +1,133 @@
+.. _minio-mc-ilm-tier-info:
+
+====================
+``mc ilm tier info``
+====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm tier info
+
+Description
+-----------
+
+.. start-mc-ilm-tier-info-desc
+
+The :mc:`mc ilm tier info` command outputs statistics about a tier or all tiers for a deployment. 
+
+.. end-mc-ilm-tier-info-desc
+
+Required Permissions
+~~~~~~~~~~~~~~~~~~~~
+
+MinIO requires the following permissions scoped to to the bucket or buckets 
+for which you are creating lifecycle management rules.
+
+- :policy-action:`s3:PutLifecycleConfiguration`
+- :policy-action:`s3:GetLifecycleConfiguration`
+
+MinIO also requires the following administrative permissions on the cluster
+in which you are creating remote tiers for object transition lifecycle
+management rules:
+
+- :policy-action:`admin:SetTier`
+- :policy-action:`admin:ListTier`
+
+For example, the following policy provides permission for configuring object
+transition lifecycle management rules on any bucket in the cluster:.
+
+.. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
+   :language: json
+   :class: copyable
+
+Syntax
+------
+
+The command has the following syntax:
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following example outputs the configuration for an existing remote tier called ``WARM-TIER`` on the ``myminio`` deployment.
+      
+      .. code-block:: shell
+         :class: copyable
+
+          mc ilm tier info myminio WARM-TIER
+
+
+   .. tab-item:: SYNTAX
+   
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm tier info TARGET TIER_NAME 
+
+Parameters
+~~~~~~~~~~
+
+The command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment on which the desired tier exists.
+      
+.. mc-cmd:: TIER_NAME
+   :optional:
+
+   The name of an existing remote tier to display. 
+
+   You **must** specify the tier in all-caps, e.g. ``WARM_TIER``.
+
+   If not specified, MinIO lists statistics for all existing tiers on the deployment.
+   
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Example
+-------
+
+Display the Statistics for an Existing Tier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example displays the statistics of the tier ``WARM-TIER`` on the ``myminio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm tier info myminio WARM-TIER 
+
+Display the Statistics for all Existing Tiers on a Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example displays the statistics of all existing tiers on the ``myminio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm tier info myminio
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility
+
+Required Permissions
+--------------------
+
+For permissions required to review a tier, refer to the :ref:`required permissions <minio-mc-ilm-tier-permissions>` on the parent command.

--- a/source/reference/minio-mc/mc-ilm-tier-ls.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-ls.rst
@@ -1,0 +1,82 @@
+.. _minio-mc-ilm-tier-ls:
+
+==================
+``mc ilm tier ls``
+==================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm tier ls
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   :mc-cmd:`mc ilm tier ls` replaces ``mc admin tier ls``.
+
+Description
+-----------
+
+.. start-mc-ilm-tier-ls-desc
+
+The :mc:`mc ilm tier ls` command shows the remote tiers configured on a deployment. 
+
+.. end-mc-ilm-tier-ls-desc
+
+Syntax
+------
+
+The command has the following syntax:
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following example outputs a list of the existing remote tiers on the ``myminio`` deployment.
+      
+      .. code-block:: shell
+         :class: copyable
+
+          mc ilm tier ls myminio
+
+
+   .. tab-item:: SYNTAX
+   
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm tier ls TARGET TIER_NAME 
+
+Parameters
+~~~~~~~~~~
+
+The command accepts the following argument:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment on which the desired tier exists.
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility
+
+Required Permissions
+--------------------
+
+For permissions required for reviewing a tier, refer to the :ref:`required permissions <minio-mc-ilm-tier-permissions>` on the parent command.

--- a/source/reference/minio-mc/mc-ilm-tier-rm.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-rm.rst
@@ -1,0 +1,115 @@
+.. _minio-mc-ilm-tier-rm:
+
+==================
+``mc ilm tier rm``
+==================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm tier rm
+
+Description
+-----------
+
+.. start-mc-ilm-tier-rm-desc
+
+The :mc:`mc ilm tier rm` command removes an remote tier that has not been used to transition any objects. 
+
+.. end-mc-ilm-tier-rm-desc
+
+.. note:: 
+
+   Once a tier has transitioned objects, it cannot be removed.
+
+Required Permissions
+~~~~~~~~~~~~~~~~~~~~
+
+MinIO requires the following permissions scoped to to the bucket or buckets 
+for which you are creating lifecycle management rules.
+
+- :policy-action:`s3:PutLifecycleConfiguration`
+- :policy-action:`s3:GetLifecycleConfiguration`
+
+MinIO also requires the following administrative permissions on the cluster
+in which you are creating remote tiers for object transition lifecycle
+management rules:
+
+- :policy-action:`admin:SetTier`
+- :policy-action:`admin:ListTier`
+
+For example, the following policy provides permission for configuring object
+transition lifecycle management rules on any bucket in the cluster:.
+
+.. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
+   :language: json
+   :class: copyable
+
+Syntax
+------
+
+The command has the following syntax:
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following example removes an existing remote tier called ``WARM-TIER`` on the ``myminio`` deployment.
+      No objects have transitioned to the ``WARM-TIER`` tier.
+      
+      .. code-block:: shell
+         :class: copyable
+
+          mc ilm tier rm myminio WARM-TIER
+
+
+   .. tab-item:: SYNTAX
+   
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm tier info TARGET TIER_NAME 
+
+Parameters
+~~~~~~~~~~
+
+The command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment on which the desired tier exists.
+      
+.. mc-cmd:: TIER_NAME
+   :required:
+
+   The name of an existing remote tier to remove. 
+
+   You **must** specify the tier in all-caps, e.g. ``WARM_TIER``.
+
+   No object can have transitioned to the tier.
+   
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility
+
+Required Permissions
+--------------------
+
+For permissions required to remove a tier, refer to the :ref:`required permissions <minio-mc-ilm-tier-permissions>` on the parent command.

--- a/source/reference/minio-mc/mc-ilm-tier-update.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-update.rst
@@ -1,0 +1,255 @@
+.. _minio-mc-ilm-tier-update:
+
+======================
+``mc ilm tier update``
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm tier update
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   :mc-cmd:`mc ilm tier update` replaces ``mc admin tier edit``.
+
+Description
+-----------
+
+.. start-mc-ilm-tier-update-desc
+
+The :mc:`mc ilm tier update` command modifies an existing configured remote tier. 
+
+.. end-mc-ilm-tier-update-desc
+
+.. admonition:: Use ``mc admin`` on MinIO Deployments Only
+   :class: note
+
+   .. include:: /includes/facts-mc-admin.rst
+      :start-after: start-minio-only
+      :end-before: end-minio-only
+
+Supported S3 Services
+~~~~~~~~~~~~~~~~~~~~~
+
+:mc:`mc ilm tier` supports *only* the following S3-compatible services as a remote target for object tiering:
+
+- MinIO
+- Amazon S3
+- Google Cloud Storage
+- Azure Blob Storage
+
+Required Permissions
+~~~~~~~~~~~~~~~~~~~~
+
+MinIO requires the following permissions scoped to to the bucket or buckets 
+for which you are creating lifecycle management rules.
+
+- :policy-action:`s3:PutLifecycleConfiguration`
+- :policy-action:`s3:GetLifecycleConfiguration`
+
+MinIO also requires the following administrative permissions on the cluster
+in which you are creating remote tiers for object transition lifecycle
+management rules:
+
+- :policy-action:`admin:SetTier`
+- :policy-action:`admin:ListTier`
+
+For example, the following policy provides permission for configuring object
+transition lifecycle management rules on any bucket in the cluster:.
+
+.. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
+   :language: json
+   :class: copyable
+
+Transition Permissions
+++++++++++++++++++++++
+
+Object transition lifecycle management rules require additional permissions
+on the remote storage tier. Specifically, MinIO requires the remote
+tier credentials provide read, write, list, and delete permissions.
+
+For example, if the remote storage tier implements AWS IAM policy-based
+access control, the following policy provides the necessary permission
+for transitioning objects into and out of the remote tier:
+
+.. literalinclude:: /extra/examples/LifecycleManagementUser.json
+   :language: json
+   :class: copyable
+
+Modify the ``Resource`` for the bucket into which MinIO tiers objects.
+
+Defer to the documentation for the supported tiering targets for more complete
+information on configuring users and permissions to support MinIO tiering:
+
+- :aws-docs:`Amazon S3 Permissions <service-authorization/latest/reference/list_amazons3.html#amazons3-actions-as-permissions>`
+- `Google Cloud Storage Access Control <https://cloud.google.com/storage/docs/access-control>`__
+- `Authorizing access to data in Azure storage <https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json>`__
+
+
+Syntax
+------
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following example updates the credentials for an existing remote tier called ``S3TIER`` on the ``myminio`` deployment.
+      
+      .. code-block:: shell
+         :class: copyable
+
+          mc ilm tier update myminio S3TIER --access-key ACCESS-KEY --secret-key SECRET-KEY  
+
+      After running this command, lifecycle management rules on the ``myminio`` deployment use the tier's new credentials to transition objects into the remote location.
+      Options not modified in the command maintain their existing configurations.
+
+   .. tab-item:: SYNTAX
+   
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ilm tier update TARGET                       \
+                            TIER_NAME                    \
+                            [--access-key value]         \
+                            [--secret-key value]         \
+                            [--use-aws-role]             \
+                            [--account-key value]        \
+                            [--credentials-file value] 
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+The command accepts the following arguments:
+      
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment.
+
+.. mc-cmd:: TIER_NAME
+   :required:
+
+   The name of the remote tier the command modifies. 
+   The value corresponds to the :mc-cmd:`mc ilm tier add TIER_NAME` specified when creating the remote tier.
+
+.. mc-cmd:: --access-key
+   :optional:
+      
+   The access key for a user on the remote S3 or MinIO tier. 
+   The user must have permission to perform read/write/list/delete operations on the remote bucket or bucket prefix.
+
+   This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``. 
+   This option has no effect for any other ``TIER_TYPE``.
+
+.. mc-cmd:: --secret-key
+   :optional:   
+
+   The secret key for a user on the remote ``s3`` or ``minio`` tier.
+
+   This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``. 
+   This option has no effect for any other ``TIER_TYPE``.
+
+.. mc-cmd:: --use-aws-role
+   :optional:
+
+   Use the access permission for the locally configured :iam-docs:`AWS Role <id_roles.html>`.
+
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``.
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --account-key
+   :optional:
+      
+   The account key for a user on a remote Azure tier.
+
+   **Required** for Azure tier types.
+   
+   Use this option to rotate the credentials for the :mc-cmd:`~mc ilm tier add --account-name` associated to the remote tier.
+
+   This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
+   This option has no effect for any other ``TIER_TYPE``.
+
+.. mc-cmd:: --credentials-file
+   :optional:
+      
+   **Required** for Google Cloud Storage tier types.
+      
+   The credential file for a user on the remote GCS tier. 
+   The user must have permission to perform read/write/list/delete operations on the remote bucket or bucket prefix.
+      
+   This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``gcs``. 
+   This option has no effect for any other ``TIER_TYPE``.
+   
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Rotate Credentials for an S3 Remote Tier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example updates the credentials for an S3 remote tier called ``S3TIER`` on the ``myminio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm tier update myminio S3TIER --access-key ACCESS-KEY --secret-key SECRET-KEY   
+
+- Replace ``S3TIER`` with the name for your Amazon Simple Storage Solution tier.
+- Replace ``ACCESS-KEY`` with the updated access key for your S3 storage.
+- Replace ``SECRET-KEY`` with the updated secret key for the access key provided.
+
+Rotate Credentials for an Azure Blob Storage Remote Tier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example updates the credentials for an Azure remote tier called ``AXTIER`` on the ``myminio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm tier update myminio AZTIER --account-key ACCOUNT-KEY  
+
+- Replace ``AZTIER`` with the name for your Azure tier.
+- Replace ``ACCOUNT-KEY`` with the updated key for your Azure storage.
+
+Rotate Credentials for a Google Cloud Storage Remote Tier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example updates the credentials for a Google Cloud Storage remote tier called ``GCSTIER`` on the ``myminio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+    mc ilm tier update myminio GCSTIER --credentials-file /path/to/credentials.json    
+
+
+- Replace ``GCSTIER`` with the name for your Google Cloud Storage tier.
+- Replace ``/path/to/credentials.json`` with the path of the updated credential file to use to access the remote storage.
+
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility
+
+Required Permissions
+--------------------
+
+For permissions required to modify a tier, refer to the :ref:`required permissions <minio-mc-ilm-tier-permissions>` on the parent command.

--- a/source/reference/minio-mc/mc-ilm-tier.rst
+++ b/source/reference/minio-mc/mc-ilm-tier.rst
@@ -1,0 +1,120 @@
+===============
+``mc ilm tier``
+===============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm tier
+
+.. versionchanged:: RELEASE.2022-12-24T15-21-38Z
+
+   :mc-cmd:`mc ilm tier` replaces ``mc admin tier``.
+
+Description
+-----------
+
+.. start-mc-ilm-tier-desc
+
+The :mc:`mc ilm tier` command and its subcommands configure a remote supported S3-compatible service for MinIO :ref:`Lifecycle Management: Object Transition ("Tiering") <minio-lifecycle-management-expiration>`. 
+
+.. end-mc-ilm-tier-desc
+
+After creating one or more tiers with this command, use :mc-cmd:`mc ilm rule` and its subcommands to create the rules that move objects to other storage.
+
+For more information, see the overview of :ref:`lifecycle management <minio-lifecycle-management>`.
+
+Subcommands
+-----------
+
+:mc-cmd:`mc ilm tier` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc ilm tier add`
+     - .. include:: /reference/minio-mc/mc-ilm-tier-add.rst
+          :start-after: start-mc-ilm-tier-add-desc
+          :end-before: end-mc-ilm-tier-add-desc
+
+   * - :mc:`~mc ilm tier check`
+     - .. include:: /reference/minio-mc/mc-ilm-tier-check.rst
+          :start-after: start-mc-ilm-tier-check-desc
+          :end-before: end-mc-ilm-tier-check-desc
+
+   * - :mc:`~mc ilm tier info`
+     - .. include:: /reference/minio-mc/mc-ilm-tier-info.rst
+          :start-after: start-mc-ilm-tier-info-desc
+          :end-before: end-mc-ilm-tier-info-desc
+
+   * - :mc:`~mc ilm tier ls`
+     - .. include:: /reference/minio-mc/mc-ilm-tier-ls.rst
+          :start-after: start-mc-ilm-tier-ls-desc
+          :end-before: end-mc-ilm-tier-ls-desc
+
+   * - :mc:`~mc ilm tier rm`
+     - .. include:: /reference/minio-mc/mc-ilm-tier-rm.rst
+          :start-after: start-mc-ilm-tier-rm-desc
+          :end-before: end-mc-ilm-tier-rm-desc
+
+   * - :mc:`~mc ilm tier update`
+     - .. include:: /reference/minio-mc/mc-ilm-tier-update.rst
+          :start-after: start-mc-ilm-tier-update-desc
+          :end-before: end-mc-ilm-tier-update-desc
+
+
+.. _minio-mc-ilm-tier-permissions:
+
+Required Permissions
+--------------------
+
+To create tiers for object transition, MinIO requires the following administrative permissions on the cluster:
+
+- :policy-action:`admin:SetTier`
+- :policy-action:`admin:ListTier`
+
+For example, the following policy provides permission for configuring object transition lifecycle management rules on any bucket in the cluster:.
+
+.. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
+   :language: json
+   :class: copyable
+
+Transition Permissions
+~~~~~~~~~~~~~~~~~~~~~~
+
+Object transition lifecycle management rules require additional permissions on the remote storage tier. 
+Specifically, MinIO requires the remote tier credentials provide read, write, list, and delete permissions.
+
+For example, if the remote storage tier implements AWS IAM policy-based access control, the following policy provides the necessary permission for transitioning objects into and out of the remote tier:
+
+.. literalinclude:: /extra/examples/LifecycleManagementUser.json
+   :language: json
+   :class: copyable
+
+Modify the ``Resource`` for the bucket into which MinIO tiers objects.
+
+Defer to the documentation for the supported tiering targets for more complete information on configuring users and permissions to support MinIO tiering:
+
+- :aws-docs:`Amazon S3 Permissions <service-authorization/latest/reference/list_amazons3.html#amazons3-actions-as-permissions>`
+- `Google Cloud Storage Access Control <https://cloud.google.com/storage/docs/access-control>`__
+- `Authorizing access to data in Azure storage <https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json>`__
+
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-ilm-tier-add
+   /reference/minio-mc/mc-ilm-tier-check
+   /reference/minio-mc/mc-ilm-tier-info
+   /reference/minio-mc/mc-ilm-tier-ls
+   /reference/minio-mc/mc-ilm-tier-rm
+   /reference/minio-mc/mc-ilm-tier-update

--- a/source/reference/minio-mc/mc-quota-clear.rst
+++ b/source/reference/minio-mc/mc-quota-clear.rst
@@ -1,0 +1,82 @@
+==================
+``mc quota clear``
+==================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc quota clear
+
+.. versionchanged:: RELEASE.2022-12-13T00-23-28Z
+
+   ``mc quota clear`` replaced ``mc admin bucket quota --clear``.
+
+Description
+-----------
+
+.. start-mc-quota-clear-desc
+
+The :mc-cmd:`mc quota clear` command removes a configured storage quota for a bucket.
+
+.. end-mc-quota-clear-desc
+
+
+Examples
+--------
+
+
+Clear Configured Bucket Quota
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc-cmd:`mc quota clear` flag to remove the quota from a bucket.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc quota clear TARGET/BUCKET
+
+- Replace ``TARGET`` with the :mc-cmd:`alias <mc alias>` of a configured MinIO deployment. 
+  Replace ``BUCKET`` with the name of the bucket on which to clear the quota.
+
+Syntax
+------
+
+:mc-cmd:`mc quota clear` has the following syntax:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc quota clear TARGET [ARGUMENTS]
+
+:mc-cmd:`mc quota clear` supports the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the bucket for which the command creates the quota. 
+   Specify the :mc-cmd:`alias <mc alias>` of the MinIO deployment as a prefix to the path. 
+   For example:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc quota clear play/mybucket
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+   
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-quota-info.rst
+++ b/source/reference/minio-mc/mc-quota-info.rst
@@ -1,0 +1,80 @@
+=================
+``mc quota info``
+=================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc quota info
+
+.. versionchanged:: RELEASE.2022-12-13T00-23-28Z
+
+   ``mc quota info`` replaced ``mc admin bucket quota``.
+
+Description
+-----------
+
+.. start-mc-quota-info-desc
+
+The :mc-cmd:`mc quota info` command displays the currently configured quota for a bucket.
+
+.. end-mc-quota-info-desc
+
+Examples
+--------
+
+
+Retrieve Bucket Quota Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc-cmd:`mc quota info` to retrieve the current quota configuration for a bucket:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc quota info TARGET/BUCKET
+
+Replace ``TARGET`` with the :mc-cmd:`alias <mc alias>` of a configured MinIO deployment. 
+Replace ``BUCKET`` with the name of the bucket on which to retrieve the quota.
+
+Syntax
+------
+
+:mc-cmd:`mc quota info` has the following syntax:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc quota info TARGET
+
+:mc-cmd:`mc quota info` supports the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the bucket for which the command creates the quota. 
+   Specify the :mc-cmd:`alias <mc alias>` of the MinIO deployment as a prefix to the path. 
+   For example:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc quota play/mybucket
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+   
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-quota-set.rst
+++ b/source/reference/minio-mc/mc-quota-set.rst
@@ -1,0 +1,130 @@
+================
+``mc quota set``
+================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc quota set
+
+.. versionchanged:: RELEASE.2022-12-13T00-23-28Z
+
+   ``mc quota set`` replaced ``mc admin bucket quota --hard``.
+
+Description
+-----------
+
+.. start-mc-quota-set-desc
+
+The :mc-cmd:`mc quota set` assigns a hard quota limit to a bucket beyond which MinIO does not allow writes.
+
+.. end-mc-quota-set-desc
+
+Units of Measurement
+~~~~~~~~~~~~~~~~~~~~
+
+The :mc-cmd:`mc quota set --size` flag accepts the following **case-insensitive** suffixes to represent the unit of the specified size value:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+   :width: 100%
+
+   * - Suffix
+     - Unit Size
+
+   * - ``k``
+     - KB (Kilobyte, 1000 Bytes)
+
+   * - ``m``
+     - MB (Megabyte, 1000 Kilobytes)
+
+   * - ``g``
+     - GB (Gigabyte, 1000 Megabytes)
+
+   * - ``t``
+     - TB (Terabyte, 1000 Gigabytes)
+
+   * - ``ki`` or ``kib``
+     - KiB (Kibibyte, 1024 Bites)
+
+   * - ``mi`` or ``mib``
+     - MiB (Mebibyte, 1024 Kibibytes)
+
+   * - ``gi`` or ``gib``
+     - GiB (Gibibyte, 1024 Mebibytes)
+
+   * - ``ti`` or ``tib``
+     - TiB (Tebibyte, 1024 Gibibytes)
+
+Omitting a suffix defaults to ``bytes``.
+
+Examples
+--------
+
+Configure a Hard Quota on a Bucket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc-cmd:`mc quota set` with the :mc-cmd:`~mc quota set --size` flag to specify a hard quota on a bucket. 
+Hard quotas prevent the bucket size from growing past the specified limit.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc quota set TARGET/BUCKET --size LIMIT
+
+- Replace ``TARGET`` with the :mc-cmd:`alias <mc alias>` of a configured MinIO deployment. 
+  Replace ``BUCKET`` with the name of the bucket on which to set the hard quota.
+
+- Replace ``LIMIT`` with the maximum size to which the bucket can grow as an integer and, as desired, a suffix. 
+  For example, to set a hard limit of 10 Terabytes, specify ``10t``.
+
+Syntax
+------
+
+:mc-cmd:`mc quota set` has the following syntax:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc quota set TARGET --size LIMIT
+
+:mc-cmd:`mc quota set` supports the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the bucket for which the command creates the quota. 
+   Specify the :mc-cmd:`alias <mc alias>` of the MinIO deployment as a prefix to the path. 
+   For example:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc quota set play/mybucket --size 10Gi
+
+.. mc-cmd:: --size
+   :required:
+
+   Sets a maximum limit to the bucket storage size. 
+   The MinIO server rejects any incoming ``PUT`` request whose contents would exceed the bucket's configured quota.
+
+   For example, a hard limit of ``10G`` would prevent adding any additional objects if the bucket reaches 10 gigabytes of size.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+   
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-rm.rst
+++ b/source/reference/minio-mc/mc-rm.rst
@@ -83,7 +83,7 @@ Parameters
 
 .. mc-cmd:: ALIAS
 
-   *Required* The :ref:`alias <alias>` of a MinIO deplyment and the full path to
+   *Required* The :ref:`alias <alias>` of a MinIO deployment and the full path to
    the object to remove. For example:
 
    .. code-block:: shell
@@ -148,7 +148,7 @@ Parameters
    
 
    *Optional* The encryption key to use for performing Server-Side Encryption
-   with Client Keys (SSE-C). Specify comma seperated key-value pairs as
+   with Client Keys (SSE-C). Specify comma separated key-value pairs as
    ``KEY=VALUE,...``.
    
    - For ``KEY``, specify the S3-compatible service 


### PR DESCRIPTION
This PR applies updates to numerous files to address changes in the two December 2022 `mc` releases.

- Deprecates `mc admin bucket quota` and links to new commands
- Adds `mc quota set | clear | info` commands
- Adds `attach | detach` subcommands to `mc admin idp ldap policy`
- Updates list of call types available to `mc admin trace`
- Updates `mc` page with new commands
- Fixes minor errors in `mc cp`
- Adds `--limit-*` flags to global flag options
- Adds `--versions` flag to `mc find`
    
Closes #685

- Updates ilm commands for new structure for tiers and rules
    
    - Deprecates `mc admin tier`
    - Deprecates `mc ilm add | edit | export | import | ls | rm` commands
    - Adds new `mc ilm rule` and six subcommands
    - Adds new `mc ilm tier` and six subcommands
    - Updates references to ilm and admin tier  commands throughout docs
    - Adds new deprecated commands page
    - Adds `mc ilm rule` and `mc ilm tier` holding pages with toctrees

- Closes #691
- Closes #662