### PR TITLE
Changes for mid-February releases

### DIFF
--- a/source/administration/batch-framework.rst
+++ b/source/administration/batch-framework.rst
@@ -97,6 +97,10 @@ The advantages of Batch Replication over :mc:`mc mirror` include:
 - The job provides for retry attempts in event that objects do not replicate
 - Batch jobs are one-time, curated processes allowing for fine control replication
 
+.. versionchanged:: RELEASE.2023-02-17T17-52-43Z
+
+   Run batch replication with multiple workers in parallel by specifying the :envvar:`MINIO_BATCH_REPLICATION_WORKERS` environment variable.
+
 Sample YAML Description File for a ``replicate`` Job Type
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/source/reference/minio-mc-admin/mc-admin-bucket-remote.rst
+++ b/source/reference/minio-mc-admin/mc-admin-bucket-remote.rst
@@ -19,7 +19,7 @@
 
 .. versionchanged:: RELEASE.2023-02-16T19-20-11Z
 
-   - ``mc admin bucket remote bandwitdh`` replaced by :mc-cmd:`mc replicate status`
+   - ``mc admin bucket remote bandwidth`` replaced by :mc-cmd:`mc replicate status`
     
      Replication related statistics are moving to the ``mc replicate status`` command.
 

--- a/source/reference/minio-mc-admin/mc-admin-bucket-remote.rst
+++ b/source/reference/minio-mc-admin/mc-admin-bucket-remote.rst
@@ -17,6 +17,12 @@
    - ``mc admin bucket remote rm`` replaced by :mc-cmd:`mc replicate rm`
    - ``mc admin bucket remote ls`` replaced by :mc-cmd:`mc replicate ls`
 
+.. versionchanged:: RELEASE.2023-02-16T19-20-11Z
+
+   - ``mc admin bucket remote bandwitdh`` replaced by :mc-cmd:`mc replicate status`
+    
+     Replication related statistics are moving to the ``mc replicate status`` command.
+
 Description
 -----------
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -2469,3 +2469,12 @@ identity management using an OpenID Connect (OIDC)-compatible provider. See
    This environment variable corresponds with the 
    :mc-conf:`identity_openid comment 
    <identity_openid.comment>` setting.
+
+Batch Replication
+~~~~~~~~~~~~~~~~~
+
+.. envvar:: MINIO_BATCH_REPLICATION_WORKERS
+
+  *Optional*
+
+  Enable parallel workers by specifying the maximum number of processes to use when performing the batch application job.


### PR DESCRIPTION
- Adds information about a new batch replication environment variable (PR #16609)
- Adds note about metrics in `mc admin bucket remote bandwidth` moved to `mc replicate status`

Partially addresses #736