### PR TITLE
DOCS-690, DOCS-707: Release updates

### DIFF
--- a/source/administration/console/managing-deployment.rst
+++ b/source/administration/console/managing-deployment.rst
@@ -57,9 +57,8 @@ Audit
 
 .. important::
 
-   The MinIO Tenant Console Audit Log feature is scheduled for deprecation and removal in an upcoming release.
-
-   You can instead use any webhook-capable database or logging service to capture :ref:`audit logs <minio-logging-publish-audit-logs>` from the Tenant.
+   MinIO plans to deprecate the Tenant Console Audit Log feature and remove it in an upcoming release.
+   As an alternative, use any webhook-capable database or logging service to capture :ref:`audit logs <minio-logging-publish-audit-logs>` from the Tenant.
 
 The Audit Log section provides an interface for viewing :ref:`audit logs <minio-logging>` collected by a configured PostgreSQL service.
 

--- a/source/administration/console/managing-deployment.rst
+++ b/source/administration/console/managing-deployment.rst
@@ -55,6 +55,12 @@ Select the :guilabel:`Start Logs` button to begin collecting logs using the sele
 Audit
 ~~~~~
 
+.. important::
+
+   The MinIO Tenant Console Audit Log feature is scheduled for deprecation and removal in an upcoming release.
+
+   You can instead use any webhook-capable database or logging service to capture :ref:`audit logs <minio-logging-publish-audit-logs>` from the Tenant.
+
 The Audit Log section provides an interface for viewing :ref:`audit logs <minio-logging>` collected by a configured PostgreSQL service.
 
 The Audit Logging feature is configured and enabled automatically for MinIO deployments created using the :ref:`MinIO Operator Console <minio-operator-console>`.
@@ -108,6 +114,21 @@ Site Replication
 The :guilabel:`Site Replication` section provides an interface for adding and managing the :ref:`site replication <minio-site-replication-overview>` configuration for the deployment.
 
 Configuring site replication requires that only a single site have existing buckets or objects (if any).
+
+.. _minio-console-encryption:
+
+Encryption
+----------
+
+The :guilabel:`Encryption` setting provides an interface for listing, creating, and deleting keys for use with :ref:`MinIO Server-Side Encryption <minio-sse>`.
+
+You can use keys created or listed in this view for object encryption operations, including setting a :ref:`bucket-level default key <minio-console-buckets>`.
+
+.. important::
+
+   Deleting a key prevents MinIO from decrypting any objects protected with that key.
+   If no backups of that key exist, deleting a key renders objects permanently unreadable.
+   See :ref:`minio-encryption-sse-secure-erasure-locking` for more information.
 
 .. _minio-console-settings:
 

--- a/source/administration/console/managing-objects.rst
+++ b/source/administration/console/managing-objects.rst
@@ -49,6 +49,8 @@ Example actions the user may be able to perform include:
 
 .. _minio-console-buckets:
 
+.. _minio-console-admin-buckets:
+
 Buckets
 -------
 
@@ -86,7 +88,7 @@ When managing a bucket, your access settings may allow you to view or change any
 
 - The :guilabel:`Summary` section displays a summary of the bucket's configuration.
 
-  Use this section to view and modify the bucket's policy, encryption, quota, and tags.
+  Use this section to view and modify the bucket's access policy, encryption, quota, and tags.
 
 - Configure alerts in the :guilabel:`Events` section to trigger :ref:`notification events <minio-bucket-notifications>` when a user uploads, accesses, or deletes matching objects.
 

--- a/source/includes/common/common-k8s-deprecation-audit-prometheus.rst
+++ b/source/includes/common/common-k8s-deprecation-audit-prometheus.rst
@@ -1,0 +1,21 @@
+.. start-deprecate-audit-logs
+
+.. important::
+
+   The MinIO Tenant Console Audit Log feature is scheduled for deprecation and removal in an upcoming release.
+   MinIO recommends disabling this feature in preparation for this change.
+
+   You can instead use any webhook-capable database or logging service to capture :ref:`audit logs <minio-logging-publish-audit-logs>` from the Tenant.
+
+.. end-deprecate-audit-logs
+
+.. start-deprecate-prometheus
+
+.. important::
+
+   The Tenant Prometheus pod feature is scheduled for deprecation and removal in an upcoming release.
+   MinIO recommends setting this value to ``false`` in preparation for this change.
+
+   You can instead use any Prometheus service deployed within the Kubernetes cluster or externally to :ref:`capture Tenant metrics <minio-metrics-collect-using-prometheus>`.
+
+.. end-deprecate-prometheus

--- a/source/includes/common/common-k8s-deprecation-audit-prometheus.rst
+++ b/source/includes/common/common-k8s-deprecation-audit-prometheus.rst
@@ -2,10 +2,10 @@
 
 .. important::
 
-   The MinIO Tenant Console Audit Log feature is scheduled for deprecation and removal in an upcoming release.
+   MinIO plans to deprecate the Tenant Console Audit Log feature and remove it in an upcoming release.
    MinIO recommends disabling this feature in preparation for this change.
 
-   You can instead use any webhook-capable database or logging service to capture :ref:`audit logs <minio-logging-publish-audit-logs>` from the Tenant.
+   As an alternative, use any webhook-capable database or logging service to capture :ref:`audit logs <minio-logging-publish-audit-logs>` from the Tenant.
 
 .. end-deprecate-audit-logs
 
@@ -13,9 +13,9 @@
 
 .. important::
 
-   The Tenant Prometheus pod feature is scheduled for deprecation and removal in an upcoming release.
+   MinIO plans to deprecate the Tenant Prometheus pod feature and remove it in an upcoming release.
    MinIO recommends setting this value to ``false`` in preparation for this change.
 
-   You can instead use any Prometheus service deployed within the Kubernetes cluster or externally to :ref:`capture Tenant metrics <minio-metrics-collect-using-prometheus>`.
+   As an alternative, use any Prometheus service deployed within the Kubernetes cluster or externally to :ref:`capture Tenant metrics <minio-metrics-collect-using-prometheus>`.
 
 .. end-deprecate-prometheus

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -632,19 +632,19 @@ Enabling SSE also creates :minio-git:`MinIO Key Encryption Service <kes>` pods i
      - Select the storage class and requested capacity associated to the PVC generated to support audit logging.
 
    * - Storage Size
-     - Specify the amount of size of storage to make available for audit logging.
+     - Specify the size of storage to make available for audit logging.
 
    * - :guilabel:`SecurityContext for LogSearch`
      - The MinIO Operator deploys a Log Search service (SQL Database and Log Search API) to support Audit Log search in the MinIO Tenant Console.
 
-       You can modify the Security Context to run the associated pod commands using a different User, Group, FsGroup, or FSGroupChangePolicy. 
-       You can also direct the pod to not run commands as the Root user.
+       You can modify the Security Context to run the associated pod commands using a different ``User``, ``Group``, ``FsGroup``, or ``FSGroupChangePolicy``. 
+       You can also direct the pod to not run commands as the ``Root`` user.
 
    * - :guilabel:`SecurityContext for PostgreSQL`
      - The MinIO Operator deploys a PostgreSQL database to support logging services.
 
-       You can modify the Security Context to run the associated pod commands using a different User, Group, FsGroup, or FSGroupChangePolicy. 
-       You can also direct the pod to not run commands as the Root user.
+       You can modify the Security Context to run the associated pod commands using a different ``User``, ``Group``, ``FsGroup``, or ``FSGroupChangePolicy``. 
+       You can also direct the pod to not run commands as the ``Root`` user.
 
        You can also modify the storage class and requested capacity associated to the PVC generated to support the Prometheus service.
 
@@ -669,13 +669,13 @@ Enabling SSE also creates :minio-git:`MinIO Key Encryption Service <kes>` pods i
      - Select the storage class and requested capacity associated to the PVC generated to support Prometheus.
 
    * - Storage Size
-     - Specify the amount of size of storage to make available for Prometheus.
+     - Specify the size of storage to make available for Prometheus.
 
    * - :guilabel:`SecurityContext`
-     - The MinIO Operator assigns this Security Context for the Prometheus pod
+     - The MinIO Operator assigns this Security Context for the Prometheus pod.
 
-       You can modify the Security Context to run the associated pod commands using a different User, Group, FsGroup, or FSGroupChangePolicy. 
-       You can also direct the pod to not run commands as the Root user.
+       You can modify the Security Context to run the associated pod commands using a different ``User``, ``Group``, ``FsGroup``, or ``FSGroupChangePolicy``. 
+       You can also direct the pod to not run commands as the ``Root`` user.
 
 .. _create-tenant-deploy-view-tenant:
 

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -217,6 +217,8 @@ To deploy a tenant from the MinIO Operator Console, complete the following steps
 
 :ref:`minio-tenant-audit-logging-settings`
 
+:ref:`minio-tenant-monitoring-settings`
+
 :ref:`create-tenant-deploy-view-tenant`
 
 :ref:`create-tenant-connect-tenant`
@@ -614,6 +616,10 @@ Enabling SSE also creates :minio-git:`MinIO Key Encryption Service <kes>` pods i
 9) Audit Log Settings
 ~~~~~~~~~~~~~~~~~~~~~~
 
+.. include:: /includes/common/common-k8s-deprecation-audit-prometheus.rst
+   :start-after: start-deprecate-audit-logs
+   :end-before: end-deprecate-audit-logs
+
 .. list-table::
    :header-rows: 1
    :widths: 30 70
@@ -634,8 +640,6 @@ Enabling SSE also creates :minio-git:`MinIO Key Encryption Service <kes>` pods i
        You can modify the Security Context to run the associated pod commands using a different User, Group, FsGroup, or FSGroupChangePolicy. 
        You can also direct the pod to not run commands as the Root user.
 
-       
-
    * - :guilabel:`SecurityContext for PostgreSQL`
      - The MinIO Operator deploys a PostgreSQL database to support logging services.
 
@@ -644,9 +648,38 @@ Enabling SSE also creates :minio-git:`MinIO Key Encryption Service <kes>` pods i
 
        You can also modify the storage class and requested capacity associated to the PVC generated to support the Prometheus service.
 
+.. _minio-tenant-monitoring-settings:
+
+10) Monitoring Settings
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common/common-k8s-deprecation-audit-prometheus.rst
+   :start-after: start-deprecate-prometheus
+   :end-before: end-deprecate-prometheus
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Field
+     - Description
+
+   * - Storage Class
+     - Select the storage class and requested capacity associated to the PVC generated to support Prometheus.
+
+   * - Storage Size
+     - Specify the amount of size of storage to make available for Prometheus.
+
+   * - :guilabel:`SecurityContext`
+     - The MinIO Operator assigns this Security Context for the Prometheus pod
+
+       You can modify the Security Context to run the associated pod commands using a different User, Group, FsGroup, or FSGroupChangePolicy. 
+       You can also direct the pod to not run commands as the Root user.
+
 .. _create-tenant-deploy-view-tenant:
 
-10) Deploy and View the Tenant
+11) Deploy and View the Tenant
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Select :guilabel:`Create` at any time to begin the deployment process. 
@@ -674,7 +707,7 @@ Each tab provides additional details or configuration options for the MinIO Tena
 
 .. _create-tenant-connect-tenant:
 
-11) Connect to the Tenant
+12) Connect to the Tenant
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The MinIO Operator creates services for the MinIO Tenant. 
@@ -732,7 +765,7 @@ Kubernetes provides multiple options for configuring external access to services
 
 .. _create-tenant-operator-forward-ports:
 
-12) Forward Ports
+13) Forward Ports
 ~~~~~~~~~~~~~~~~~
 
 .. cond:: k8s and not openshift

--- a/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
+++ b/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
@@ -27,15 +27,6 @@ The procedure on this page documents the following:
 
    - An :mc:`mc` installation on your local host configured to :ref:`access <alias>` the MinIO deployment
 
-.. cond:: k8s
-
-   The MinIO Operator supports deploying a :ref:`per-tenant Prometheus instance <create-tenant-configure-section>` configured to support metrics and visualizations.
-   This includes automatically configuring the Tenant to enable the :ref:`Tenant Console historical metric view <minio-console-metrics>`.
-
-   You can still use this procedure to configure an external Prometheus service for supporting monitoring and alerting for a MinIO Tenant.
-   You must configure all necessary network control components, such as Ingress or a Load Balancer, to facilitate access between the Tenant and the Prometheus service.
-   This procedure assumes your local host machine can access the Tenant via :mc:`mc`.
-
 Configure Prometheus to Collect and Alert using MinIO Metrics
 -------------------------------------------------------------
 
@@ -75,6 +66,12 @@ The command returns output similar to the following:
 - Set the ``targets`` array with a hostname that resolves to the MinIO deployment.
 
   This can be any single node, or a load balancer/proxy which handles connections to the MinIO nodes.
+
+  .. cond:: k8s
+
+     For Prometheus deployments in the same cluster as the MinIO Tenant, you can specify the service DNS name for the ``minio`` service.
+
+     For Prometheus deployments external to the cluster, you must specify an ingress or load balancer endpoint configured to route connections to and from the MinIO Tenant.
 
 2) Restart Prometheus with the Updated Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/kubectl-minio-plugin/kubectl-minio-init.rst
+++ b/source/reference/kubectl-minio-plugin/kubectl-minio-init.rst
@@ -49,6 +49,7 @@ Syntax
          kubectl minio init                      \
                        [--cluster-domain]        \
                        [--console-image]         \
+                       [--console-tls]           \
                        [--default-console-image] \
                        [--default-kes-image]     \
                        [--default-minio-image]   \
@@ -83,6 +84,15 @@ The command supports the following flags:
 
    The image to use when deploying the :minio-git:`MinIO Console <console>` in Operator mode, where administrators can create and manage MinIO tenants using a Graphical User Interface.
    Defaults to ``minio/console:v0.17.3``.
+
+.. mc-cmd:: --console-tls
+   :optional:
+
+   .. versionadded:: 4.5.6
+
+   Enables TLS for the Operator Console.
+
+   Disabled by default.
 
 .. mc-cmd:: --default-console-image
    :optional:

--- a/source/reference/kubectl-minio-plugin/kubectl-minio-tenant-create.rst
+++ b/source/reference/kubectl-minio-plugin/kubectl-minio-tenant-create.rst
@@ -70,20 +70,24 @@ Syntax
 
       .. code-block:: shell
 
-         kubectl minio tenant create                  \
-                              TENANT_NAME             \
-                              [--interactive]         \
-                              --capacity              \
-                              --servers               \
-                              --volumes               \
-                              [--enable-host-sharing] \
-                              [--image]               \
-                              [--image-pull-secret]   \
-                              [--kes-config]          \
-                              [--namespace]           \
-                              [--output]              \
-                              [--pool]                \
-                              [--storage-class] 
+         kubectl minio tenant create                      \
+                              TENANT_NAME                 \                          
+                              [--interactive]             \
+                              [--disable-tls]             \
+                              [--enable-audit-logs]       \
+                              [--enable-prometheus]       \
+                              [--expose-console-service]  \
+                              [--expose-minio-service]    \
+                              [--image]                   \
+                              [--image-pull-secret]       \
+                              [--kes-config]              \
+                              [--namespace]               \
+                              [--output]                  \
+                              [--pool]                    \
+                              [--storage-class]           \
+                              --capacity                  \
+                              --servers                   \
+                              --volumes                   \
 
 
 Flags
@@ -148,15 +152,93 @@ The command supports the following flags:
 
    If the specified number of volumes exceeds the number of unbound ``PV`` available on the cluster, :mc:`kubectl minio tenant create` hangs and waits until the required ``PV`` exist.
 
-.. mc-cmd:: --enable-host-sharing
+.. mc-cmd:: --disable-tls
    :optional:
 
-   .. important::
-   
-      To be used in testing environments only.
-      This flag is **not** supported in production environments.
-   
-   Disable pod anti-affinity to allow co-location of pods on a single node.
+   Disables automatic TLS certificate provisioning on the Tenant.
+
+.. mc-cmd:: --enable-audit-logs
+   :optional:
+
+   .. include:: /includes/common/common-k8s-deprecation-audit-prometheus.rst
+      :start-after: start-deprecate-audit-logs
+      :end-before: end-deprecate-audit-logs
+
+   Defaults to ``true``.
+
+   Deploys the MinIO Tenant with a PostgreSQL Pod which, combined with an additional auto-deployed service, enables Audit Logging in the Tenant Console.
+
+   You can control the configuration of the PostgreSQL pod using the following optional parameters:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 40 60
+      :width: 80%
+
+      * - Option
+        - Description
+
+      * - ``--audit-logs-disk-space <int>``
+        - Specify the amount of storage to provision for the PostgreSQL pod.
+          The Operator provisions a PVC requesting the specified amount of storage in gigabytes.
+
+          Defaults to ``5``
+
+          If no Persistent Volume can meet the PVC request, the pod fails to deploy.
+
+      * - ``--audit-logs-pg-image``
+        - Specify the Docker image to use for deploying the PostgreSQL pod.
+
+      * - ``--audit-logs-storage-class``
+        - Specify the storage class to assign to the generated PVC for the PostgreSQL Pod.
+
+   Specify ``false`` to deploy the Tenant without the PostgreSQL and Audit Logging Console feature.
+
+.. mc-cmd:: --enable-prometheus
+   :optional:
+
+   .. include:: /includes/common/common-k8s-deprecation-audit-prometheus.rst
+      :start-after: start-deprecate-prometheus
+      :end-before: end-deprecate-prometheus
+
+   Defaults to ``true``.
+
+   Deploys the MinIO Tenant with a Prometheus pod which enables the :ref:`MinIO Console Metrics <minio-console-monitoring>` view.
+
+   You can control the configuration of the Prometheus pod using the following optional parameters:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 40 60
+      :width: 80%
+
+      * - Option
+        - Description
+
+      * - ``--prometheus-disk-space <int>``
+        - Specify the amount of storage to provision for the Prometheus pod.
+          The Operator provisions a PVC requesting the specified amount of storage in gigabytes.
+
+          Defaults to ``5``.
+
+      * - ``--prometheus-image``
+        - Specify the Docker image to use for deploying the Prometheus pod.
+
+      * - ``--prometheus-storage-class``
+        - Specify the storage class to assign to the generated PVC for the Prometheus pod.
+
+
+.. mc-cmd:: --expose-console-service
+   :optional:
+
+   Directs the Operator to configure the MinIO Tenant Console service with the :kube-docs:`LoadBalancer <concepts/services-networking/service/#loadbalancer>` networking type. 
+   For Kubernetes clusters configured with a global load balancer, this option allows the Console to request an external IP address automatically.
+
+.. mc-cmd:: --expose-minio-service
+   :optional:
+
+   Directs the Operator to configure the MinIO API service with the :kube-docs:`LoadBalancer <concepts/services-networking/service/#loadbalancer>` networking type. 
+   For Kubernetes clusters configured with a global load balancer, this option allows the Console to request an external IP address automatically.
 
 .. mc-cmd:: --image
    :optional:


### PR DESCRIPTION
Closes #690 

Closes #707 

Partially addresses scheduled removal of Console Audit Log and Tenant Prometheus deployments

Staged:

- http://192.241.195.202:9000/staging/k8s-fixups/operations/install-deploy-manage/deploy-minio-tenant.html#minio-tenant-audit-logging-settings
- http://192.241.195.202:9000/staging/k8s-fixups/operations/install-deploy-manage/deploy-minio-tenant.html#monitoring-settings
- http://192.241.195.202:9000/staging/k8s-fixups/reference/kubectl-minio-plugin/kubectl-minio-tenant-create.html
- 