### PR TITLE
Updates for mc RELEASE.2023-01-11T03-14-16Z

### DIFF
--- a/source/operations/data-recovery/recover-after-site-failure.rst
+++ b/source/operations/data-recovery/recover-after-site-failure.rst
@@ -47,14 +47,14 @@ If a peer site fails, such as due to a major disaster or long power outage, you 
 The following procedure can restore data in scenarios where :ref:`site replication <minio-site-replication-overview>` was active prior to the site loss.
 This procedure assumes a *total loss* of one or more peer sites versus replication lag or delays due to latency or transient deployment downtime.
 
-1. Remove the failed site from the MinIO site replication configuration using the :mc-cmd:`mc admin replicate remove` command with the ``--force`` option. 
+1. Remove the failed site from the MinIO site replication configuration using the :mc-cmd:`mc admin replicate rm` command with the ``--force`` option. 
    
    The following command force-removes an unhealthy peer site from the replication configuration:
 
    .. code-block:: shell
       :class: copyable
 
-      mc admin replicate remove HEALTHY_PEER UNHEALTHY_PEER --force
+      mc admin replicate rm HEALTHY_PEER UNHEALTHY_PEER --force
 
    - Replace ``HEALTHY_PEER`` with the :ref:`alias <alias>` of any healthy peer in the replication configuration
 
@@ -70,7 +70,7 @@ This procedure assumes a *total loss* of one or more peer sites versus replicati
 
    .. warning::
 
-      The :mc-cmd:`mc admin replicate remove --force` command only operates on the online or healthy nodes in the site replication configuration.
+      The :mc-cmd:`mc admin replicate rm --force` command only operates on the online or healthy nodes in the site replication configuration.
       The removed offline MinIO deployment retains its original replication configuration, such that if the deployment resumes normal operations it would continue replication operations to its configured peer sites.
 
       If you plan to re-use the hardware for the site replication configuration, you **must** completely wipe the drives for the deployment before re-initializing MinIO and adding the site back to the replication configuration.

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -482,11 +482,11 @@ You can re-add the site at a later date, but you must first completely wipe buck
    .. tab-item:: Command Line
       :sync: cli
 
-      Use :mc-cmd:`mc admin replicate remove`
+      Use :mc-cmd:`mc admin replicate rm`
 
       .. code-block:: shell
 
-         mc admin replicate remove ALIAS PEER_TO_REMOVE --force
+         mc admin replicate rm ALIAS PEER_TO_REMOVE --force
 
       - Replace ``ALIAS`` with the :ref:`alias <alias>` of any peer site in the replication configuration.
 

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -434,11 +434,11 @@ If a peer site changes its hostname, you can modify the replication configuratio
             mc admin replicate info <ALIAS>
          
       
-      #. Update the site's endpoint with :mc-cmd:`mc admin replicate edit`
+      #. Update the site's endpoint with :mc-cmd:`mc admin replicate update`
       
          .. code-block:: shell
 
-            mc admin replicate edit ALIAS --deployment-id [DEPLOYMENT-ID] --endpoint [NEW-ENDPOINT]
+            mc admin replicate update ALIAS --deployment-id [DEPLOYMENT-ID] --endpoint [NEW-ENDPOINT]
 
          Replace [DEPLOYMENT-ID] with the deployment ID of the site to update.
          

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -12,6 +12,11 @@
 
 .. mc:: mc admin replicate
 
+.. versionchanged:: RELEASE.2023-01-11T03-14-16Z
+
+   - ``mc admin replicate edit`` renamed to :mc-cmd:`mc admin replicate update`
+   - ``mc admin replicate remove`` renamed to :mc-cmd:`mc admin replicate rm`
+
 Description
 -----------
 
@@ -53,20 +58,20 @@ The :mc-cmd:`mc admin replicate` command has the following subcommands:
    * - :mc-cmd:`mc admin replicate add`
      - Create a new site replication configuration or expand an existing configuration.
 
-   * - :mc-cmd:`mc admin replicate edit`
-     - Edits the endpoint of the specified peer site in the site replication configuration.
-
    * - :mc-cmd:`mc admin replicate info`
      - Returns information about site replication configuration.
-
-   * - :mc-cmd:`mc admin replicate remove`
-     - Removes an entire site replication configuration or one or more peer sites from participating in site replication.
 
    * - :mc-cmd:`mc admin replicate resync`
      - Resynchronizes content from one site to a second site if the second site has lost data.
 
+   * - :mc-cmd:`mc admin replicate rm`
+     - Removes an entire site replication configuration or one or more peer sites from participating in site replication.
+
    * - :mc-cmd:`mc admin replicate status`
      - Displays the status for :ref:`replicable data <minio-site-replication-what-replicates>` across participating sites.
+
+   * - :mc-cmd:`mc admin replicate update`
+     - Modify the endpoint of the specified peer site in the site replication configuration.
 
 Syntax
 ------
@@ -122,10 +127,14 @@ Syntax
       The deployments to add must be empty.
 
 
-.. mc-cmd:: edit
+.. mc-cmd:: update
    :fullpath:
 
    Modifies the endpoint used for an existing peer site participating in site replication.
+
+   .. versionchanged:: RELEASE.2023-01-11T03-14-16Z
+
+      ``mc admin replicate edit`` renamed to ``mc admin replicate update``.
 
    .. tab-set::
 
@@ -134,7 +143,7 @@ Syntax
          .. code-block:: shell
             :class: copyable
 
-            mc admin replicate edit                                                   \
+            mc admin replicate update                                                   \
                                minio2                                                 \
                                --deployment-id c1758167-4426-454f-9aae-5c3dfdf6df64   \
                                --endpoint https://minio2:9000
@@ -145,7 +154,7 @@ Syntax
 
          .. code-block:: shell
 
-            mc [GLOBALFLAGS] admin replicate edit                       \
+            mc [GLOBALFLAGS] admin replicate update                       \
                                         ALIAS                           \
                                         --deployment-id [deploymentID]  \
                                         --endpoint [newEndpoint]
@@ -167,8 +176,12 @@ Syntax
       
       The new endpoint or URL to associate with the peer site.
 
-.. mc-cmd:: remove
+.. mc-cmd:: rm
    :fullpath:
+
+   .. versionchanged:: RELEASE.2023-01-11T03-14-16Z
+
+      The ``mc admin replicate remove`` subcommand renamed to ``mc admin replicate rm``.
 
    Removes one or more sites from a site replication configuration.
 
@@ -184,9 +197,9 @@ Syntax
          .. code-block:: shell
             :class: copyable
 
-            mc admin replicate remove   \
-                               minio2   \
-                               --all    \
+            mc admin replicate rm      \
+                               minio2  \
+                               --all   \
                                --force
 
          Remove the sites with alias names ``minio5`` and ``minio6`` from an existing site replication configuration that includes `minio2`
@@ -194,11 +207,11 @@ Syntax
          .. code-block:: shell
             :class: copyable
 
-            mc admin replicate remove   \
-                               minio2   \
-                               minio5    \
-                               minio6    \
-                               --force  \
+            mc admin replicate rm      \
+                               minio2  \
+                               minio5  \
+                               minio6  \
+                               --force
         
       .. tab-item:: SYNTAX
          
@@ -206,11 +219,11 @@ Syntax
 
          .. code-block:: shell
             
-            mc [GLOBALFLAGS] admin remove       \
-                                   TARGET       \
-                                   ALIAS1       \
-                                   [ALIAS2...]  \
-                                   --all        \
+            mc [GLOBALFLAGS] admin rm          \
+                                   TARGET      \
+                                   ALIAS1      \
+                                   [ALIAS2...] \
+                                   --all       \
                                    --force
 
    .. mc-cmd:: TARGET

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -123,6 +123,7 @@ Syntax
    Valid call types include:
 
    - ``batch-replication``
+   - ``bootstrap``
    - ``decommission``
    - ``healing``
    - ``internal``
@@ -130,6 +131,7 @@ Syntax
    - ``rebalance``
    - ``replication-resync``
    - ``s3``
+   - ``scanner``
    - ``storage``
 
    If not specified, MinIO returns call types of ``s3``.

--- a/source/reference/minio-mc-admin/mc-admin-update.rst
+++ b/source/reference/minio-mc-admin/mc-admin-update.rst
@@ -20,6 +20,9 @@ The command also supports using a private mirror server for environments where t
 
 .. end-mc-admin-update-desc
 
+After running the command, a prompt displays to confirm the update.
+Type ``y`` and ``[ENTER]`` to confirm and proceed with the update.
+
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only
    :class: note
 
@@ -62,7 +65,9 @@ Syntax
 .. code-block:: shell
    :class: copyable
 
-   mc admin update ALIAS [MIRROR_URL]
+   mc admin update ALIAS         \
+                   [MIRROR_URL]  \
+                   [--yes]             
 
 :mc-cmd:`mc admin update` supports the following arguments:
 
@@ -78,3 +83,7 @@ Syntax
    
    The mirror URL of the ``minio`` server binary to use for updating MinIO servers in the :mc-cmd:`~mc admin update ALIAS` deployment.
 
+.. mc-cmd:: --yes, -y
+   :optional:
+
+   Pass this flag to confirm the update and bypass the confirmation prompt.

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -64,6 +64,14 @@ Table of Deprecated Admin Commands
      - Replacement Command
      - Version of Change
 
+   * - ``mc admin replicate edit``
+     - :mc:`mc admin replicate update`
+     - mc RELEASE.2023-01-11T03-14-16Z
+
+   * - ``mc admin replicate remove``
+     - :mc:`mc admin replicate rm`
+     - mc RELEASE.2023-01-11T03-14-16Z
+
    * - ``mc admin tier add``
      - :mc:`mc ilm tier add`
      - mc RELEASE.2022-12-24T15-21-38Z
@@ -95,6 +103,8 @@ Table of Deprecated Admin Commands
    * - ``mc admin bucket quota``
      - :mc-cmd:`mc quota clear`, :mc-cmd:`mc quota info`, :mc-cmd:`mc quota set`
      - mc RELEASE.2022-12-13T00-23-28Z
+
+
 
 
 

--- a/source/reference/minio-mc/mc-license-update.rst
+++ b/source/reference/minio-mc/mc-license-update.rst
@@ -33,9 +33,9 @@ The command has the following syntax:
 
 .. code-block:: shell
 
-   mc [GLOBALFLAGS] license update                 \
-                            ALIAS                  \
-                            LICENSE-FILE-WITH-PATH \
+   mc [GLOBALFLAGS] license update                   \
+                            ALIAS                    \
+                            [LICENSE-FILE-WITH-PATH] \
                             [--airgap]
 
 Parameters
@@ -47,9 +47,11 @@ Parameters
    The :ref:`alias <alias>` of the MinIO deployment.
 
 .. mc-cmd:: LICENSE-FILE-WITH-PATH
-   :required:
+   :optional:
 
    The path (relative to the current working directory) and file name of the key to use to update the deployment's license.
+
+   If not passed with the command, MinIO checks the license file on SUBNET and automatically updates it.
    
 .. mc-cmd:: --airgap
    :optional:

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -306,6 +306,12 @@ Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --watch` to continuously mirror obj
 Behavior
 --------
 
+Mirror Continues on Failed Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If an object of the same name exists on the target, MinIO outputs an error for the duplicate object.
+``mc mirror`` continues to mirror other objects from the source to the destination after the error.
+
 MinIO Trims Empty Prefixes on Object Removal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/minio-mc/mc-pipe.rst
+++ b/source/reference/minio-mc/mc-pipe.rst
@@ -49,6 +49,10 @@ The :mc:`mc pipe` command streams content from `STDIN <https://www.gnu.org/softw
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
+.. versionchanged:: RELEASE.2023-01-11T03-14-16Z
+
+   ``mc pipe`` now supports concurrent uploads for better throughput of large streams.
+
 Parameters
 ~~~~~~~~~~
 

--- a/source/reference/minio-mc/mc-support-inspect.rst
+++ b/source/reference/minio-mc/mc-support-inspect.rst
@@ -20,7 +20,12 @@ Description
 The :mc:`mc support inspect` command collects the data and metadata associated to objects at the specified path.
 MinIO assembles this data from each backend drive storing an :ref:`erasure shard <minio-erasure-coding>` for each specified object.
 
-The command produces an encrypted zip file that includes all matching files with their respective *host+drive+path*. 
+The command produces an encrypted zip file that includes all matching files with their respective *host+drive+path*.
+
+.. versionchanged:: RELEASE.2023-01-11T03-14-16Z
+
+   The file uploads to MinIO for use by the engineering team in support efforts.
+   The file saves the the current working directory in the event the file does not successfully upload (such as in an airgapped environment).
 
 .. versionchanged:: RELEASE.2022-12-12T19-27-27Z
    
@@ -36,7 +41,7 @@ Exercise caution before sending a report to a third party or posting the report 
 Wildcards
 ---------
 
-The command suports wildcard ``*`` pattern matching for prefixes or objects. 
+The command supports wildcard ``*`` pattern matching for prefixes or objects. 
 
 .. code-block:: shell
    :class: copyable


### PR DESCRIPTION
- Adds info on `mc mirror` continuing after a failed object sync [PR 4427](https://github.com/minio/mc/pull/4427)
- Adds addition call type to `mc admin trace` [PR 4416](https://github.com/minio/mc/pull/4416)
- Adds info about changed default file behavior for `mc support inspect` [PR 4420](https://github.com/minio/mc/pull/4420)
- Concurrent upload support for `mc pipe` [PR 4435](https://github.com/minio/mc/pull/4435)
- Renames two `mc admin replicate` subcommands [PR 4383](https://github.com/minio/mc/pull/4383)
- Updates behavior of `mc license update` to no longer require license file [PR 4429](https://github.com/minio/mc/pull/4429)
- New flag for `mc admin update` to bypass confirmation prompt [PR 4439](https://github.com/minio/mc/pull/4427)

There is no doc issue to track this update.

Staged:
- [`mc mirror`](http://192.241.195.202:9000/staging/mc-2023-01-11/reference/minio-mc/mc-mirror.html)
- [`mc admin trace`](http://192.241.195.202:9000/staging/mc-2023-01-11/reference/minio-mc-admin/mc-admin-trace.html#mc.admin.trace.-call)
- [`mc support inspect`](http://192.241.195.202:9000/staging/mc-2023-01-11/reference/minio-mc/mc-support-inspect.html)
- [`mc pipe`](http://192.241.195.202:9000/staging/mc-2023-01-11/reference/minio-mc/mc-pipe.html)
- [`mc admin replicate`](http://192.241.195.202:9000/staging/mc-2023-01-11/reference/minio-mc-admin/mc-admin-replicate.html) Also several other pages that referenced the commands in examples.
- [`mc admin update`](http://192.241.195.202:9000/staging/mc-2023-01-11/reference/minio-mc-admin/mc-admin-update.html)