### PR TITLE
added krew upgrade command

### DIFF
--- a/source/includes/k8s/install-minio-kubectl-plugin.rst
+++ b/source/includes/k8s/install-minio-kubectl-plugin.rst
@@ -16,6 +16,13 @@ You can install the MinIO plugin using either the Kubernetes Krew plugin manager
          kubectl krew update
          kubectl krew install minio
 
+      If you want to update the MinIO plugin with Krew, use the following command:
+
+      .. code-block:: shell
+         :class copyable
+
+         kubectl krew upgrade minio
+
       You can validate the installation of the MinIO plugin using the following command:
 
       .. code-block:: shell


### PR DESCRIPTION
Ran into this while looking at <https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/upgrade-minio-operator.html>.
The headline of point "3" states "Download the Latest Stable Version of the MinIO Kubernetes Plugin", but it actually includes just an installation guide.
Therefore extended the included installation guide with guideline how to update the plugin with krew.

Signed-off-by: Tim Beermann <beermann@osism.tech>
