### PR TITLE
mc admin speedtest and mc ping updates

### DIFF
--- a/source/reference/deprecated/mc-admin-speedtest.rst
+++ b/source/reference/deprecated/mc-admin-speedtest.rst
@@ -8,6 +8,8 @@
    :local:
    :depth: 2
 
+.. mc:: mc admin speedtest
+
 .. versionchanged:: RELEASE.2022-07-24T02-25-13Z
 
 .. important:: 

--- a/source/reference/deprecated/mc-admin-speedtest.rst
+++ b/source/reference/deprecated/mc-admin-speedtest.rst
@@ -8,7 +8,11 @@
    :local:
    :depth: 2
 
-.. mc:: mc admin speedtest
+.. versionchanged:: RELEASE.2022-07-24T02-25-13Z
+
+.. important:: 
+
+   The ``mc admin speedtest`` function has moved to the :mc:`mc support perf` command.
 
 Description
 -----------

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -120,11 +120,6 @@ The following table lists :mc:`mc admin` commands:
           :start-after: start-mc-admin-service-desc
           :end-before: end-mc-admin-service-desc
 
-   * - :mc-cmd:`mc admin speedtest`
-     - .. include:: /reference/minio-mc-admin/mc-admin-speedtest.rst
-          :start-after: start-mc-admin-speedtest-desc
-          :end-before: end-mc-admin-speedtest-desc
-
    * - :mc-cmd:`mc admin top`
      - .. include:: /reference/minio-mc-admin/mc-admin-top.rst
           :start-after: start-mc-admin-top-desc

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -108,10 +108,6 @@ Table of Deprecated Admin Commands
      - :mc-cmd:`mc quota clear`, :mc-cmd:`mc quota info`, :mc-cmd:`mc quota set`
      - mc RELEASE.2022-12-13T00-23-28Z
 
-
-
-
-
 .. toctree::
    :titlesonly:
    :hidden:
@@ -124,3 +120,4 @@ Table of Deprecated Admin Commands
    /reference/deprecated/mc-ilm-rm
    /reference/deprecated/mc-admin-tier
    /reference/deprecated/mc-admin-bucket-quota
+   /reference/deprecated/mc-admin-speedtest

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -72,6 +72,10 @@ Table of Deprecated Admin Commands
      - :mc:`mc admin replicate rm`
      - mc RELEASE.2023-01-11T03-14-16Z
 
+   * - ``mc admin speedtest``
+     - :mc:`mc support perf`
+     - mc RELEASE.2022-07-24T02-25-13Z
+
    * - ``mc admin tier add``
      - :mc:`mc ilm tier add`
      - mc RELEASE.2022-12-24T15-21-38Z

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -280,6 +280,11 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-od-desc
           :end-before: end-mc-od-desc
 
+   * - :mc:`mc ping`
+     - .. include:: /reference/minio-mc/mc-ping.rst
+          :start-after: start-mc-ping-desc
+          :end-before: end-mc-ping-desc  
+
    * - :mc:`mc pipe`
      - .. include:: /reference/minio-mc/mc-pipe.rst
           :start-after: start-mc-pipe-desc
@@ -540,6 +545,7 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-mirror
    /reference/minio-mc/mc-mv
    /reference/minio-mc/mc-od
+   /reference/minio-mc/mc-ping
    /reference/minio-mc/mc-pipe
    /reference/minio-mc/mc-quota
    /reference/minio-mc/mc-rb

--- a/source/reference/minio-mc/mc-ping.rst
+++ b/source/reference/minio-mc/mc-ping.rst
@@ -28,7 +28,7 @@ The :mc:`mc ping` command performs a liveness check on a specified target.
       .. code-block:: shell
          :class: copyable
 
-         mc ping play -c 5
+         mc ping play --count 5
 
       The command pings the deployment at the :mc:`~mc alias` ``play`` for five cycles.
       The output resembles the following:
@@ -67,14 +67,14 @@ Parameters
 
    The full path to the :ref:`alias <minio-mc-alias>` or prefix where the command should run.
 
-.. mc-cmd:: --count, -c
+.. mc-cmd:: --count
    :optional:
 
    Specify the number of times to perform the check.
 
    If not specified, the liveness check performs continuously until stopped.
 
-.. mc-cmd:: --error-count, -e
+.. mc-cmd:: --error-count
    :optional:
    
    Specify a number of errors to receive before exiting.
@@ -86,14 +86,14 @@ Parameters
 
       mc ping TARGET -e 5
 
-.. mc-cmd:: --interval, -i
+.. mc-cmd:: --interval
    :optional:
 
    The length of time in seconds to wait between requests.
 
    By default, the command waits 1 second between requests.
 
-.. mc-cmd:: --distributed, -a
+.. mc-cmd:: --distributed
    :optional:
 
    Send requests to all servers in the MinIO cluster.

--- a/source/reference/minio-mc/mc-ping.rst
+++ b/source/reference/minio-mc/mc-ping.rst
@@ -1,0 +1,144 @@
+===========
+``mc ping``
+===========
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc ping
+
+Syntax
+------
+
+.. start-mc-pipe-desc
+
+The :mc:`mc ping` command performs a liveness check on a specified target.
+
+.. end-mc-pipe-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following sends a response request to the target(s) and outputs the minimum, maximum, average, and roundtrip times of the response, as well as the number of errors encountered when processing the request.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc ping play -c 5
+
+      The command pings the deployment at the :mc:`~mc alias` ``play`` for five cycles.
+      The output resembles the following:
+
+      .. code-block:: shell
+
+         1: https://play.min.io   min=213.00ms   max=213.00ms   average=213.00ms   errors=0   roundtrip=213.00ms
+         2: https://play.min.io   min=67.15ms    max=213.00ms   average=140.07ms   errors=0   roundtrip=67.15ms 
+         3: https://play.min.io   min=67.15ms    max=213.00ms   average=115.85ms   errors=0   roundtrip=67.41ms 
+         4: https://play.min.io   min=61.26ms    max=213.00ms   average=102.20ms   errors=0   roundtrip=61.26ms 
+         5: https://play.min.io   min=61.26ms    max=213.00ms   average=95.03ms    errors=0   roundtrip=66.36ms 
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] ping                       \
+                          TARGET                     \
+                          [--count, -c value]        \
+                          [--error-count, -e value]  \
+                          [--interval, -i value]     \
+                          [--distributed, -a value]
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the :ref:`alias <minio-mc-alias>` or prefix where the command should run.
+
+.. mc-cmd:: --count, -c
+   :optional:
+
+   Specify the number of times to perform the check.
+
+   If not specified, the liveness check performs continuously until stopped.
+
+.. mc-cmd:: --error-count, -e
+   :optional:
+   
+   Specify a number of errors to receive before exiting.
+
+   For example, to stop the ping process after receiving five errors, use
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc ping TARGET -e 5
+
+.. mc-cmd:: --interval, -i
+   :optional:
+
+   The length of time in seconds to wait between requests.
+
+   By default, the command waits 1 second between requests.
+
+.. mc-cmd:: --distributed, -a
+   :optional:
+
+   Send requests to all servers in the MinIO cluster.
+         
+   .. note::
+      
+      Use this option for distributed deployments where you have direct access to each node or pod.
+      This flag does not work when nodes are placed behind a service, such as a load balancer.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Return Latency and Liveness for 5 Requests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command sends a liveness check for a deployment with the alias ``myminio`` five times, outputs the result of each check, then ends.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ping myminio --count 5
+
+Send Liveness Checks Repeatedly with 5 Minute Wait Between Each Request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command sends continuous liveness check requests with an interval of 5 minutes (300 seconds) between each request.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ping myminio --interval 300
+
+End Liveness Checks for Error Counts Greater Than 20
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command sends continuous liveness checks until 20 errors have been encountered:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ping myminio --error-count 20

--- a/source/reference/minio-mc/mc-support-perf.rst
+++ b/source/reference/minio-mc/mc-support-perf.rst
@@ -8,7 +8,12 @@
    :local:
    :depth: 1
 
+.. mc:: mc admin speedtest
 .. mc:: mc support perf
+
+.. versionchanged:: RELEASE.2022-07-24T02-25-13Z
+
+   ``mc support perf`` replaces the ``mc admin speedtest`` command.
 
 Description
 -----------

--- a/source/reference/minio-mc/mc-support-perf.rst
+++ b/source/reference/minio-mc/mc-support-perf.rst
@@ -8,7 +8,6 @@
    :local:
    :depth: 1
 
-.. mc:: mc admin speedtest
 .. mc:: mc support perf
 
 .. versionchanged:: RELEASE.2022-07-24T02-25-13Z


### PR DESCRIPTION
- Adds `mc ping` doc

Closes #538 

- Deprecates `mc admin speedtest` to `mc support perf`

Closes #678 

Staged
- http://192.241.195.202:9000/staging/speedtest/reference/minio-mc/mc-ping.html
- http://192.241.195.202:9000/staging/speedtest/reference/minio-mc-deprecated.html
- http://192.241.195.202:9000/staging/speedtest/reference/deprecated/mc-admin-speedtest.html