### PR TITLE
DOCS-699: improve documentation on storage classes for remote targets

### DIFF
--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -26,7 +26,7 @@ Object Transition ("Tiering")
 MinIO supports creating object transition lifecycle management rules, where MinIO can automatically move an object to a remote storage "tier". 
 MinIO supports any of the following remote tier targets:
 
-- :ref:`MinIO or other S3-compatible storage <minio-lifecycle-management-transition-to-s3>`
+- :ref:`MinIO <minio-lifecycle-management-transition-to-minio>`
 - :ref:`Amazon S3 <minio-lifecycle-management-transition-to-s3>`
 - :ref:`Google Cloud Storage <minio-lifecycle-management-transition-to-gcs>`
 - :ref:`Microsoft Azure Blob Storage 
@@ -126,6 +126,7 @@ Consider regularly checking cluster metrics, capacity, and resource usage to ens
 .. toctree::
    :hidden:
 
+   /administration/object-management/transition-objects-to-minio.rst
    /administration/object-management/transition-objects-to-s3.rst
    /administration/object-management/transition-objects-to-gcs.rst
    /administration/object-management/transition-objects-to-azure.rst

--- a/source/administration/object-management/transition-objects-to-azure.rst
+++ b/source/administration/object-management/transition-objects-to-azure.rst
@@ -193,13 +193,16 @@ The example above uses the following arguments:
 
    * - :mc-cmd:`STORAGE_CLASS <mc ilm tier add --storage-class>`
      - The Azure access tier MinIO applies to objects transitioned to the Azure container.
-       MinIO *requires* the remote Azure access tier implement immediate object retrieval with no rehydration or manual intervention required.
-       MinIO recommends one of the following Azure archive tiers:
+
+       MinIO tiering behavior depends on the remote storage returning objects immediately (milliseconds to seconds) upon request.
+       MinIO therefore *cannot* support remote storage which requires rehydration, wait periods, or manual intervention.
+
+       The following Azure access tiers meet MinIO's requirements as a remote tier:
 
        - ``Hot``
        - ``Cool``
 
-       See :azure-docs:`Hot, cool, and archive access tiers for blob data <storage/blobs/access-tiers-overview.html>`
+       For more information, see :azure-docs:`Hot, cool, and archive access tiers for blob data <storage/blobs/access-tiers-overview.html>`.
 
 3) Create and Apply the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/object-management/transition-objects-to-azure.rst
+++ b/source/administration/object-management/transition-objects-to-azure.rst
@@ -75,6 +75,15 @@ Refer to the `Azure RBAC
 documentation for more complete guidance on configuring the required
 permissions.
 
+Remote Bucket Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MinIO only supports Azure blob storage with locally redundant storage (LRS) as the remote storage resource.
+When :azure-docs:`creating the Azure storage account <common/storage-account-create>`, ensure the storage account corresponds to either Standard or Premium blob storage with the LRS redundancy option.
+The Azure Go SDK API used by MinIO does not support any other redundancy options.
+
+For more information on Azure storage accounts, see :azure-docs:`Storage accounts <storage/common/storage-account-overview#types-of-storage-accounts>`.
+
 Considerations
 --------------
 
@@ -101,6 +110,18 @@ Availability of Remote Data
 .. include:: /includes/common-minio-tiering.rst
    :start-after: start-transition-data-loss-desc
    :end-before: end-transition-data-loss-desc
+
+Remote Storage Account and Container Must Exist
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create the remote Azure storage account and container *prior* to configuring lifecycle management tiers or rules using that resource as the target.
+
+MinIO only supports the Standard and Premium blob storage account types.
+
+If you set a default Storage Account :azure-docs:`default access tier <storage/blobs/access-tiers-online-manage>`, MinIO uses that default *if* you do not specify a :mc-cmd:`storage class <mc ilm tier add --storage-class>` when defining the remote tier.
+Ensure you document the settings of both your Azure storage account and MinIO tiering configuration to avoid any potential confusion, misconfiguration, or other unexpected outcomes.
+
+For more information on Azure blob storage configuration, see :azure-docs:`Blob Storage resources <blobs/storage-blobs-introduction#blob-storage-resources>`.
 
 Procedure
 ---------
@@ -148,6 +169,17 @@ The example above uses the following arguments:
        remote storage tier. Specify the name in all-caps, e.g. ``AZURE_TIER``.
        This value is required in the next step.
 
+   * - :mc-cmd:`ACCOUNT <mc ilm tier add --account-name>`
+     - The account name MinIO uses to access the bucket. The account name
+       *must* correspond to an :abbr:`Azure (Microsoft Azure)` user with the
+       required :ref:`permissions
+       <minio-lifecycle-management-transition-to-azure-permissions-remote>`.
+
+       You cannot change this account name after creating the tier.
+
+   * - :mc-cmd:`KEY <mc ilm tier add --account-key>`
+     - The corresponding key for the specified ``ACCOUNT``.
+
    * - :mc-cmd:`BUCKET <mc ilm tier add --bucket>`
      - The name of the bucket on the :abbr:`Azure (Microsoft Azure)` storage
        backend to which MinIO transitions objects.
@@ -162,20 +194,18 @@ The example above uses the following arguments:
        MinIO recommends specifying this optional prefix for remote storage tiers
        which contain other data, including transitioned objects from other MinIO
        deployments. This prefix should provide a clear reference back to the
-       source MinIO deployment to faciliate ease of operations related to
+       source MinIO deployment to facilitate ease of operations related to
        diagnostics, maintenance, or disaster recovery.
 
-   * - :mc-cmd:`ACCOUNT <mc ilm tier add --account-name>`
-     - The account name MinIO uses to access the bucket. The account name
-       *must* correspond to an :abbr:`Azure (Microsoft Azure)` user with the
-       required :ref:`permissions
-       <minio-lifecycle-management-transition-to-azure-permissions-remote>`.
+   * - :mc-cmd:`STORAGE_CLASS <mc ilm tier add --storage-class>`
+     - The Azure access tier to which MinIO transitions objects. 
+       MinIO *requires* the remote Azure access tier implement immediate object retrieval with no rehydration or manual intervention required.
+       MinIO recommends one of the following Azure archive tiers:
 
-       You cannot change this account name after creating the tier.
+       - ``Hot``
+       - ``Cool``
 
-   * - :mc-cmd:`KEY <mc ilm tier add --account-key>`
-     - The corresponding key for the specified ``ACCOUNT``.
-
+       See :azure-docs:`Hot, cool, and archive access tiers for blob data <storage/blobs/access-tiers-overview.html>`
 
 3) Create and Apply the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/object-management/transition-objects-to-gcs.rst
+++ b/source/administration/object-management/transition-objects-to-gcs.rst
@@ -80,7 +80,7 @@ Remote Bucket Must Exist
 
 Create the remote GCS bucket *prior* to configuring lifecycle management tiers or rules using that bucket as the target.
 
-If you set a default GCS :gcp-docs:`storage class <storage-classes>`, MinIO uses that default *if* you do not specify a :mc-cmd:`storage class <mc ilm tier add --storage-class>` when defining the remote tier.
+If you set a default GCS :gcs-docs:`storage class <storage-classes>`, MinIO uses that default *if* you do not specify a :mc-cmd:`storage class <mc ilm tier add --storage-class>` when defining the remote tier.
 Ensure you document the settings of both your GCS bucket and MinIO tiering configuration to avoid any potential confusion, misconfiguration, or other unexpected outcomes.
 
 Considerations
@@ -132,7 +132,8 @@ service as the remote storage tier:
    mc ilm tier add gcs TARGET TIER_NAME \
       --bucket BUCKET \
       --prefix PREFIX \
-      --credentials-file CREDENTIALS
+      --credentials-file CREDENTIALS \
+      --storage-class STORAGE_CLASS
 
 The example above uses the following arguments:
 
@@ -153,14 +154,6 @@ The example above uses the following arguments:
        remote storage tier. Specify the name in all-caps, e.g. ``GCS_TIER``.
        This value is required in the next step.
 
-   * - :mc-cmd:`CREDENTIALS <mc ilm tier add --credentials-file>`
-     - The `credential file
-       <https://cloud.google.com/docs/authentication/getting-started>`__ for a
-       user on the remote GCS tier. The specified user credentials *must*
-       correspond to a GCS user with the required
-       :ref:`permissions 
-       <minio-lifecycle-management-transition-to-gcs-permissions-remote>`.
-
    * - :mc-cmd:`BUCKET <mc ilm tier add --bucket>`
      - The name of the bucket on the :abbr:`GCS (Google Cloud Storage)` storage
        backend to which MinIO transitions objects.
@@ -175,8 +168,27 @@ The example above uses the following arguments:
        MinIO recommends specifying this optional prefix for remote storage tiers
        which contain other data, including transitioned objects from other MinIO
        deployments. This prefix should provide a clear reference back to the
-       source MinIO deployment to faciliate ease of operations related to
+       source MinIO deployment to facilitate ease of operations related to
        diagnostics, maintenance, or disaster recovery.
+
+   * - :mc-cmd:`CREDENTIALS <mc ilm tier add --credentials-file>`
+     - The `credential file
+       <https://cloud.google.com/docs/authentication/getting-started>`__ for a
+       user on the remote GCS tier. The specified user credentials *must*
+       correspond to a GCS user with the required
+       :ref:`permissions 
+       <minio-lifecycle-management-transition-to-gcs-permissions-remote>`.
+
+   * - :mc-cmd:`STORAGE_CLASS <mc ilm tier add --storage-class>`
+     - The GCS storage class MinIO applies to objects transitioned to the GCS bucket.
+       MinIO *requires* the remote GCS storage class implement immediate object retrieval with no rehydration or manual intervention required.
+       MinIO recommends on of the following GCS storage classes:
+
+       - ``STANDARD``
+       - ``NEARLINE``
+       - ``COLDLINE``
+
+       For more information, see :gcs-docs:`GCS storage class <storage-classes>`.
 
 
 3) Create and Apply the Transition Rule

--- a/source/administration/object-management/transition-objects-to-gcs.rst
+++ b/source/administration/object-management/transition-objects-to-gcs.rst
@@ -180,9 +180,12 @@ The example above uses the following arguments:
        <minio-lifecycle-management-transition-to-gcs-permissions-remote>`.
 
    * - :mc-cmd:`STORAGE_CLASS <mc ilm tier add --storage-class>`
-     - The GCS storage class MinIO applies to objects transitioned to the GCS bucket.
-       MinIO *requires* the remote GCS storage class implement immediate object retrieval with no rehydration or manual intervention required.
-       MinIO recommends on of the following GCS storage classes:
+     - The :abbr:`GCS (Google Cloud Storage)` storage class MinIO applies to objects transitioned to the GCS bucket.
+
+       MinIO tiering behavior depends on the remote storage returning objects immediately (milliseconds to seconds) upon request.
+       MinIO therefore *cannot* support remote storage which requires rehydration, wait periods, or manual intervention.
+
+       The following GCS storage classes meet MinIO's requirements as a remote tier:
 
        - ``STANDARD``
        - ``NEARLINE``

--- a/source/administration/object-management/transition-objects-to-gcs.rst
+++ b/source/administration/object-management/transition-objects-to-gcs.rst
@@ -75,6 +75,14 @@ Refer to the `GCS IAM permissions
 documentation for more complete guidance on configuring the required
 permissions.
 
+Remote Bucket Must Exist
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create the remote GCS bucket *prior* to configuring lifecycle management tiers or rules using that bucket as the target.
+
+If you set a default GCS :gcp-docs:`storage class <storage-classes>`, MinIO uses that default *if* you do not specify a :mc-cmd:`storage class <mc ilm tier add --storage-class>` when defining the remote tier.
+Ensure you document the settings of both your GCS bucket and MinIO tiering configuration to avoid any potential confusion, misconfiguration, or other unexpected outcomes.
+
 Considerations
 --------------
 

--- a/source/administration/object-management/transition-objects-to-minio.rst
+++ b/source/administration/object-management/transition-objects-to-minio.rst
@@ -190,10 +190,10 @@ The example above uses the following arguments:
        diagnostics, maintenance, or disaster recovery.
 
    * - :mc-cmd:`STORAGE_CLASS <mc ilm tier add --storage-class>`
-     - The MinIO storage class to which MinIO transitions objects. Specify
-       one of the following supported storage classes:
+     - The :ref:`Erasure Coding storage class <minio-ec-storage-class>` MinIO applies to objects transitions to the remote MinIO bucket. 
+       Specify one of the following supported storage classes:
 
-       - ``STANDARD``
+       - ``STANDARD`` *Recommended*
        - ``REDUCED``
 
    * - :mc-cmd:`REGION <mc ilm tier add --region>`

--- a/source/administration/object-management/transition-objects-to-minio.rst
+++ b/source/administration/object-management/transition-objects-to-minio.rst
@@ -1,8 +1,8 @@
-.. _minio-lifecycle-management-transition-to-s3:
+.. _minio-lifecycle-management-transition-to-minio:
 
-===================================
-Transition Objects from MinIO to S3
-===================================
+=============================================
+Transition Objects to Remote MinIO Deployment
+=============================================
 
 .. default-domain:: minio
 
@@ -10,11 +10,8 @@ Transition Objects from MinIO to S3
    :local:
    :depth: 2
 
-The procedure on this page creates a new object lifecycle management rule that
-transition objects from a MinIO bucket to a remote storage tier on the Amazon
-Web Services S3 storage backend *or* an S3-compatible service. This procedure
-supports use cases such as tiering objects to low-cost or archival storage after
-a certain time period or calendar date.
+The procedure on this page creates a new object lifecycle management rule that transitions objects from a bucket on a primary MinIO deployment to a bucket remote MinIO deployment.
+This procedure supports cost-management strategies such as tiering objects from a "hot" MinIO deployment using NVMe storage to a "warm" MinIO deployment using SSD .
 
 .. todo: diagram
 
@@ -32,13 +29,13 @@ instructions on downloading and installing ``mc``.
 Use the :mc:`mc alias` command to create an alias for the source MinIO cluster.
 Alias creation requires specifying an access key for a user on the source and
 destination clusters. The specified users must have :ref:`permissions
-<minio-lifecycle-management-transition-to-s3-permissions>` for configuring and
+<minio-lifecycle-management-transition-to-minio-permissions>` for configuring and
 applying transition operations.
 
-.. _minio-lifecycle-management-transition-to-s3-permissions:
+.. _minio-lifecycle-management-transition-to-minio-permissions:
 
-Required MinIO Permissions
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Required Source MinIO Permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 MinIO requires the following permissions scoped to the bucket or buckets 
 for which you are creating lifecycle management rules.
@@ -54,16 +51,16 @@ management rules:
 - :policy-action:`admin:ListTier`
 
 For example, the following policy provides permission for configuring object
-transition lifecycle management rules on any bucket in the cluster:.
+transition lifecycle management rules on any bucket in the cluster:
 
 .. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
    :language: json
    :class: copyable
 
-.. _minio-lifecycle-management-transition-to-s3-permissions-remote:
+.. _minio-lifecycle-management-transition-to-minio-permissions-remote:
 
-Required S3 Permissions
-~~~~~~~~~~~~~~~~~~~~~~~
+Required Remote MinIO Permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Object transition lifecycle management rules require additional permissions
 on the remote storage tier. Specifically, MinIO requires the remote
@@ -79,15 +76,14 @@ for transitioning objects into and out of the remote tier:
 
 Modify the ``Resource`` for the bucket into which MinIO tiers objects.
 
-Refer to the :aws-docs:`Amazon S3 Permissions 
-<service-authorization/latest/reference/list_amazons3.html#amazons3-actions-as-permissions>` 
-documentation for more complete guidance on configuring the required
-permissions.
+Refer to the :ref:`minio-policy` documentation for more complete guidance on configuring the required permissions.
 
 Remote Bucket Must Exist
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create the remote S3 bucket *prior* to configuring lifecycle management tiers or rules using that bucket as the target.
+Create the remote bucket *prior* to configuring lifecycle management tiers or rules using that bucket as the target.
+
+If the remote bucket contains existing data, use the :mc-cmd:`prefix <mc ilm tier add --prefix>` feature to isolate transitioned objects from any other objects on that bucket.
 
 Considerations
 --------------
@@ -120,7 +116,7 @@ Procedure
 1) Configure User Accounts and Policies for Lifecycle Management
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. |permissions| replace:: :ref:`permissions <minio-lifecycle-management-transition-to-s3-permissions>`
+.. |permissions| replace:: :ref:`permissions <minio-lifecycle-management-transition-to-minio-permissions>`
 
 .. include:: /includes/common-minio-tiering.rst
    :start-after: start-create-transition-user-desc
@@ -129,13 +125,13 @@ Procedure
 2) Configure the Remote Storage Tier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc:`mc ilm tier add` command to add an Amazon S3 service as the
+Use the :mc:`mc ilm tier add` command to add the remote MinIO deployment as the
 new remote storage tier:
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm tier add s3 TARGET TIER_NAME  \
+   mc ilm tier add minio TARGET TIER_NAME  \
       --endpoint https://HOSTNAME       \
       --access-key ACCESS_KEY           \
       --secret-key SECRET_KEY           \
@@ -154,30 +150,30 @@ The example above uses the following arguments:
    * - Argument
      - Description
    
-   * - :mc-cmd:`TARGET <mc ilm tier add TARGET>`
+   * - :mc-cmd:`ALIAS <mc ilm tier add TARGET>`
      - The :mc:`alias <mc alias>` of the MinIO deployment on which to configure
-       the S3 remote tier.
+       the MinIO remote tier.
    
    * - :mc-cmd:`TIER_NAME <mc ilm tier add TIER_NAME>`
-     - The name to associate with the new S3 remote storage tier. Specify the
-       name in all-caps, e.g. ``S3_TIER``. This value is required in the next
+     - The name to associate with the new MinIO remote storage tier. Specify the
+       name in all-caps, e.g. ``MINIO_WARM_TIER``. This value is required in the next
        step.
 
    * - :mc-cmd:`HOSTNAME <mc ilm tier add --endpoint>`
-     - The URL endpoint for the S3 storage backend.
+     - The URL endpoint for the MinIO storage backend.
 
    * - :mc-cmd:`ACCESS_KEY <mc ilm tier add --access-key>`
-     - The S3 access key MinIO uses to access the bucket. The
+     - The access key MinIO uses to access the bucket. The
        access key *must* correspond to an IAM user with the 
        required 
        :ref:`permissions 
-       <minio-lifecycle-management-transition-to-s3-permissions-remote>`.
+       <minio-lifecycle-management-transition-to-minio-permissions-remote>`.
 
    * - :mc-cmd:`SECRET_KEY <mc ilm tier add --secret-key>`
      - The corresponding secret key for the specified ``ACCESS_KEY``.
 
    * - :mc-cmd:`BUCKET <mc ilm tier add --bucket>`
-     - The name of the bucket on the S3 storage backend to which MinIO
+     - The name of the bucket on the remote MinIO deployment to which the ``SOURCE``
        transitions objects.
 
    * - :mc-cmd:`PREFIX <mc ilm tier add --prefix>`
@@ -190,26 +186,21 @@ The example above uses the following arguments:
        MinIO recommends specifying this optional prefix for remote storage tiers
        which contain other data, including transitioned objects from other MinIO
        deployments. This prefix should provide a clear reference back to the
-       source MinIO deployment to faciliate ease of operations related to
+       source MinIO deployment to facilitate ease of operations related to
        diagnostics, maintenance, or disaster recovery.
 
    * - :mc-cmd:`STORAGE_CLASS <mc ilm tier add --storage-class>`
-     - The S3 storage class to which MinIO transitions objects. 
-       MinIO *requires* the remote storage class implement immediate object retrieval with no rehydration or manual intervention required.
-       MinIO recommends one of the following S3 storage classes:
+     - The MinIO storage class to which MinIO transitions objects. Specify
+       one of the following supported storage classes:
 
        - ``STANDARD``
-       - ``STANDARD_IA``
-       - ``STANDARD_ONEZONE``
-
-       Omit this value to use the default storage class for the bucket.
-       Specifying this value overrides the bucket storage class.
-
-       See :s3-docs:`Using Amazon S3 storage classes <storage-class-intro.html>`
+       - ``REDUCED``
 
    * - :mc-cmd:`REGION <mc ilm tier add --region>`
-     - The AWS S3 region of the specified ``BUCKET``. You can safely omit this
-       option if the ``HOSTNAME`` includes the region.
+     - The MinIO region of the specified ``BUCKET``.
+
+       MinIO deployments typically do not require setting a region as part of setup.
+       Only include this option if you explicitly set the ``MINIO_SITE_REGION`` configuration setting for the deployment.
 
 3) Create and Apply the Transition Rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/object-management/transition-objects-to-minio.rst
+++ b/source/administration/object-management/transition-objects-to-minio.rst
@@ -10,7 +10,7 @@ Transition Objects to Remote MinIO Deployment
    :local:
    :depth: 2
 
-The procedure on this page creates a new object lifecycle management rule that transitions objects from a bucket on a primary MinIO deployment to a bucket remote MinIO deployment.
+The procedure on this page creates a new object lifecycle management rule that transitions objects from a bucket on a primary MinIO deployment to a bucket on a remote MinIO deployment.
 This procedure supports cost-management strategies such as tiering objects from a "hot" MinIO deployment using NVMe storage to a "warm" MinIO deployment using SSD .
 
 .. todo: diagram

--- a/source/administration/object-management/transition-objects-to-minio.rst
+++ b/source/administration/object-management/transition-objects-to-minio.rst
@@ -11,7 +11,7 @@ Transition Objects to Remote MinIO Deployment
    :depth: 2
 
 The procedure on this page creates a new object lifecycle management rule that transitions objects from a bucket on a primary MinIO deployment to a bucket on a remote MinIO deployment.
-This procedure supports cost-management strategies such as tiering objects from a "hot" MinIO deployment using NVMe storage to a "warm" MinIO deployment using SSD .
+This procedure supports cost-management strategies such as tiering objects from a "hot" MinIO deployment using NVMe storage to a "warm" MinIO deployment using SSD.
 
 .. todo: diagram
 
@@ -67,7 +67,7 @@ on the remote storage tier. Specifically, MinIO requires the remote
 tier credentials provide read, write, list, and delete permissions for the
 remote bucket.
 
-For example, the following policy provides the necessary permission
+For example, the following policy on the remote MinIO deployment provides the necessary permission
 for transitioning objects into and out of the remote tier:
 
 .. literalinclude:: /extra/examples/LifecycleManagementUser.json

--- a/source/administration/object-management/transition-objects-to-s3.rst
+++ b/source/administration/object-management/transition-objects-to-s3.rst
@@ -195,8 +195,11 @@ The example above uses the following arguments:
 
    * - :mc-cmd:`STORAGE_CLASS <mc ilm tier add --storage-class>`
      - The S3 storage class to which MinIO transitions objects. 
-       MinIO *requires* the remote storage class implement immediate object retrieval with no rehydration or manual intervention required.
-       MinIO recommends one of the following S3 storage classes:
+
+       MinIO tiering behavior depends on the remote storage returning objects immediately (milliseconds to seconds) upon request.
+       MinIO therefore *cannot* support remote storage which requires rehydration, wait periods, or manual intervention.
+
+       The following S3 storage classes meet MinIO's requirements as a remote tier:
 
        - ``STANDARD``
        - ``STANDARD_IA``
@@ -205,7 +208,7 @@ The example above uses the following arguments:
        Omit this value to use the default storage class for the bucket.
        Specifying this value overrides the bucket storage class.
 
-       See :s3-docs:`Using Amazon S3 storage classes <storage-class-intro.html>`
+       For more information, see :s3-docs:`Using Amazon S3 storage classes <storage-class-intro.html>`.
 
    * - :mc-cmd:`REGION <mc ilm tier add --region>`
      - The AWS S3 region of the specified ``BUCKET``. You can safely omit this

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -72,6 +72,7 @@ extlinks = {
     'minio-docs'      : ('https://min.io/docs/%s?ref=docs-internal',''),
     'gke-docs'        : ('https://cloud.google.com/kubernetes-engine/docs/%s',''),
     'gcp-docs'        : ('https://cloud.google.com/compute/docs/%s',''),
+    'gcs-docs'        : ('https://cloud.google.com/storage/docs/%s',''),
     'aks-docs'        : ('https://learn.microsoft.com/en-us/azure/aks/%s',''),
     'azure-docs'      : ('https://learn.microsoft.com/en-us/azure/%s',''),
 

--- a/source/includes/common-minio-tiering.rst
+++ b/source/includes/common-minio-tiering.rst
@@ -111,9 +111,11 @@ This tutorial includes the necessary syntax for setting this prefix.
 
 .. start-transition-data-loss-desc
 
-MinIO creates metadata for each transitioned object that identifies its location
-on the remote storage. This metadata is required for accessing the object, such
-that applications cannot access a transition object independent of MinIO.
+MinIO tiering behavior depends on the remote storage returning objects immediately (milliseconds to seconds) upon request.
+MinIO therefore *cannot* support remote storage which requires rehydration, wait periods, or manual intervention.
+
+MinIO creates metadata for each transitioned object that identifies its location on the remote storage. 
+Applications cannot trivially identify and access a transitioned object independent of MinIO.
 Availability of the transitioned data therefore depends on the same core
 protections that :ref:`erasure coding <minio-erasure-coding>` and distributed
 deployment topologies provide for all objects on the MinIO deployment. Using

--- a/source/reference/minio-mc/mc-ilm-tier-add.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-add.rst
@@ -225,6 +225,8 @@ The command accepts the following arguments:
 
    The bucket on the remote tier to which MinIO transitions objects.
 
+   For ``azure`` remote tiers, this value corresponds to the :azure-docs:`Container name <storage/blobs/storage-blobs-introduction#containers>`
+
 .. mc-cmd:: --prefix
    :optional:
 
@@ -235,16 +237,37 @@ The command accepts the following arguments:
 .. mc-cmd:: --storage-class
    :optional:
 
-   The AWS storage class to use for objects transitioned by MinIO. 
-   MinIO supports only the following storage classes:
+   The storage class to apply to objects transitioned by MinIO to the remote bucket.
+   The specified storage class varies depending on the ``TIER_TYPE``.
+   MinIO object transition *requires* the remote storage class to support immediate retrieval (e.g. no rehydration or manual intervention required).
+   
+   Select the tab corresponding to the ``TIER_TYPE`` to view the recommended storage classes:
 
-   - ``STANDARD``
-   - ``REDUCED_REDUNDANCY``
+   .. tab-set::
 
-   Defaults to ``STANDARD`` if omitted. 
+      .. tab-item:: minio
 
-   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` or ``minio``.
-   This option has no effect for any other value of ``TIER_TYPE``.
+         - ``STANDARD`` *Recommended*
+         - ``REDUCED``
+
+      .. tab-item:: s3
+
+         - ``STANDARD``
+         - ``STANDARD_IA``
+         - ``ONEZONE_IA``
+
+      .. tab-item:: gcs
+
+         - ``STANDARD``
+         - ``NEARLINE``
+         - ``COLDLINE``
+
+      .. tab-item:: azure 
+         
+         - ``Hot``
+         - ``Cool``
+
+   If omitted, objects use the default storage class defined for the remote bucket.
 
 .. mc-cmd:: --region
    :optional:

--- a/source/reference/minio-mc/mc-ilm-tier-add.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-add.rst
@@ -194,19 +194,20 @@ The command accepts the following arguments:
 .. mc-cmd:: --account-name
    :optional:
 
-   The account name for a user on the remote Azure tier. 
-   The user must have permission to perform read/write/list/delete operations on the remote bucket or bucket prefix.
-      
+   The :azure-docs:`Storage Account <storage/common/storage-account-overview>` to use as the remote storage resource.
+
    Required if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
    This option has no effect for any other value of ``TIER_TYPE``.
 
-   MinIO does *not* support changing the account name associated to an Azure remote tier. 
-   Azure storage backends are tied to the account, such that changing the account would change the storage backend and prevent access to any objects transitioned to the original account/backend.
+   MinIO does *not* support changing the storage account name associated to an Azure remote tier. 
+   Azure storage backends are tied to the storage account, such that changing this value would change the storage backend and prevent access to any objects transitioned to the original account/backend.
 
 .. mc-cmd:: --account-key
    :optional:
 
-   The account key for the :mc-cmd:`~mc ilm tier add --account-name` associated to the remote Azure tier.
+   The corresponding shared account key for the :mc-cmd:`~mc ilm tier add --account-name` associated to the remote Azure tier.
+
+   The account key must have an assigned Azure policy with the required :ref:`permissions <minio-lifecycle-management-transition-to-azure-permissions-remote>`.
 
    Required if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
    This option has no effect for any other value of ``TIER_TYPE``.

--- a/source/reference/minio-mc/mc-ilm-tier-add.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-add.rst
@@ -238,11 +238,13 @@ The command accepts the following arguments:
 .. mc-cmd:: --storage-class
    :optional:
 
+   The storage class ("access tier" for Microsoft Azure) MinIO applies to objects transitioned to the remote bucket.
+
    The storage class to apply to objects transitioned by MinIO to the remote bucket.
-   The specified storage class varies depending on the ``TIER_TYPE``.
-   MinIO object transition *requires* the remote storage class to support immediate retrieval (e.g. no rehydration or manual intervention required).
+   MinIO tiering behavior depends on the remote storage returning objects immediately (milliseconds to seconds) upon request.
+   MinIO therefore *cannot* support remote storage which requires rehydration, wait periods, or manual intervention.
    
-   Select the tab corresponding to the ``TIER_TYPE`` to view the recommended storage classes:
+   Select the tab corresponding to the ``TIER_TYPE`` for a list of supported values for each tier:
 
    .. tab-set::
 
@@ -251,11 +253,15 @@ The command accepts the following arguments:
          - ``STANDARD`` *Recommended*
          - ``REDUCED``
 
+         For more information, see :ref:`Erasure Coding storage class <minio-ec-storage-class>`.
+
       .. tab-item:: s3
 
          - ``STANDARD``
          - ``STANDARD_IA``
          - ``ONEZONE_IA``
+
+         For more information, see :s3-docs:`Using Amazon S3 storage classes <storage-class-intro.html>`.
 
       .. tab-item:: gcs
 
@@ -263,10 +269,14 @@ The command accepts the following arguments:
          - ``NEARLINE``
          - ``COLDLINE``
 
+         For more information, see :gcs-docs:`GCS storage class <storage-classes>`.
+
       .. tab-item:: azure 
          
          - ``Hot``
          - ``Cool``
+
+         For more information, see :azure-docs:`Hot, cool, and archive access tiers for blob data <storage/blobs/access-tiers-overview.html>`.
 
    If omitted, objects use the default storage class defined for the remote bucket.
 


### PR DESCRIPTION
Closes #699 

# Summary

Improves documentation around setting a storage class or other remote storage type when configuring the remote tier for ILM rules.

# Staged

- http://192.241.195.202:9000/staging/DOCS-699/linux/reference/minio-mc/mc-ilm-tier-add.html#mc.ilm.tier.add.-storage-class
- http://192.241.195.202:9000/staging/DOCS-699/linux/administration/object-management/transition-objects-to-minio.html
- http://192.241.195.202:9000/staging/DOCS-699/linux/administration/object-management/transition-objects-to-s3.html#configure-the-remote-storage-tier
- http://192.241.195.202:9000/staging/DOCS-699/linux/administration/object-management/transition-objects-to-gcs.html#configure-the-remote-storage-tier
- http://192.241.195.202:9000/staging/DOCS-699/linux/administration/object-management/transition-objects-to-azure.html#configure-the-remote-storage-tier

Also added some guidance up at the top around the remote bucket.