### PR TITLE
Adds ARM64 architecture to Linux install pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,8 @@ sync-minio-version:
 	@echo "Retrieving current MinIO version"
 	$(eval DEB = $(shell curl -s https://min.io/assets/downloads-minio.json | jq '.Linux."MinIO Server".amd64.DEB.download' | sed "s|linux-amd64|linux-amd64/archive|g"))
 	$(eval RPM = $(shell curl -s https://min.io/assets/downloads-minio.json | jq '.Linux."MinIO Server".amd64.RPM.download' | sed "s|linux-amd64|linux-amd64/archive|g"))
+	$(eval DEBARM64 = $(shell curl -s https://min.io/assets/downloads-minio.json | jq '.Linux."MinIO Server".arm64.DEB.download' | sed "s|linux-arm64|linux-arm64/archive|g"))
+	$(eval RPMARM64 = $(shell curl -s https://min.io/assets/downloads-minio.json | jq '.Linux."MinIO Server".arm64.RPM.download' | sed "s|linux-arm64|linux-arm64/archive|g"))
 	$(eval MINIO = $(shell curl --retry 10 -Ls -o /dev/null -w "%{url_effective}" https://github.com/minio/minio/releases/latest | sed "s/https:\/\/github.com\/minio\/minio\/releases\/tag\///"))
 
 	@$(eval kname = $(shell uname -s))
@@ -198,11 +200,15 @@ sync-minio-version:
 		sed -i "" "s|MINIOLATEST|${MINIO}|g" source/conf.py; \
 		sed -i "" "s|DEBURL|${DEB}|g" source/conf.py; \
 		sed -i "" "s|RPMURL|${RPM}|g" source/conf.py; \
+		sed -i "" "s|DEBARM64URL|${DEBARM64}|g" source/conf.py; \
+		sed -i "" "s|RPMARM64URL|${RPMARM64}|g" source/conf.py; \
 		;; \
 	*) \
 		sed -i "s|MINIOLATEST|${MINIO}|g" source/conf.py; \
 		sed -i "s|DEBURL|${DEB}|g" source/conf.py; \
 		sed -i "s|RPMURL|${RPM}|g" source/conf.py; \
+		sed -i "s|DEBARM64URL|${DEBARM64}|g" source/conf.py; \
+		sed -i "s|RPMARM64URL|${RPMARM64}|g" source/conf.py; \
 		;; \
 	esac
 

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -285,6 +285,8 @@ rst_prolog = """
 .. |minio-latest| replace:: MINIOLATEST
 .. |minio-rpm| replace:: RPMURL
 .. |minio-deb| replace:: DEBURL
+.. |minio-rpmarm64| replace:: RPMARM64URL
+.. |minio-debarm64| replace:: DEBARM64URL
 .. |subnet| replace:: `MinIO SUBNET <https://min.io/pricing?jmp=docs>`__
 .. |subnet-short| replace:: `SUBNET <https://min.io/pricing?jmp=docs>`__
 .. |SNSD| replace:: :abbr:`SNSD (Single-Node Single-Drive)`

--- a/source/includes/linux/common-installation.rst
+++ b/source/includes/linux/common-installation.rst
@@ -6,46 +6,106 @@ automatically install MinIO to the necessary system paths and create a
 ``systemd`` service file for running MinIO automatically. MinIO strongly
 recommends using RPM or DEB installation routes.
 
-.. tab-set::
 
-   .. tab-item:: RPM (RHEL)
-      :sync: rpm
+.. dropdown:: amd64 (Intel or AMD 64-bit processors)
+   :open:
 
-      Use the following commands to download the latest stable MinIO RPM and
-      install it.
+   Use one of the following options to download the MinIO server installation file for a machine running Linux on an Intel or AMD 64-bit processor.
 
-      .. code-block:: shell
-         :class: copyable
-         :substitutions:
+   .. tab-set::
+   
+      .. tab-item:: RPM (RHEL)
+         :sync: rpm
+   
+         Use the following commands to download the latest stable MinIO RPM and
+         install it.
+   
+         .. code-block:: shell
+            :class: copyable
+            :substitutions:
+   
+            wget |minio-rpm| -O minio.rpm
+            sudo dnf install minio.rpm
+   
+      .. tab-item:: DEB (Debian/Ubuntu)
+         :sync: deb
+   
+         Use the following commands to download the latest stable MinIO DEB and
+         install it:
+   
+         .. code-block:: shell
+            :class: copyable
+            :substitutions:
+   
+            wget |minio-deb| -O minio.deb
+            sudo dpkg -i minio.deb
+   
+      .. tab-item:: Binary
+         :sync: binary
+   
+         Use the following commands to download the latest stable MinIO binary and
+         install it to the system ``$PATH``:
+   
+         .. code-block:: shell
+            :class: copyable
+   
+            wget https://dl.min.io/server/minio/release/linux-amd64/minio
+            chmod +x minio
+            sudo mv minio /usr/local/bin/
 
-         wget |minio-rpm| -O minio.rpm
-         sudo dnf install minio.rpm
+.. dropdown:: arm64 (Apple M1/M2 or other ARM 64-bit processors)
+   
+   Use one of the following options to download the MinIO server installation file for a machine running Linux on an ARM 64-bit processor, such as the Apple M1 or M2.
 
-   .. tab-item:: DEB (Debian/Ubuntu)
-      :sync: deb
+   .. tab-set::
+   
+      .. tab-item:: RPM (RHEL)
+         :sync: rpm
+   
+         Use the following commands to download the latest stable MinIO RPM and
+         install it.
+   
+         .. code-block:: shell
+            :class: copyable
+            :substitutions:
+   
+            wget |minio-rpmarm64| -O minio.rpm
+            sudo dnf install minio.rpm
+   
+      .. tab-item:: DEB (Debian/Ubuntu)
+         :sync: deb
+   
+         Use the following commands to download the latest stable MinIO DEB and
+         install it:
+   
+         .. code-block:: shell
+            :class: copyable
+            :substitutions:
+   
+            wget |minio-debarm64| -O minio.deb
+            sudo dpkg -i minio.deb
+   
+      .. tab-item:: Binary
+         :sync: binary
+   
+         Use the following commands to download the latest stable MinIO binary and
+         install it to the system ``$PATH``:
+   
+         .. code-block:: shell
+            :class: copyable
+   
+            wget https://dl.min.io/server/minio/release/linux-arm64/minio
+            chmod +x minio
+            MINIO_ROOT_USER=admin MINIO_ROOT_PASSWORD=password ./minio server /mnt/data --console-address ":9001"
 
-      Use the following commands to download the latest stable MinIO DEB and
-      install it:
+.. dropdown:: Other Architectures
 
-      .. code-block:: shell
-         :class: copyable
-         :substitutions:
+   MinIO also supports additional architectures:
 
-         wget |minio-deb| -O minio.deb
-         sudo dpkg -i minio.deb
+   - ppc64le
+   - s390x
 
-   .. tab-item:: Binary
-      :sync: binary
-
-      Use the following commands to download the latest stable MinIO binary and
-      install it to the system ``$PATH``:
-
-      .. code-block:: shell
-         :class: copyable
-
-         wget https://dl.min.io/server/minio/release/linux-amd64/minio
-         chmod +x minio
-         sudo mv minio /usr/local/bin/
+   For instructions to download the binary, RPM, or DEB files for those architectures, see the `MinIO download page <https://min.io/download#/linux?ref=docs-install>`__.
 
 .. end-install-minio-binary-desc
 


### PR DESCRIPTION
- updates Makefile to retrieve ARM URLs
- updates default-conf to create substitutes for ARM URLs
- updates linux install include to add dropdowns for each architecture

Closes #679