### PR TITLE
Update mc reference docs for improved nav structure

### DIFF
--- a/source/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.rst
@@ -50,7 +50,7 @@ You must have network access and log in credentials with correct permissions to 
 
 You can access the deployments by logging in to the :ref:`MinIO Console <minio-console>` for each deployment or by installing :mc:`mc` and using the command line.
 
-If using the command line, use the :mc:`mc alias` command to create an alias for each MinIO deployment. 
+If using the command line, use the :mc:`mc alias set` command to create an alias for each MinIO deployment. 
 Alias creation requires specifying an access key for a user on the deployment. 
 This user **must** have permission to create and manage users and policies on the deployment. 
 

--- a/source/administration/bucket-replication/enable-server-side-two-way-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-two-way-bucket-replication.rst
@@ -44,7 +44,7 @@ You must have network access and login credentials with required permissions to 
 
 You can access the deployments by logging in to the :ref:`MinIO Console <minio-console>` for each deployment or by installing :mc:`mc` and using the command line.
 
-If using the command line, use the :mc:`mc alias` command to create an alias for both MinIO deployments. 
+If using the command line, use the :mc:`mc alias set` command to create an alias for both MinIO deployments. 
 Alias creation requires specifying an access key for a user on the deployment. 
 This user **must** have permission to create and manage users and policies on the deployment. 
 

--- a/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
+++ b/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
@@ -27,7 +27,7 @@ Install :mc:`mc` on a machine with network access to both source and destination
 clusters. See the ``mc`` :ref:`Installation Quickstart <mc-install>` for
 instructions on downloading and installing ``mc``.
 
-Use the :mc:`mc alias` command to create an alias for the source MinIO cluster
+Use the :mc:`mc alias set` command to create an alias for the source MinIO cluster
 and the destination S3-compatible service. Alias creation requires specifying an
 access key for a user on the source and destination clusters. The specified
 users must have :ref:`permissions

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -243,7 +243,7 @@ enable versioning on only a prefix or subset of objects in a bucket.
       Toggle the :guilabel:`Versioning` field to enable versioning on the bucket.
 
       The MinIO Console also supports enabling versioning as part of bucket
-      creation. See :ref:`minio-console-admin-buckets` for more information on
+      creation. See :ref:`minio-console-buckets` for more information on
       bucket management using the MinIO Console.
 
    .. tab-item:: MinIO CLI
@@ -292,7 +292,7 @@ MinIO :mc:`mc` CLI, or using an S3-compatible SDK.
 
       Select the :guilabel:`Versioning` field and follow the instructions to suspend versioning in the bucket.
 
-      See :ref:`minio-console-admin-buckets` for more information on bucket
+      See :ref:`minio-console-buckets` for more information on bucket
       management using the MinIO Console.
 
    .. tab-item:: MinIO CLI

--- a/source/administration/object-management/transition-objects-to-azure.rst
+++ b/source/administration/object-management/transition-objects-to-azure.rst
@@ -29,7 +29,7 @@ Install :mc:`mc` on a machine with network access to both source and destination
 clusters. See the ``mc`` :ref:`Installation Quickstart <mc-install>` for
 instructions on downloading and installing ``mc``.
 
-Use the :mc:`mc alias` command to create an alias for the source MinIO cluster.
+Use the :mc:`mc alias set` command to create an alias for the source MinIO cluster.
 Alias creation requires specifying an access key for a user on the source and
 destination clusters. The specified users must have :ref:`permissions
 <minio-lifecycle-management-transition-to-azure-permissions>` for configuring

--- a/source/administration/object-management/transition-objects-to-gcs.rst
+++ b/source/administration/object-management/transition-objects-to-gcs.rst
@@ -29,7 +29,7 @@ Install :mc:`mc` on a machine with network access to both source and destination
 clusters. See the ``mc`` :ref:`Installation Quickstart <mc-install>` for
 instructions on downloading and installing ``mc``.
 
-Use the :mc:`mc alias` command to create an alias for the source MinIO cluster.
+Use the :mc:`mc alias set` command to create an alias for the source MinIO cluster.
 Alias creation requires specifying an access key for a user on the source and
 destination clusters. The specified users must have :ref:`permissions
 <minio-lifecycle-management-transition-to-gcs-permissions>` for configuring and

--- a/source/administration/object-management/transition-objects-to-minio.rst
+++ b/source/administration/object-management/transition-objects-to-minio.rst
@@ -26,7 +26,7 @@ Install :mc:`mc` on a machine with network access to both source and destination
 clusters. See the ``mc`` :ref:`Installation Quickstart <mc-install>` for
 instructions on downloading and installing ``mc``.
 
-Use the :mc:`mc alias` command to create an alias for the source MinIO cluster.
+Use the :mc:`mc alias set` command to create an alias for the source MinIO cluster.
 Alias creation requires specifying an access key for a user on the source and
 destination clusters. The specified users must have :ref:`permissions
 <minio-lifecycle-management-transition-to-minio-permissions>` for configuring and

--- a/source/administration/object-management/transition-objects-to-s3.rst
+++ b/source/administration/object-management/transition-objects-to-s3.rst
@@ -29,7 +29,7 @@ Install :mc:`mc` on a machine with network access to both source and destination
 clusters. See the ``mc`` :ref:`Installation Quickstart <mc-install>` for
 instructions on downloading and installing ``mc``.
 
-Use the :mc:`mc alias` command to create an alias for the source MinIO cluster.
+Use the :mc:`mc alias set` command to create an alias for the source MinIO cluster.
 Alias creation requires specifying an access key for a user on the source and
 destination clusters. The specified users must have :ref:`permissions
 <minio-lifecycle-management-transition-to-s3-permissions>` for configuring and

--- a/source/index.rst
+++ b/source/index.rst
@@ -172,6 +172,7 @@ Any file uploaded to ``play`` should be considered public and non-protected.
       /developers/security-token-service
       /reference/minio-mc
       /reference/minio-mc-admin
+      /reference/minio-mc-deprecated
       /reference/minio-server/minio-server
       /integrations/integrations
 

--- a/source/operations/checklists/software.rst
+++ b/source/operations/checklists/software.rst
@@ -66,7 +66,7 @@ Post Install Tasks
 
 
    * - :octicon:`circle` 
-     - (optional) Create :mc:`mc alias` for each server from your local machine for command line access to work with the MinIO deployment from a local machine
+     - (optional) Create an :mc:`mc alias` for each server with :mc:`mc alias set` from your local machine for command line access to work with the MinIO deployment from a local machine
 
    * - :octicon:`circle`
      - Configure :ref:`Bucket replication <minio-bucket-replication-requirements>` to duplicate contents of a bucket to another bucket location

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -151,38 +151,20 @@ The following table lists :mc-cmd:`mc` commands:
    * - Command
      - Description
 
-   * - | :mc:`mc alias set`
-       | :mc:`mc alias remove`
-       | :mc:`mc alias list`
-     - The ``mc alias`` commands provide a convenient interface for
-       managing the list of S3-compatible hosts that :mc-cmd:`mc` can connect to
-       and run operations against.
-
-       :mc-cmd:`mc` commands that operate on S3-compatible services *require*
-       specifying an alias for that service.
+   * - :mc:`mc alias`
+     - .. include:: /reference/minio-mc/mc-alias.rst
+          :start-after: start-mc-alias-desc
+          :end-before: end-mc-alias-desc
      
-   * - | :mc:`mc anonymous set`
-       | :mc:`mc anonymous set-json`
-       | :mc:`mc anonymous get`
-       | :mc:`mc anonymous get-json`
-       | :mc:`mc anonymous list`
-       | :mc:`mc anonymous links`
-
-     - The :mc:`mc anonymous` command supports setting or removing anonymous
-       :ref:`policies <minio-policy>` to a bucket and its contents. Buckets with
-       anonymous policies allow public access where clients can perform any
-       action granted by the policy without :ref:`authentication
-       <minio-authentication-and-identity-management>`.
+   * - :mc:`mc anonymous`
+     - .. include:: /reference/minio-mc/mc-anonymous.rst
+          :start-after: start-mc-anonymous-desc
+          :end-before: end-mc-anonymous-desc
      
-   * - | :mc:`mc batch generate`
-       | :mc:`mc batch start`
-       | :mc:`mc batch list`
-       | :mc:`mc batch status`
-       | :mc:`mc batch describe`
-     - The ``mc batch`` commands allow you to run one or more job tasks on a MinIO deployment.
-       Specify the jobs to run in a YAML-formatted file you can start generating with :mc:`mc batch generate`. 
-       Use :mc:`mc batch start` to when you are ready to begin the job(s) defined in the file.
-       Display current jobs with :mc:`mc batch list`, see current status with :mc:`mc batch status`, and output the full definition for a current job with :mc:`mc batch describe`.
+   * - :mc:`mc batch`
+     - .. include:: /reference/minio-mc/mc-batch.rst
+          :start-after: start-mc-batch-desc
+          :end-before: end-mc-batch-desc
 
    * - :mc:`mc cat`
      - .. include:: /reference/minio-mc/mc-cat.rst
@@ -199,23 +181,15 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-diff-desc
           :end-before: end-mc-diff-desc
      
-   * - | :mc:`mc encrypt set`
-       | :mc:`mc encrypt info`
-       | :mc:`mc encrypt clear`
-     - The ``mc encrypt`` command sets, updates, or disables the default bucket
-       Server-Side Encryption (SSE) mode. MinIO automatically encrypts objects
-       using the specified SSE mode.
+   * - :mc:`mc encrypt`
+     - .. include:: /reference/minio-mc/mc-encrypt.rst
+          :start-after: start-mc-encrypt-desc
+          :end-before: end-mc-encrypt-desc
      
-   * - | :mc:`mc event add`
-       | :mc:`mc event remove`
-       | :mc:`mc event list`
-     - The ``mc event`` command supports adding, removing, and listing
-       the bucket event notifications.
-
-       MinIO automatically sends triggered events to the configured notification
-       targets. MinIO supports notification targets like AMQP (RabbitMQ), Redis,
-       ElasticSearch, NATS and PostgreSQL. See :ref:`MinIO Bucket Notifications
-       <minio-bucket-notifications>` for more information.
+   * - :mc:`mc event`
+     - .. include:: /reference/minio-mc/mc-event.rst
+          :start-after: start-mc-event-desc
+          :end-before: end-mc-event-desc
      
    * - :mc:`mc find`
      - .. include:: /reference/minio-mc/mc-find.rst
@@ -227,26 +201,20 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-head-desc
           :end-before: end-mc-head-desc
      
-   * - | :mc:`mc ilm tier`
-       | :mc:`mc ilm rule`
-       | :mc:`mc ilm restore`
-     - The ``mc ilm`` commands manage :ref:`object lifecycle management rules <minio-lifecycle-management>` on a MinIO deployment. 
-
-       Use these command to create tiers, create :ref:`tiering <minio-lifecycle-management-tiering>` rules, and manage :ref:`expiration <minio-lifecycle-management-expiration>` rules for objects on a bucket.
+   * - :mc:`mc ilm`
+     - .. include:: /reference/minio-mc/mc-ilm.rst
+          :start-after: start-mc-ilm-desc
+          :end-before: end-mc-ilm-desc
      
-   * - | :mc:`mc legalhold set`
-       | :mc:`mc legalhold info`
-       | :mc:`mc legalhold clear`
-     - The ``mc legalhold`` command sets, removes, or retrieves 
-       the :ref:`Object Legal Hold (WORM) <minio-object-locking-legalhold>`
-       settings for object(s).
+   * - :mc:`mc legalhold`
+     - .. include:: /reference/minio-mc/mc-legalhold.rst
+          :start-after: start-mc-legalhold-desc
+          :end-before: end-mc-legalhold-desc
 
-   * - | :mc:`mc license register` 
-       | :mc:`mc license info`
-       | :mc:`mc license update`
-       | :mc:`mc license unregister` 
-     - The ``mc license`` commands work with cluster registration for |SUBNET|. 
-       Use the commands to register a deployment, unregister a deployment, display information about the cluster's current license, or update the license key for a cluster.
+   * - :mc:`mc license`
+     - .. include:: /reference/minio-mc/mc-license.rst
+          :start-after: start-mc-license-desc
+          :end-before: end-mc-license-desc
 
    * - :mc:`mc ls`
      - .. include:: /reference/minio-mc/mc-ls.rst
@@ -278,56 +246,35 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-pipe-desc
           :end-before: end-mc-pipe-desc  
 
-   * - | :mc:`mc quota set`
-       | :mc:`mc quota info`
-       | :mc:`mc quota clear`
-
-     - The ``mc quota`` commands configure, display, or remove a hard quota limit on a bucket. 
-       When a bucket with a quota configured reaches the specified limit, MinIO rejects further ``PUT`` requests for the bucket. 
+   * - :mc:`mc quota`
+     - .. include:: /reference/minio-mc/mc-quota.rst
+          :start-after: start-mc-quota-desc
+          :end-before: end-mc-quota-desc  
      
    * - :mc:`mc rb`
      - .. include:: /reference/minio-mc/mc-rb.rst
           :start-after: start-mc-rb-desc
           :end-before: end-mc-rb-desc
      
-   * - | :mc:`mc retention set`
-       | :mc:`mc retention info`
-       | :mc:`mc retention clear`
-
-     - The :mc:`mc retention` command configures the 
-       :ref:`Write-Once Read-Many (WORM) locking <minio-object-locking>`
-       settings for an object or object(s) in a bucket. You can also set the
-       default object lock settings for a bucket, where all objects without
-       explicit object lock settings inherit the bucket default.
-
-   * - | :mc:`mc replicate add`
-       | :mc:`mc replicate diff`
-       | :mc:`mc replicate export`
-       | :mc:`mc replicate import`
-       | :mc:`mc replicate ls`
-       | :mc:`mc replicate resync`
-       | :mc:`mc replicate rm`
-       | :mc:`mc replicate status`
-       | :mc:`mc replicate update`
-
-     - The :mc:`mc replicate <mc replicate add>` command configures and
-       manages the :ref:`Server-Side Bucket Replication
-       <minio-bucket-replication-serverside>` for a MinIO deployment, including
-       :ref:`active-active replication configurations
-       <minio-bucket-replication-serverside-twoway>` and
-       :ref:`resynchronization <minio-replication-behavior-resync>`.
+   * - :mc:`mc replicate`
+     - .. include:: /reference/minio-mc/mc-replicate.rst
+          :start-after: start-mc-replicate-desc
+          :end-before: end-mc-replicate-desc
      
+   * - :mc:`mc retention`
+     - .. include:: /reference/minio-mc/mc-retention.rst
+          :start-after: start-mc-retention-desc
+          :end-before: end-mc-retention-desc
+
    * - :mc:`mc rm`
      - .. include:: /reference/minio-mc/mc-rm.rst
           :start-after: start-mc-rm-desc
           :end-before: end-mc-rm-desc
      
-   * - | :mc:`mc share download`
-       | :mc:`mc share upload`
-       | :mc:`mc share list`
-     - The :mc:`mc share download` and :mc:`mc share upload`
-       commands generate presigned URLs for downloading and uploading
-       objects to a MinIO bucket.
+   * - :mc:`mc share`
+     - .. include:: /reference/minio-mc/mc-share.rst
+          :start-after: start-mc-share-desc
+          :end-before: end-mc-share-desc
      
    * - :mc:`mc sql`
      - .. include:: /reference/minio-mc/mc-sql.rst
@@ -339,23 +286,15 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-stat-desc
           :end-before: end-mc-stat-desc
 
-   * - | :mc:`mc support callhome`
-       | :mc:`mc support diag`
-       | :mc:`mc support inspect`
-       | :mc:`mc support perf`
-       | :mc:`mc support profile`
-       | :mc:`mc support proxy`
-       | :mc:`mc support top`
-     - The MinIO Client ``mc support`` commands provides tools for analyzing deployment health or performance and for running diagnostics.
-       You can also upload generated health reports for further analysis by MinIO engineering.
-       The ``mc support`` commands require an active |SUBNET| registration.
+   * - :mc:`mc support`
+     - .. include:: /reference/minio-mc/mc-support.rst
+          :start-after: start-mc-support-desc
+          :end-before: end-mc-support-desc
 
-   * - | :mc:`mc tag set`
-       | :mc:`mc tag remove`
-       | :mc:`mc tag list`
-
-     - The :mc:`mc tag` command adds, removes, and lists tags associated to
-       a bucket or object.
+   * - :mc:`mc tag`
+     - .. include:: /reference/minio-mc/mc-tag.rst
+          :start-after: start-mc-tag-desc
+          :end-before: end-mc-tag-desc
      
    * - :mc:`mc tree`
      - .. include:: /reference/minio-mc/mc-tree.rst
@@ -524,82 +463,37 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    :titlesonly:
    :hidden:
    
-   /reference/minio-mc/mc-alias-set
-   /reference/minio-mc/mc-alias-list
-   /reference/minio-mc/mc-alias-remove
-   /reference/minio-mc/mc-anonymous-set
-   /reference/minio-mc/mc-anonymous-get
-   /reference/minio-mc/mc-anonymous-list
-   /reference/minio-mc/mc-anonymous-links
-   /reference/minio-mc/mc-anonymous-get-json
-   /reference/minio-mc/mc-anonymous-set-json
-   /reference/minio-mc/mc-batch-describe
-   /reference/minio-mc/mc-batch-generate
-   /reference/minio-mc/mc-batch-list
-   /reference/minio-mc/mc-batch-start
-   /reference/minio-mc/mc-batch-status
+   /reference/minio-mc/mc-alias
+   /reference/minio-mc/mc-anonymous
+   /reference/minio-mc/mc-batch
    /reference/minio-mc/mc-cat
    /reference/minio-mc/mc-cp
    /reference/minio-mc/mc-diff
-   /reference/minio-mc/mc-encrypt-set
-   /reference/minio-mc/mc-encrypt-info
-   /reference/minio-mc/mc-encrypt-clear
-   /reference/minio-mc/mc-event-add
-   /reference/minio-mc/mc-event-list
-   /reference/minio-mc/mc-event-remove
+   /reference/minio-mc/mc-encrypt
+   /reference/minio-mc/mc-event
    /reference/minio-mc/mc-find
    /reference/minio-mc/mc-head
-   /reference/minio-mc/mc-ilm-restore
-   /reference/minio-mc/mc-ilm-rule
-   /reference/minio-mc/mc-ilm-tier
-   /reference/minio-mc/mc-legalhold-set
-   /reference/minio-mc/mc-legalhold-info
-   /reference/minio-mc/mc-legalhold-clear
-   /reference/minio-mc/mc-license-info
-   /reference/minio-mc/mc-license-register
-   /reference/minio-mc/mc-license-unregister
-   /reference/minio-mc/mc-license-update
+   /reference/minio-mc/mc-ilm
+   /reference/minio-mc/mc-legalhold
+   /reference/minio-mc/mc-license
    /reference/minio-mc/mc-ls
    /reference/minio-mc/mc-mb
    /reference/minio-mc/mc-mirror
    /reference/minio-mc/mc-mv
    /reference/minio-mc/mc-od
    /reference/minio-mc/mc-pipe
-   /reference/minio-mc/mc-quota-clear
-   /reference/minio-mc/mc-quota-info
-   /reference/minio-mc/mc-quota-set
+   /reference/minio-mc/mc-quota
    /reference/minio-mc/mc-rb
-   /reference/minio-mc/mc-replicate-add
-   /reference/minio-mc/mc-replicate-diff
-   /reference/minio-mc/mc-replicate-ls
-   /reference/minio-mc/mc-replicate-update
-   /reference/minio-mc/mc-replicate-resync
-   /reference/minio-mc/mc-replicate-rm
-   /reference/minio-mc/mc-replicate-status
-   /reference/minio-mc/mc-replicate-export
-   /reference/minio-mc/mc-replicate-import
-   /reference/minio-mc/mc-retention-set
-   /reference/minio-mc/mc-retention-info
-   /reference/minio-mc/mc-retention-clear
+   /reference/minio-mc/mc-replicate
+   /reference/minio-mc/mc-retention
    /reference/minio-mc/mc-rm
-   /reference/minio-mc/mc-share-download
-   /reference/minio-mc/mc-share-upload
-   /reference/minio-mc/mc-share-list
+   /reference/minio-mc/mc-share
    /reference/minio-mc/mc-sql
    /reference/minio-mc/mc-stat
-   /reference/minio-mc/mc-support-callhome
-   /reference/minio-mc/mc-support-diag
-   /reference/minio-mc/mc-support-inspect
-   /reference/minio-mc/mc-support-perf
-   /reference/minio-mc/mc-support-profile
-   /reference/minio-mc/mc-support-proxy
-   /reference/minio-mc/mc-support-top
-   /reference/minio-mc/mc-tag-set
-   /reference/minio-mc/mc-tag-list
-   /reference/minio-mc/mc-tag-remove
+   /reference/minio-mc/mc-support
+   /reference/minio-mc/mc-tag
    /reference/minio-mc/mc-tree
    /reference/minio-mc/mc-undo
    /reference/minio-mc/mc-update
    /reference/minio-mc/mc-version
    /reference/minio-mc/mc-watch
-   /reference/minio-mc-deprecated

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -143,6 +143,13 @@ Command Quick Reference
 
 The following table lists :mc-cmd:`mc` commands:
 
+.. note:: 
+
+   The MinIO Client also includes an administration extension for managing MinIO deployments. 
+   See :mc:`mc admin` for more complete documentation.
+
+   The below table does not include those commands.
+
 .. list-table::
    :header-rows: 1
    :widths: 30 70
@@ -151,17 +158,28 @@ The following table lists :mc-cmd:`mc` commands:
    * - Command
      - Description
 
-   * - :mc:`mc alias`
+   * - | :mc:`mc alias list`
+       | :mc:`mc alias remove`
+       | :mc:`mc alias set`
      - .. include:: /reference/minio-mc/mc-alias.rst
           :start-after: start-mc-alias-desc
           :end-before: end-mc-alias-desc
      
-   * - :mc:`mc anonymous`
+   * - | :mc:`mc anonymous get`
+       | :mc:`mc anonymous get-json`
+       | :mc:`mc anonymous links`
+       | :mc:`mc anonymous list`
+       | :mc:`mc anonymous set`
+       | :mc:`mc anonymous set-json`
      - .. include:: /reference/minio-mc/mc-anonymous.rst
           :start-after: start-mc-anonymous-desc
           :end-before: end-mc-anonymous-desc
      
-   * - :mc:`mc batch`
+   * - | :mc:`mc batch describe`
+       | :mc:`mc batch generate`
+       | :mc:`mc batch list`
+       | :mc:`mc batch start`
+       | :mc:`mc batch status`
      - .. include:: /reference/minio-mc/mc-batch.rst
           :start-after: start-mc-batch-desc
           :end-before: end-mc-batch-desc
@@ -181,12 +199,16 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-diff-desc
           :end-before: end-mc-diff-desc
      
-   * - :mc:`mc encrypt`
+   * - | :mc:`mc encrypt clear`
+       | :mc:`mc encrypt info`
+       | :mc:`mc encrypt set`
      - .. include:: /reference/minio-mc/mc-encrypt.rst
           :start-after: start-mc-encrypt-desc
           :end-before: end-mc-encrypt-desc
      
-   * - :mc:`mc event`
+   * - | :mc:`mc event add`
+       | :mc:`mc event list`
+       | :mc:`mc event remove`
      - .. include:: /reference/minio-mc/mc-event.rst
           :start-after: start-mc-event-desc
           :end-before: end-mc-event-desc
@@ -201,17 +223,34 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-head-desc
           :end-before: end-mc-head-desc
      
-   * - :mc:`mc ilm`
+   * - | :mc:`mc ilm restore`
+       | :mc:`mc ilm rule add`
+       | :mc:`mc ilm rule edit`
+       | :mc:`mc ilm rule export`
+       | :mc:`mc ilm rule import`
+       | :mc:`mc ilm rule ls`
+       | :mc:`mc ilm rule rm`
+       | :mc:`mc ilm tier add`
+       | :mc:`mc ilm tier check`
+       | :mc:`mc ilm tier info`
+       | :mc:`mc ilm tier ls`
+       | :mc:`mc ilm tier rm`
+       | :mc:`mc ilm tier update`
      - .. include:: /reference/minio-mc/mc-ilm.rst
           :start-after: start-mc-ilm-desc
           :end-before: end-mc-ilm-desc
      
-   * - :mc:`mc legalhold`
+   * - | :mc:`mc legalhold clear`
+       | :mc:`mc legalhold info`
+       | :mc:`mc legalhold set`
      - .. include:: /reference/minio-mc/mc-legalhold.rst
           :start-after: start-mc-legalhold-desc
           :end-before: end-mc-legalhold-desc
 
-   * - :mc:`mc license`
+   * - | :mc:`mc license info`
+       | :mc:`mc license register`
+       | :mc:`mc license unregister`
+       | :mc:`mc license update`
      - .. include:: /reference/minio-mc/mc-license.rst
           :start-after: start-mc-license-desc
           :end-before: end-mc-license-desc
@@ -246,7 +285,9 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-pipe-desc
           :end-before: end-mc-pipe-desc  
 
-   * - :mc:`mc quota`
+   * - | :mc:`mc quota clear`
+       | :mc:`mc quota info`
+       | :mc:`mc quota set`
      - .. include:: /reference/minio-mc/mc-quota.rst
           :start-after: start-mc-quota-desc
           :end-before: end-mc-quota-desc  
@@ -256,12 +297,22 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-rb-desc
           :end-before: end-mc-rb-desc
      
-   * - :mc:`mc replicate`
+   * - | :mc:`mc replicate add`
+       | :mc:`mc replicate diff`
+       | :mc:`mc replicate export`
+       | :mc:`mc replicate import`
+       | :mc:`mc replicate ls`
+       | :mc:`mc replicate resync`
+       | :mc:`mc replicate rm`
+       | :mc:`mc replicate status`
+       | :mc:`mc replicate update`
      - .. include:: /reference/minio-mc/mc-replicate.rst
           :start-after: start-mc-replicate-desc
           :end-before: end-mc-replicate-desc
      
-   * - :mc:`mc retention`
+   * - | :mc:`mc retention clear`
+       | :mc:`mc retention info`
+       | :mc:`mc retention set`
      - .. include:: /reference/minio-mc/mc-retention.rst
           :start-after: start-mc-retention-desc
           :end-before: end-mc-retention-desc
@@ -271,7 +322,9 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-rm-desc
           :end-before: end-mc-rm-desc
      
-   * - :mc:`mc share`
+   * - | :mc:`mc share download`
+       | :mc:`mc share list`
+       | :mc:`mc share upload`
      - .. include:: /reference/minio-mc/mc-share.rst
           :start-after: start-mc-share-desc
           :end-before: end-mc-share-desc
@@ -286,12 +339,22 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-stat-desc
           :end-before: end-mc-stat-desc
 
-   * - :mc:`mc support`
+   * - | :mc:`mc support callhome`
+       | :mc:`mc support diag`
+       | :mc:`mc support inspect`
+       | :mc:`mc support perf`
+       | :mc:`mc support profile`
+       | :mc:`mc support proxy`
+       | :mc:`mc support top api`
+       | :mc:`mc support top disk`
+       | :mc:`mc support top locks`
      - .. include:: /reference/minio-mc/mc-support.rst
           :start-after: start-mc-support-desc
           :end-before: end-mc-support-desc
 
-   * - :mc:`mc tag`
+   * - | :mc:`mc tag list`
+       | :mc:`mc tag remove`
+       | :mc:`mc tag set`
      - .. include:: /reference/minio-mc/mc-tag.rst
           :start-after: start-mc-tag-desc
           :end-before: end-mc-tag-desc
@@ -320,10 +383,6 @@ The following table lists :mc-cmd:`mc` commands:
      - .. include:: /reference/minio-mc/mc-watch.rst
           :start-after: start-mc-watch-desc
           :end-before: end-mc-watch-desc
-     
-
-:mc-cmd:`mc` also includes an administration extension for managing MinIO
-deployments. See :mc:`mc admin` for more complete documentation.
 
 .. _mc-configuration:
 

--- a/source/reference/minio-mc/mc-alias-set.rst
+++ b/source/reference/minio-mc/mc-alias-set.rst
@@ -12,7 +12,6 @@
    :local:
    :depth: 2
 
-.. mc:: mc alias
 .. mc:: mc alias set
 
 .. |command| replace:: :mc:`mc alias set`

--- a/source/reference/minio-mc/mc-alias.rst
+++ b/source/reference/minio-mc/mc-alias.rst
@@ -1,0 +1,61 @@
+============
+``mc alias``
+============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc alias
+
+
+Description
+-----------
+
+.. start-mc-alias-desc
+
+The :mc:`mc alias` commands provide a convenient interface for managing the list of S3-compatible hosts that :mc-cmd:`mc` can connect to and run operations against.
+
+.. end-mc-alias-desc
+
+.. important:: 
+   
+   :mc-cmd:`mc` commands that operate on S3-compatible services *require* specifying an alias for that service.
+
+Subcommands
+-----------
+
+:mc:`mc alias` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc alias list`
+     - .. include:: /reference/minio-mc/mc-alias-list.rst
+          :start-after: start-mc-alias-list-desc
+          :end-before: end-mc-alias-list-desc
+
+   * - :mc:`~mc alias remove`
+     - .. include:: /reference/minio-mc/mc-alias-remove.rst
+          :start-after: start-mc-alias-remove-desc
+          :end-before: end-mc-alias-remove-desc
+
+   * - :mc:`~mc alias set`
+     - .. include:: /reference/minio-mc/mc-alias-set.rst
+          :start-after: start-mc-alias-set-desc
+          :end-before: end-mc-alias-set-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-alias-list
+   /reference/minio-mc/mc-alias-remove
+   /reference/minio-mc/mc-alias-set

--- a/source/reference/minio-mc/mc-anonymous-get-json.rst
+++ b/source/reference/minio-mc/mc-anonymous-get-json.rst
@@ -15,12 +15,12 @@
 Syntax
 ------
 
-.. start-mc-policy-get-json-desc
+.. start-mc-anonymous-get-json-desc
 
 The :mc:`mc anonymous get-json` command gets anonymous (i.e. unauthenticated or
 public) access :ref:`policies <minio-policy>` for a bucket. 
 
-.. end-mc-policy-get-json-desc
+.. end-mc-anonymous-get-json-desc
 
 Buckets with anonymous policies allow clients to access the bucket contents
 and perform actions consistent with the specified policy without 

--- a/source/reference/minio-mc/mc-anonymous-get.rst
+++ b/source/reference/minio-mc/mc-anonymous-get.rst
@@ -15,12 +15,12 @@
 Syntax
 ------
 
-.. start-mc-policy-get-desc
+.. start-mc-anonymous-get-desc
 
 The :mc:`mc anonymous get` command gets the anonymous (i.e. unauthenticated or
 public) access :ref:`policies <minio-policy>` for a bucket. 
 
-.. end-mc-policy-get-desc
+.. end-mc-anonymous-get-desc
 
 Buckets with anonymous policies allow clients to access the bucket contents
 and perform actions consistent with the specified policy without 

--- a/source/reference/minio-mc/mc-anonymous-links.rst
+++ b/source/reference/minio-mc/mc-anonymous-links.rst
@@ -15,12 +15,12 @@
 Syntax
 ------
 
-.. start-mc-policy-links-desc
+.. start-mc-anonymous-links-desc
 
 The :mc:`mc anonymous links` retrieves the HTTP URL for anonymous (i.e.
 unauthenticated or public) access to a bucket. 
 
-.. end-mc-policy-links-desc
+.. end-mc-anonymous-links-desc
 
 Buckets with anonymous policies allow clients to access the bucket contents
 and perform actions consistent with the specified policy without 

--- a/source/reference/minio-mc/mc-anonymous-list.rst
+++ b/source/reference/minio-mc/mc-anonymous-list.rst
@@ -15,12 +15,12 @@
 Syntax
 ------
 
-.. start-mc-policy-list-desc
+.. start-mc-anonymous-list-desc
 
 The :mc:`mc anonymous list` retrieves all anonymous (i.e. unauthenticated or
 public) access policies for a bucket. 
 
-.. end-mc-policy-list-desc
+.. end-mc-anonymous-list-desc
 
 Buckets with anonymous policies allow clients to access the bucket contents
 and perform actions consistent with the specified policy without 

--- a/source/reference/minio-mc/mc-anonymous-set-json.rst
+++ b/source/reference/minio-mc/mc-anonymous-set-json.rst
@@ -15,13 +15,13 @@
 Syntax
 ------
 
-.. start-mc-policy-set-json-desc
+.. start-mc-anonymous-set-json-desc
 
 The :mc:`mc anonymous set-json` command sets anonymous (i.e. unauthenticated or
 public) access :ref:`policies <minio-policy>` for a bucket using using an IAM
 :s3-docs:`JSON policy document <using-iam-policies>`. 
 
-.. end-mc-policy-set-json-desc
+.. end-mc-anonymous-set-json-desc
 
 Buckets with anonymous policies allow clients to access the bucket contents
 and perform actions consistent with the specified policy without 

--- a/source/reference/minio-mc/mc-anonymous-set.rst
+++ b/source/reference/minio-mc/mc-anonymous-set.rst
@@ -1,4 +1,5 @@
 .. _minio-mc-policy-set:
+.. _minio-mc-anonymous-set:
 
 ====================
 ``mc anonymous set``
@@ -10,18 +11,17 @@
    :local:
    :depth: 2
 
-.. mc:: mc anonymous
 .. mc:: mc anonymous set
 
 Syntax
 ------
 
-.. start-mc-policy-set-desc
+.. start-mc-anonymous-set-desc
 
 The :mc:`mc anonymous set` command sets anonymous (i.e. unauthenticated or public)
 access :ref:`policies <minio-policy>` for a bucket. 
 
-.. end-mc-policy-set-desc
+.. end-mc-anonymous-set-desc
 
 Buckets with anonymous policies allow clients to access the bucket contents
 and perform actions consistent with the specified policy without 

--- a/source/reference/minio-mc/mc-anonymous.rst
+++ b/source/reference/minio-mc/mc-anonymous.rst
@@ -1,0 +1,76 @@
+================
+``mc anonymous``
+================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc anonymous
+
+
+Description
+-----------
+
+.. start-mc-anonymous-desc
+
+The :mc:`mc anonymous` command supports setting or removing anonymous :ref:`policies <minio-policy>` to a bucket and its contents. 
+Buckets with anonymous policies allow public access where clients can perform any action granted by the policy without :ref:`authentication <minio-authentication-and-identity-management>`.
+
+.. end-mc-anonymous-desc
+
+Subcommands
+-----------
+
+:mc-cmd:`mc anonymous` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc anonymous get`
+     - .. include:: /reference/minio-mc/mc-anonymous-get.rst
+          :start-after: start-mc-anonymous-get-desc
+          :end-before: end-mc-anonymous-get-desc
+
+   * - :mc:`~mc anonymous get-json`
+     - .. include:: /reference/minio-mc/mc-anonymous-get-json.rst
+          :start-after: start-mc-anonymous-get-json-desc
+          :end-before: end-mc-anonymous-get-json-desc
+
+   * - :mc:`~mc anonymous links`
+     - .. include:: /reference/minio-mc/mc-anonymous-links.rst
+          :start-after: start-mc-anonymous-links-desc
+          :end-before: end-mc-anonymous-links-desc
+
+   * - :mc:`~mc anonymous list`
+     - .. include:: /reference/minio-mc/mc-anonymous-list.rst
+          :start-after: start-mc-anonymous-list-desc
+          :end-before: end-mc-anonymous-list-desc
+
+   * - :mc:`~mc anonymous set`
+     - .. include:: /reference/minio-mc/mc-anonymous-set.rst
+          :start-after: start-mc-anonymous-set-desc
+          :end-before: end-mc-anonymous-set-desc
+
+   * - :mc:`~mc anonymous set-json`
+     - .. include:: /reference/minio-mc/mc-anonymous-set-json.rst
+          :start-after: start-mc-anonymous-set-json-desc
+          :end-before: end-mc-anonymous-set-json-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-anonymous-set
+   /reference/minio-mc/mc-anonymous-get
+   /reference/minio-mc/mc-anonymous-list
+   /reference/minio-mc/mc-anonymous-links
+   /reference/minio-mc/mc-anonymous-get-json
+   /reference/minio-mc/mc-anonymous-set-json

--- a/source/reference/minio-mc/mc-batch-generate.rst
+++ b/source/reference/minio-mc/mc-batch-generate.rst
@@ -10,8 +10,6 @@
    :local:
    :depth: 2
 
-.. mc:: mc batch
-
 .. mc:: mc batch generate
 
 .. versionchanged:: MinIO RELEASE.2022-10-08T20-11-00Z or later

--- a/source/reference/minio-mc/mc-batch.rst
+++ b/source/reference/minio-mc/mc-batch.rst
@@ -1,0 +1,69 @@
+============
+``mc batch``
+============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc batch
+
+
+Description
+-----------
+
+.. start-mc-batch-desc
+
+The :mc:`mc batch` commands allow you to run one or more job tasks on a MinIO deployment.
+
+.. end-mc-batch-desc
+
+Subcommands
+-----------
+
+:mc-cmd:`mc batch` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc batch describe`
+     - .. include:: /reference/minio-mc/mc-batch-describe.rst
+          :start-after: start-mc-batch-describe-desc
+          :end-before: end-mc-batch-describe-desc
+
+   * - :mc:`~mc batch generate`
+     - .. include:: /reference/minio-mc/mc-batch-generate.rst
+          :start-after: start-mc-batch-generate-desc
+          :end-before: end-mc-batch-generate-desc
+
+   * - :mc:`~mc batch list`
+     - .. include:: /reference/minio-mc/mc-batch-list.rst
+          :start-after: start-mc-batch-list-desc
+          :end-before: end-mc-batch-list-desc
+
+   * - :mc:`~mc batch start`
+     - .. include:: /reference/minio-mc/mc-batch-start.rst
+          :start-after: start-mc-batch-start-desc
+          :end-before: end-mc-batch-start-desc
+
+   * - :mc:`~mc batch status`
+     - .. include:: /reference/minio-mc/mc-batch-status.rst
+          :start-after: start-mc-batch-status-desc
+          :end-before: end-mc-batch-status-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-batch-describe
+   /reference/minio-mc/mc-batch-generate
+   /reference/minio-mc/mc-batch-list
+   /reference/minio-mc/mc-batch-start
+   /reference/minio-mc/mc-batch-status

--- a/source/reference/minio-mc/mc-encrypt.rst
+++ b/source/reference/minio-mc/mc-encrypt.rst
@@ -1,0 +1,58 @@
+==============
+``mc encrypt``
+==============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc encrypt
+
+
+Description
+-----------
+
+.. start-mc-encrypt-desc
+
+The :mc:`mc encrypt` commands set, update, or disable the default bucket Server-Side Encryption (SSE) mode. 
+MinIO automatically encrypts objects using the specified SSE mode.
+
+.. end-mc-encrypt-desc
+
+Subcommands
+-----------
+
+:mc:`mc encrypt` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc encrypt clear`
+     - .. include:: /reference/minio-mc/mc-encrypt-clear.rst
+          :start-after: start-mc-encrypt-clear-desc
+          :end-before: end-mc-encrypt-clear-desc
+
+   * - :mc:`~mc encrypt info`
+     - .. include:: /reference/minio-mc/mc-encrypt-info.rst
+          :start-after: start-mc-encrypt-info-desc
+          :end-before: end-mc-encrypt-info-desc
+
+   * - :mc:`~mc encrypt set`
+     - .. include:: /reference/minio-mc/mc-encrypt-set.rst
+          :start-after: start-mc-encrypt-set-desc
+          :end-before: end-mc-encrypt-set-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-encrypt-clear
+   /reference/minio-mc/mc-encrypt-info
+   /reference/minio-mc/mc-encrypt-set

--- a/source/reference/minio-mc/mc-event.rst
+++ b/source/reference/minio-mc/mc-event.rst
@@ -1,0 +1,62 @@
+============
+``mc event``
+============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc event
+
+
+Description
+-----------
+
+.. start-mc-event-desc
+
+The :mc:`mc event` command supports adding, removing, and listing bucket event notifications.
+
+.. end-mc-event-desc
+
+MinIO automatically sends triggered events to the configured notification targets. 
+MinIO supports notification targets like AMQP (RabbitMQ), Redis, ElasticSearch, NATS and PostgreSQL. 
+See :ref:`MinIO Bucket Notifications <minio-bucket-notifications>` for more information.
+
+
+Subcommands
+-----------
+
+:mc:`mc event` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc event add`
+     - .. include:: /reference/minio-mc/mc-event-add.rst
+          :start-after: start-mc-event-add-desc
+          :end-before: end-mc-event-add-desc
+
+   * - :mc:`~mc event list`
+     - .. include:: /reference/minio-mc/mc-event-list.rst
+          :start-after: start-mc-event-list-desc
+          :end-before: end-mc-event-list-desc
+
+   * - :mc:`~mc event remove`
+     - .. include:: /reference/minio-mc/mc-event-remove.rst
+          :start-after: start-mc-event-remove-desc
+          :end-before: end-mc-event-remove-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-event-add
+   /reference/minio-mc/mc-event-list
+   /reference/minio-mc/mc-event-remove

--- a/source/reference/minio-mc/mc-ilm.rst
+++ b/source/reference/minio-mc/mc-ilm.rst
@@ -1,0 +1,64 @@
+==========
+``mc ilm``
+==========
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ilm
+
+
+Description
+-----------
+
+.. start-mc-ilm-desc
+
+The :mc:`mc ilm` commands manage :ref:`object lifecycle management rules <minio-lifecycle-management>` and tiering on a MinIO deployment. 
+
+.. end-mc-ilm-desc
+
+Use these command to 
+
+- create tiers
+- create :ref:`tiering <minio-lifecycle-management-tiering>` rules
+- manage :ref:`expiration <minio-lifecycle-management-expiration>` rules for objects on a bucket
+     
+
+Subcommands
+-----------
+
+:mc:`mc ilm` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc ilm restore`
+     - .. include:: /reference/minio-mc/mc-ilm-restore.rst
+          :start-after: start-mc-ilm-restore-desc
+          :end-before: end-mc-ilm-restore-desc
+
+   * - :mc:`~mc ilm rule`
+     - .. include:: /reference/minio-mc/mc-ilm-rule.rst
+          :start-after: start-mc-ilm-rule-desc
+          :end-before: end-mc-ilm-rule-desc
+
+   * - :mc:`~mc ilm tier`
+     - .. include:: /reference/minio-mc/mc-ilm-tier.rst
+          :start-after: start-mc-ilm-tier-desc
+          :end-before: end-mc-ilm-tier-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-ilm-restore
+   /reference/minio-mc/mc-ilm-rule
+   /reference/minio-mc/mc-ilm-tier

--- a/source/reference/minio-mc/mc-legalhold-set.rst
+++ b/source/reference/minio-mc/mc-legalhold-set.rst
@@ -10,7 +10,6 @@
    :local:
    :depth: 2
 
-.. mc:: mc legalhold
 .. mc:: mc legalhold set
 
 .. |command| replace:: :mc:`mc legalhold set`

--- a/source/reference/minio-mc/mc-legalhold.rst
+++ b/source/reference/minio-mc/mc-legalhold.rst
@@ -1,0 +1,57 @@
+================
+``mc legalhold``
+================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc legalhold
+
+
+Description
+-----------
+
+.. start-mc-legalhold-desc
+
+The :mc:`mc legalhold` command sets, removes, or retrieves the :ref:`Object Legal Hold (WORM) <minio-object-locking-legalhold>` settings for object(s).
+
+.. end-mc-legalhold-desc
+
+Subcommands
+-----------
+
+:mc:`mc legalhold` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc legalhold clear`
+     - .. include:: /reference/minio-mc/mc-legalhold-clear.rst
+          :start-after: start-mc-legalhold-clear-desc
+          :end-before: end-mc-legalhold-clear-desc
+
+   * - :mc:`~mc legalhold info`
+     - .. include:: /reference/minio-mc/mc-legalhold-info.rst
+          :start-after: start-mc-legalhold-info-desc
+          :end-before: end-mc-legalhold-info-desc
+
+   * - :mc:`~mc legalhold set`
+     - .. include:: /reference/minio-mc/mc-legalhold-set.rst
+          :start-after: start-mc-legalhold-set-desc
+          :end-before: end-mc-legalhold-set-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-legalhold-clear
+   /reference/minio-mc/mc-legalhold-info
+   /reference/minio-mc/mc-legalhold-set

--- a/source/reference/minio-mc/mc-license-info.rst
+++ b/source/reference/minio-mc/mc-license-info.rst
@@ -13,8 +13,12 @@
 Description
 -----------
 
+.. start-mc-license-info-desc
+
 The :mc-cmd:`mc license info` command displays information about the MinIO deployment's license status.
 Specifically, whether the deployment uses the AGPLv3 Open Source license of the `MinIO Commercial License <https://min.io/product/subnet?ref=docs>`__.
+
+.. end-mc-license-info-desc
 
 You must register your deployment with MinIO |SUBNET| to activate your commercial license.
 

--- a/source/reference/minio-mc/mc-license-register.rst
+++ b/source/reference/minio-mc/mc-license-register.rst
@@ -15,7 +15,11 @@
 Description
 -----------
 
+.. start-mc-license-register-desc
+
 The :mc-cmd:`mc license register` command connects your deployment with your |SUBNET| account.
+
+.. end-mc-license-register-desc
 
 After registration, you can upload deployment health reports directly to SUBNET using the :mc-cmd:`mc support diag` command.
 

--- a/source/reference/minio-mc/mc-license-unregister.rst
+++ b/source/reference/minio-mc/mc-license-unregister.rst
@@ -14,9 +14,15 @@
 Description
 -----------
 
+.. start-mc-license-unregister-desc
+
 The :mc-cmd:`mc license unregister` command disconnects your deployment from your |SUBNET| account.
 
-After unregistering, you can no longer use the :mc:`mc support` commands.
+.. end-mc-license-unregister-desc
+
+.. important::
+
+   After unregistering, you can no longer use the :mc:`mc support` commands.
 
 
 Examples

--- a/source/reference/minio-mc/mc-license-update.rst
+++ b/source/reference/minio-mc/mc-license-update.rst
@@ -13,7 +13,11 @@
 Description
 -----------
 
+.. start-mc-license-update-desc
+
 Use the :mc-cmd:`mc license update` command to replace a license key for a deployment.
+
+.. end-mc-license-update-desc
 
 .. versionchanged:: RELEASE.2023-01-18T04-36-38Z
 

--- a/source/reference/minio-mc/mc-license.rst
+++ b/source/reference/minio-mc/mc-license.rst
@@ -1,0 +1,64 @@
+==============
+``mc license``
+==============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc license
+
+
+Description
+-----------
+
+.. start-mc-license-desc
+
+The :mc:`mc license` commands work with cluster registration for |SUBNET|. 
+Use the commands to register a deployment, unregister a deployment, display information about the cluster's current license, or update the license key for a cluster.
+
+.. end-mc-license-desc
+
+Subcommands
+-----------
+
+:mc:`mc license` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc license info`
+     - .. include:: /reference/minio-mc/mc-license-info.rst
+          :start-after: start-mc-license-info-desc
+          :end-before: end-mc-license-info-desc
+
+   * - :mc:`~mc license register`
+     - .. include:: /reference/minio-mc/mc-license-register.rst
+          :start-after: start-mc-license-register-desc
+          :end-before: end-mc-license-register-desc
+
+   * - :mc:`~mc license unregister`
+     - .. include:: /reference/minio-mc/mc-license-unregister.rst
+          :start-after: start-mc-license-unregister-desc
+          :end-before: end-mc-license-unregister-desc
+
+   * - :mc:`~mc license update`
+     - .. include:: /reference/minio-mc/mc-license-update.rst
+          :start-after: start-mc-license-update-desc
+          :end-before: end-mc-license-update-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-license-info
+   /reference/minio-mc/mc-license-register
+   /reference/minio-mc/mc-license-unregister
+   /reference/minio-mc/mc-license-update

--- a/source/reference/minio-mc/mc-quota.rst
+++ b/source/reference/minio-mc/mc-quota.rst
@@ -1,0 +1,59 @@
+============
+``mc quota``
+============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc quota
+
+
+Description
+-----------
+
+.. start-mc-quota-desc
+
+The :mc:`mc quota` commands configure, display, or remove a hard quota limit on a bucket. 
+
+.. end-mc-quota-desc
+
+When a bucket with a quota configured reaches the specified limit, MinIO rejects further ``PUT`` requests for the bucket. 
+
+Subcommands
+-----------
+
+:mc:`mc quota` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc quota clear`
+     - .. include:: /reference/minio-mc/mc-quota-clear.rst
+          :start-after: start-mc-quota-clear-desc
+          :end-before: end-mc-quota-clear-desc
+
+   * - :mc:`~mc quota info`
+     - .. include:: /reference/minio-mc/mc-quota-info.rst
+          :start-after: start-mc-quota-info-desc
+          :end-before: end-mc-quota-info-desc
+
+   * - :mc:`~mc quota set`
+     - .. include:: /reference/minio-mc/mc-quota-set.rst
+          :start-after: start-mc-quota-set-desc
+          :end-before: end-mc-quota-set-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-quota-clear
+   /reference/minio-mc/mc-quota-info
+   /reference/minio-mc/mc-quota-set

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -10,7 +10,6 @@
    :local:
    :depth: 2
 
-.. mc:: mc replicate
 .. mc:: mc replicate add
 
 .. versionchanged:: RELEASE.2022-12-24T15-21-38Z 

--- a/source/reference/minio-mc/mc-replicate.rst
+++ b/source/reference/minio-mc/mc-replicate.rst
@@ -1,0 +1,97 @@
+================
+``mc replicate``
+================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc replicate
+
+
+Description
+-----------
+
+.. start-mc-replicate-desc
+
+The :mc:`mc replicate <mc replicate add>` command configures and manages the :ref:`Server-Side Bucket Replication <minio-bucket-replication-serverside>` for a MinIO deployment, including :ref:`active-active replication configurations <minio-bucket-replication-serverside-twoway>` and :ref:`resynchronization <minio-replication-behavior-resync>`.
+
+.. end-mc-replicate-desc
+
+.. note::
+
+   For multi-site replication, see :mc:`mc admin replicate`.
+
+Subcommands
+-----------
+
+:mc:`mc replicate` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc replicate add`
+     - .. include:: /reference/minio-mc/mc-replicate-add.rst
+          :start-after: start-mc-replicate-add-desc
+          :end-before: end-mc-replicate-add-desc
+
+   * - :mc:`~mc replicate diff`
+     - .. include:: /reference/minio-mc/mc-replicate-diff.rst
+          :start-after: start-mc-replicate-diff-desc
+          :end-before: end-mc-replicate-diff-desc
+
+   * - :mc:`~mc replicate export`
+     - .. include:: /reference/minio-mc/mc-replicate-export.rst
+          :start-after: start-mc-replicate-export-desc
+          :end-before: end-mc-replicate-export-desc
+
+   * - :mc:`~mc replicate import`
+     - .. include:: /reference/minio-mc/mc-replicate-import.rst
+          :start-after: start-mc-replicate-import-desc
+          :end-before: end-mc-replicate-import-desc
+
+   * - :mc:`~mc replicate ls`
+     - .. include:: /reference/minio-mc/mc-replicate-ls.rst
+          :start-after: start-mc-replicate-ls-desc
+          :end-before: end-mc-replicate-ls-desc
+
+   * - :mc:`~mc replicate resync`
+     - .. include:: /reference/minio-mc/mc-replicate-resync.rst
+          :start-after: start-mc-replicate-resync-desc
+          :end-before: end-mc-replicate-resync-desc
+
+   * - :mc:`~mc replicate rm`
+     - .. include:: /reference/minio-mc/mc-replicate-rm.rst
+          :start-after: start-mc-replicate-rm-desc
+          :end-before: end-mc-replicate-rm-desc
+
+   * - :mc:`~mc replicate status`
+     - .. include:: /reference/minio-mc/mc-replicate-status.rst
+          :start-after: start-mc-replicate-status-desc
+          :end-before: end-mc-replicate-status-desc
+
+   * - :mc:`~mc replicate update`
+     - .. include:: /reference/minio-mc/mc-replicate-update.rst
+          :start-after: start-mc-replicate-update-desc
+          :end-before: end-mc-replicate-update-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-replicate-add
+   /reference/minio-mc/mc-replicate-diff
+   /reference/minio-mc/mc-replicate-ls
+   /reference/minio-mc/mc-replicate-update
+   /reference/minio-mc/mc-replicate-resync
+   /reference/minio-mc/mc-replicate-rm
+   /reference/minio-mc/mc-replicate-status
+   /reference/minio-mc/mc-replicate-export
+   /reference/minio-mc/mc-replicate-import

--- a/source/reference/minio-mc/mc-retention-clear.rst
+++ b/source/reference/minio-mc/mc-retention-clear.rst
@@ -19,14 +19,14 @@
 Syntax
 ------
 
-.. start-mc-retention-desc
+.. start-mc-retention-clear-desc
 
 The :mc:`mc retention clear` command removes the 
 :ref:`Write-Once Read-Many (WORM) locking <minio-object-locking>` settings for
 an object or object(s) in a bucket. You can also remove the default object lock
 settings for a bucket.
 
-.. end-mc-retention-desc
+.. end-mc-retention-clear-desc
 
 To change the retention status of an object under 
 :ref:`legal hold <minio-object-locking-legalhold>`, use 

--- a/source/reference/minio-mc/mc-retention-info.rst
+++ b/source/reference/minio-mc/mc-retention-info.rst
@@ -19,17 +19,17 @@
 Syntax
 ------
 
-.. start-mc-retention-desc
+.. start-mc-retention-info-desc
 
 The :mc:`mc retention info` command configures the :ref:`Write-Once Read-Many (WORM)
 locking <minio-object-locking>` settings for an object or object(s) in a bucket.
 You can also set the default object lock settings for a bucket, where all
 objects without explicit object lock settings inherit the bucket default.
 
-.. end-mc-retention-desc
+.. end-mc-retention-info-desc
 
 To lock an object under :ref:`legal hold <minio-object-locking-legalhold>`, 
-use :mc:`mc legalhold`.
+use :mc:`mc legalhold set`.
 
 :mc:`mc retention info` *requires* that the specified bucket has object locking
 enabled. You can **only** enable object locking at bucket creation. See

--- a/source/reference/minio-mc/mc-retention-set.rst
+++ b/source/reference/minio-mc/mc-retention-set.rst
@@ -10,7 +10,6 @@
    :local:
    :depth: 2
 
-.. mc:: mc retention
 .. mc:: mc retention set
 
 .. replacements for mc retention set
@@ -24,7 +23,7 @@
 Syntax
 ------
 
-.. start-mc-retention-desc
+.. start-mc-retention-set-desc
 
 The :mc:`mc retention set` command configures the
 :ref:`Write-Once Read-Many (WORM) locking <minio-object-locking>` settings for
@@ -32,10 +31,10 @@ an object or object(s) in a bucket. You can also set the default object lock
 settings for a bucket, where all objects without explicit object lock settings
 inherit the bucket default.
 
-.. end-mc-retention-desc
+.. end-mc-retention-set-desc
 
 To lock an object under :ref:`legal hold <minio-object-locking-legalhold>`, 
-use :mc:`mc legalhold`.
+use :mc:`mc legalhold set`.
 
 :mc:`mc retention set` *requires* that the specified bucket has object locking
 enabled. You can **only** enable object locking at bucket creation. See

--- a/source/reference/minio-mc/mc-retention.rst
+++ b/source/reference/minio-mc/mc-retention.rst
@@ -1,0 +1,58 @@
+================
+``mc retention``
+================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc retention
+
+
+Description
+-----------
+
+.. start-mc-retention-desc
+
+The :mc:`mc retention` command configures the :ref:`Write-Once Read-Many (WORM) locking <minio-object-locking>` settings for an object or object(s) in a bucket. 
+You can also set the default object lock settings for a bucket, where all objects without explicit object lock settings inherit the bucket default.
+
+.. end-mc-retention-desc
+
+Subcommands
+-----------
+
+:mc:`mc retention` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc retention clear`
+     - .. include:: /reference/minio-mc/mc-retention-clear.rst
+          :start-after: start-mc-retention-clear-desc
+          :end-before: end-mc-retention-clear-desc
+
+   * - :mc:`~mc retention info`
+     - .. include:: /reference/minio-mc/mc-retention-info.rst
+          :start-after: start-mc-retention-info-desc
+          :end-before: end-mc-retention-info-desc
+
+   * - :mc:`~mc retention set`
+     - .. include:: /reference/minio-mc/mc-retention-set.rst
+          :start-after: start-mc-retention-set-desc
+          :end-before: end-mc-retention-set-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-retention-set
+   /reference/minio-mc/mc-retention-info
+   /reference/minio-mc/mc-retention-clear

--- a/source/reference/minio-mc/mc-share-list.rst
+++ b/source/reference/minio-mc/mc-share-list.rst
@@ -13,12 +13,12 @@
 Syntax
 -----------
 
-.. start-mc-share-upload-desc
+.. start-mc-share-list-desc
 
 The :mc:`mc share list` command displays any unexpired presigned URLs generated
 by :mc:`mc share upload` or :mc:`mc share download`
 
-.. end-mc-share-upload-desc
+.. end-mc-share-list-desc
 
 Applications can perform a ``PUT`` to retrieve the object from the URL. 
 

--- a/source/reference/minio-mc/mc-share.rst
+++ b/source/reference/minio-mc/mc-share.rst
@@ -1,0 +1,57 @@
+============
+``mc share``
+============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc share
+
+
+Description
+-----------
+
+.. start-mc-share-desc
+
+Use the :mc:`mc share` commands to manage presigned URLs for downloading and uploading objects to a MinIO bucket.
+
+.. end-mc-share-desc
+
+Subcommands
+-----------
+
+:mc:`mc share` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc share download`
+     - .. include:: /reference/minio-mc/mc-share-download.rst
+          :start-after: start-mc-share-download-desc
+          :end-before: end-mc-share-download-desc
+
+   * - :mc:`~mc share list`
+     - .. include:: /reference/minio-mc/mc-share-list.rst
+          :start-after: start-mc-share-list-desc
+          :end-before: end-mc-share-list-desc
+
+   * - :mc:`~mc share upload`
+     - .. include:: /reference/minio-mc/mc-share-upload.rst
+          :start-after: start-mc-share-upload-desc
+          :end-before: end-mc-share-upload-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-share-download
+   /reference/minio-mc/mc-share-upload
+   /reference/minio-mc/mc-share-list

--- a/source/reference/minio-mc/mc-support-callhome.rst
+++ b/source/reference/minio-mc/mc-support-callhome.rst
@@ -17,7 +17,12 @@
 Description
 -----------
 
+.. start-mc-support-callhome-desc
+
 The :mc-cmd:`mc support callhome` command allows the enabling or disabling of reports from a deployment to |SUBNET|.
+
+.. end-mc-support-callhome-desc
+
 All ``mc support`` commands require an active SUBNET subscription.
 
 When enabled, MinIO can send logs to SUBNET in real time, diagnostics every 24 hours, or both.

--- a/source/reference/minio-mc/mc-support-diag.rst
+++ b/source/reference/minio-mc/mc-support-diag.rst
@@ -8,7 +8,6 @@
    :local:
    :depth: 1
 
-.. mc:: mc support
 .. mc:: mc support diag
 
 .. include:: /includes/common-mc-support.rst
@@ -18,7 +17,12 @@
 Description
 -----------
 
+.. start-mc-support-diag-desc
+
 The :mc-cmd:`mc support diag` command generates a health report for a MinIO deployment.
+
+.. end-mc-support-diag-desc
+
 For deployments registered with the MinIO subscription network (|subnet-short|), the command can automatically upload the health report for analysis.
 
 The resulting health report is intended for use by MinIO Engineering via SUBNET and may contain internal or private data points.

--- a/source/reference/minio-mc/mc-support-inspect.rst
+++ b/source/reference/minio-mc/mc-support-inspect.rst
@@ -17,7 +17,12 @@
 Description
 -----------
 
+.. start-mc-support-inspect-desc
+
 The :mc:`mc support inspect` command collects the data and metadata associated to objects at the specified path.
+
+.. end-mc-support-inspect-desc
+
 MinIO assembles this data from each backend drive storing an :ref:`erasure shard <minio-erasure-coding>` for each specified object.
 
 The command produces an encrypted zip file that includes all matching files with their respective *host+drive+path*.

--- a/source/reference/minio-mc/mc-support-perf.rst
+++ b/source/reference/minio-mc/mc-support-perf.rst
@@ -13,10 +13,13 @@
 Description
 -----------
 
+.. start-mc-support-perf-desc
+
 Use the :mc:`mc support perf` command to review the performance of the S3 API (read/write), network IO, and storage (drive read/write).
 
-The resulting tests can provide general guidance of deployment performance under S3 ``GET`` and ``PUT`` requests and identify any potential bottlenecks.
+.. end-mc-support-perf-desc
 
+The resulting tests can provide general guidance of deployment performance under S3 ``GET`` and ``PUT`` requests and identify any potential bottlenecks.
 For more complete performance testing, consider using a combination of load-testing using your staging application environments and the MinIO `WARP <https://github.com/minio/warp>`_ S3 benchmarking tool.
    
 :mc:`mc support perf` has three subcommands

--- a/source/reference/minio-mc/mc-support-profile.rst
+++ b/source/reference/minio-mc/mc-support-profile.rst
@@ -13,8 +13,12 @@
 Description
 -----------
 
+.. start-mc-support-profile-desc
+
 The :mc:`mc support profile` command runs a system profile for your deployment.
 The results of the profile can provide insight into the MinIO server process running on a given node.
+
+.. end-mc-support-profile-desc
 
 The resulting report is intended for use by MinIO Engineering.
 You can upload the report to |subnet|.

--- a/source/reference/minio-mc/mc-support-proxy.rst
+++ b/source/reference/minio-mc/mc-support-proxy.rst
@@ -13,8 +13,11 @@
 Description
 -----------
 
+.. start-mc-support-proxy-desc
+
 Use the :mc-cmd:`mc support proxy` command to configure a proxy to use to communicate with |SUBNET|.
 
+.. end-mc-support-proxy-desc
 
 Examples
 --------

--- a/source/reference/minio-mc/mc-support-top.rst
+++ b/source/reference/minio-mc/mc-support-top.rst
@@ -24,9 +24,11 @@ Description
 The :mc:`mc support top` command returns statistics for distributed
 MinIO deployments, similar to the output of the ``top`` command in a shell. 
 
-:mc:`mc support top` is not supported on single-node single-drive MinIO deployments.
-
 .. end-mc-support-top-desc
+
+.. note::
+
+   :mc:`mc support top` is not supported on single-node single-drive MinIO deployments.
 
 :mc-cmd:`mc support top` has the following subcommands:
 

--- a/source/reference/minio-mc/mc-support.rst
+++ b/source/reference/minio-mc/mc-support.rst
@@ -1,0 +1,87 @@
+==============
+``mc support``
+==============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc support
+
+
+Description
+-----------
+
+.. start-mc-support-desc
+
+The MinIO Client :mc:`mc support` commands provides tools for analyzing deployment health or performance and for running diagnostics.
+You can also upload generated health reports for further analysis by MinIO engineering.
+
+.. end-mc-support-desc
+
+.. important::
+
+   The ``mc support`` commands require an active |SUBNET| registration.
+
+
+Subcommands
+-----------
+
+:mc:`mc support` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc support callhome`
+     - .. include:: /reference/minio-mc/mc-support-callhome.rst
+          :start-after: start-mc-support-callhome-desc
+          :end-before: end-mc-support-callhome-desc
+
+   * - :mc:`~mc support diag`
+     - .. include:: /reference/minio-mc/mc-support-diag.rst
+          :start-after: start-mc-support-diag-desc
+          :end-before: end-mc-support-diag-desc
+
+   * - :mc:`~mc support inspect`
+     - .. include:: /reference/minio-mc/mc-support-inspect.rst
+          :start-after: start-mc-support-inspect-desc
+          :end-before: end-mc-support-inspect-desc
+
+   * - :mc:`~mc support perf`
+     - .. include:: /reference/minio-mc/mc-support-perf.rst
+          :start-after: start-mc-support-perf-desc
+          :end-before: end-mc-support-perf-desc
+
+   * - :mc:`~mc support profile`
+     - .. include:: /reference/minio-mc/mc-support-profile.rst
+          :start-after: start-mc-support-profile-desc
+          :end-before: end-mc-support-profile-desc
+
+   * - :mc:`~mc support proxy`
+     - .. include:: /reference/minio-mc/mc-support-proxy.rst
+          :start-after: start-mc-support-proxy-desc
+          :end-before: end-mc-support-proxy-desc
+
+   * - :mc:`~mc support top`
+     - .. include:: /reference/minio-mc/mc-support-top.rst
+          :start-after: start-mc-support-top-desc
+          :end-before: end-mc-support-top-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-support-callhome
+   /reference/minio-mc/mc-support-diag
+   /reference/minio-mc/mc-support-inspect
+   /reference/minio-mc/mc-support-perf
+   /reference/minio-mc/mc-support-profile
+   /reference/minio-mc/mc-support-proxy
+   /reference/minio-mc/mc-support-top

--- a/source/reference/minio-mc/mc-tag-set.rst
+++ b/source/reference/minio-mc/mc-tag-set.rst
@@ -10,7 +10,6 @@
    :local:
    :depth: 2
 
-.. mc:: mc tag
 .. mc:: mc tag set
 
 .. |command| replace:: :mc:`mc tag set`
@@ -66,8 +65,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The :ref:`alias <alias>` for a MinIO deployment and the
+   The :ref:`alias <alias>` for a MinIO deployment and the
    full path to the object on which to apply the tag (e.g. bucket and path to
    object). For example:
 
@@ -76,8 +76,9 @@ Parameters
       mc tag set myminio/mybucket/object.txt
 
 .. mc-cmd:: TAGS
+   :required:
 
-   *Required* An ampersand-seperated (``&``) list of key-value pairs
+   An ampersand-seperated (``&``) list of key-value pairs
    (``KEY=VALUE``), where each pair represents one tag to assign to the object.
    For example:
 

--- a/source/reference/minio-mc/mc-tag.rst
+++ b/source/reference/minio-mc/mc-tag.rst
@@ -1,0 +1,57 @@
+==========
+``mc tag``
+==========
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc tag
+
+
+Description
+-----------
+
+.. start-mc-tag-desc
+
+The :mc:`mc tag` command adds, removes, and lists tags associated to a bucket or object.
+
+.. end-mc-tag-desc
+
+Subcommands
+-----------
+
+:mc:`mc tag` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc tag list`
+     - .. include:: /reference/minio-mc/mc-tag-list.rst
+          :start-after: start-mc-tag-list-desc
+          :end-before: end-mc-tag-list-desc
+
+   * - :mc:`~mc tag remove`
+     - .. include:: /reference/minio-mc/mc-tag-remove.rst
+          :start-after: start-mc-tag-remove-desc
+          :end-before: end-mc-tag-remove-desc
+
+   * - :mc:`~mc tag set`
+     - .. include:: /reference/minio-mc/mc-tag-set.rst
+          :start-after: start-mc-tag-set-desc
+          :end-before: end-mc-tag-set-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   /reference/minio-mc/mc-tag-set
+   /reference/minio-mc/mc-tag-list
+   /reference/minio-mc/mc-tag-remove


### PR DESCRIPTION
- Adds landing pages for all two-word `mc` commands
- Nests three+ word commands under appropriate two-word commands
- Updates MinIO Client doc to only list two-word commands
- Uses description from each command to populate list of subcommand descriptions
- Modifies toctree for MinIO Client doc and each command/subcommand to improve left nav experienc

Closes #710

Staged at http://192.241.195.202:9000/staging/reference/reference/minio-mc.html