### PR TITLE
Updates to docs for mc RELEASE.2023-01-28T20-29-38Z

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct.rst
@@ -98,7 +98,8 @@ Syntax
                                         [--access-key]  \
                                         [--secret-key]  \
                                         [--policy]      \
-                                        ALIAS
+                                        [--commment]    \
+                                        ALIAS           \
                                         USER
 
    .. mc-cmd:: ALIAS
@@ -131,6 +132,14 @@ Syntax
       :optional:
 
       The path to a :ref:`policy document <minio-policy>` to attach to the new access keys. The attached policy cannot grant access to any action or resource not explicitly allowed by the parent user's policies.
+
+   .. mc-cmd:: --comment
+      :optional:
+
+      .. versionadded:: RELEASE.2023-01-28T20-29-38Z
+
+      Add a note to the service account.
+      For example, you might specify the reason the service account exists.
 
 .. mc-cmd:: list
    :fullpath:

--- a/source/reference/minio-mc/mc-ilm-restore.rst
+++ b/source/reference/minio-mc/mc-ilm-restore.rst
@@ -50,6 +50,7 @@ tier, while the temporary copy becomes ``HEAD`` for that object.
                           [--recursive]    \
                           [--vid "string"] \
                           [--versions]     \
+                          [--encrypt-key]  \
                           ALIAS
 
       .. include:: /includes/common-minio-mc.rst
@@ -61,39 +62,46 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The MinIO :ref:`alias <alias>`, bucket, and path to the
-   archived object to restore.
+   The MinIO :ref:`alias <alias>`, bucket, and path to the archived object to restore.
 
    .. code-block:: shell
 
       mc ilm restore myminio/mybucket/object.txt
 
-
 .. mc-cmd:: --days                     
-   
+   :optional:
 
-   *Optional* The number of days after which MinIO expires the restored copy
-   of the archived object.
-
+   The number of days after which MinIO expires the restored copy of the archived object.
 
 .. mc-cmd:: --recursive, r                  
-   
+   :optional:
 
-   *Optional* Restores all objects under the specified prefix.
-
+   Restores all objects under the specified prefix.
 
 .. mc-cmd:: --versions                       
-   
+   :optional:
 
-   *Optional* Restores all versions of the object on the remote tier.
-
+   Restores all versions of the object on the remote tier.
 
 .. mc-cmd:: --version-id, vid  
+   :optional:
+
+   Restores the specified version of the object on the remote tier.
+
+.. mc-cmd:: --encrypt-key
+   :optional:
+
+   .. versionadded:: RELEASE.2023-01-28T20-29-38Z
+
+   Encrypt or decrypt objects using server-side encryption with client-specified keys. 
+   Specify key-value pairs as ``KEY=VALUE``.
    
+   - Each ``KEY`` represents a bucket or object. 
+   - Each ``VALUE`` represents the data key to use for encrypting object(s).
 
-   *Optional* Restores the specified version of the object on the remote tier.
-
+   Enclose the entire list of key-value pairs passed to :mc-cmd:`~mc ilm restore --encrypt-key` in double quotes ``"``.
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-license-unregister.rst
+++ b/source/reference/minio-mc/mc-license-unregister.rst
@@ -39,7 +39,8 @@ The command has the following syntax:
 
 .. code-block:: shell
 
-   mc [GLOBALFLAGS] license unregister ALIAS
+   mc [GLOBALFLAGS] license unregister ALIAS       \
+                                       [--airgap]
 
 Parameters
 ~~~~~~~~~~
@@ -48,6 +49,14 @@ Parameters
    :required:
 
    The :ref:`alias <alias>` of the MinIO deployment.
+
+.. mc-cmd:: --airgap
+   :optional:
+
+   .. versionadded:: RELEASE.2023-01-28T20-29-38Z
+
+   Removes registration info from the deployment without also unregistering from SUBNET.
+   Use in environments without direct access to the Internet.
 
 
 Global Flags

--- a/source/reference/minio-mc/mc-support-perf.rst
+++ b/source/reference/minio-mc/mc-support-perf.rst
@@ -77,7 +77,7 @@ The command does not specify the blocksize, so the default of 4MiB is used.
 Test Drive Speed Measurements with Custom Specifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Run drive read/write performance measurements on a cluster with alias ``minio1`` specificying a blocksize of 64KiB and data read/written from each drive of 2GiB.
+Run drive read/write performance measurements on a cluster with alias ``minio1`` specifying a blocksize of 64KiB and data read/written from each drive of 2GiB.
 
 .. code-block:: shell
    :class: copyable
@@ -100,61 +100,49 @@ Syntax
 .. mc-cmd:: drive
    :fullpath:
 
-Measure the read/write speed of the drives in a cluster.
+   Measure the read/write speed of the drives in a cluster.
 
-.. code-block:: shell
+   .. code-block:: shell
                
-   mc [GLOBAL FLAGS] support perf drive   \
-                   [--concurrent]         \
-                   [--verbose, -v]        \
-                   [--filesize]           \
-                   [--blocksize]          \
-                   [--serial]             \
-                   [--airgap]             \
-                   ALIAS
+      mc [GLOBAL FLAGS] support perf drive   \
+                      [--concurrent]         \
+                      [--verbose, -v]        \
+                      [--filesize]           \
+                      [--blocksize]          \
+                      [--serial]             \
+                      [--airgap]             \
+                      ALIAS
 
 .. mc-cmd:: object
    :fullpath:
 
-Measure the S3 peformance of reading and writing objects in a cluster.
+   Measure the S3 performance of reading and writing objects in a cluster.
 
-.. code-block:: shell
+   .. code-block:: shell
                
-   mc [GLOBAL FLAGS] support perf object  \
-                   [--duration]           \
-                   [--size]               \
-                   [--concurrent]         \
-                   [--verbose, -v]        \
-                   [--airgap]             \
-                   ALIAS  
+      mc [GLOBAL FLAGS] support perf object  \
+                      [--size]               \
+                      [--concurrent]         \
+                      [--verbose, -v]        \
+                      [--airgap]             \
+                      ALIAS  
             
 .. mc-cmd:: net
    :fullpath:
 
    Measure the network throughput of all nodes in a cluster.
 
-.. code-block:: shell
+   .. code-block:: shell
 
-   mc [GLOBAL FLAGS] support perf net  \
-                   [--concurrent]      \
-                   [--verbose, -v]     \
-                   [--serial]          \
-                   [--airgap]          \
-                   ALIAS
+      mc [GLOBAL FLAGS] support perf net  \
+                      [--concurrent]      \
+                      [--verbose, -v]     \
+                      [--serial]          \
+                      [--airgap]          \
+                      ALIAS
 
 Parameters
 ~~~~~~~~~~
-
-.. mc-cmd:: --duration
-   :optional:
-
-   Applies to the :mc-cmd:`~mc support perf object` command.
-
-   Specify the duration for the performance tests to run.
-
-   If not specified, the default value is ``10s``.
-
-   Use ``--duration <value>`` where ``<value>`` is a number and a unit of ``s`` for seconds, ``m`` for minutes.
 
 .. mc-cmd:: --airgap
    :optional:


### PR DESCRIPTION
Updates related to [mc RELEASE.2023-01-28T20-29-38Z](https://github.com/minio/mc/releases/tag/RELEASE.2023-01-28T20-29-38Z)

- new `--comment` flag for `mc admin user add` service accounts
- new `--airgap` flag for `mc license unregister`
- new `--encrypt-key` flag for `mc ilm restore`
- removed `--duration` flag for `mc support perf`
- new `--api-key` flag for `mc license register`

No doc issue for tracking this release.

Closes #715 for ilm restore flag