### PR TITLE
Updates for Console 0.23.1

### DIFF
--- a/source/administration/console/managing-deployment.rst
+++ b/source/administration/console/managing-deployment.rst
@@ -94,14 +94,18 @@ MinIO automatically heals objects and drives when it detects problems, such as d
 
 .. _minio-console-notifications:
 
-Notifications
--------------
+Events
+------
 
-The :guilabel:`Notifications` section provides an interface to view, add, or remove :ref:`Bucket Notification <minio-bucket-notifications>` targets.
+.. versionchanged:: Console 0.23.1
+
+   Notifications section renamed to Events.
+
+The :guilabel:`Events` section provides an interface to view, add, or remove :ref:`Event Notification <minio-bucket-notifications>` targets.
 
 You can use this screen configure MinIO to push notification events to the one or more target destinations, including Redis, MySQL, Kafka, PostgreSQL, AMQP, MQTT, Elastic Search, NATS, NSQ, or a Webhook.
 
-Select the :guilabel:`Add Notification Target +` button to add a new target to the deployment.
+Select the :guilabel:`Add Event Destination +` button to add a new event target to the deployment.
 
 You can select an existing notification target from the list to view its details or delete the target.
 

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -424,6 +424,9 @@ The :guilabel:`Configure` section displays optional configuration settings for t
 
              If your OpenShift cluster enforces :openshift-docs:`Security Context Constraints </authentication/managing-security-context-constraints.html>` , ensure you set the Tenant constraints appropriately such that pods can start and run normally.
 
+   * - :guilabel:`Custom Runtime Configurations`
+     - Toggle on to customize the :kube-docs:`Runtime Class <concepts/containers/runtime-class/>` for the tenant to use. 
+
    * - :guilabel:`Additional Environment Variables`
      - Enter any additional the key:value pairs to use as environment variables for the tenant.
 
@@ -550,9 +553,21 @@ The :guilabel:`Security` section displays TLS certificate settings for the MinIO
 
        MinIO also supports uploading Certificate Authority certificates for validating client certificates minted by that CA.
 
+.. versionadded:: Console 0.23.1
+
+   A message displays under the certificate with the date of expiration and length of time until expiration.
+
+   The message adjusts depending on the length of time to expiration:
+   
+   - More than 30 days, the message text displays in gray.
+   - Within 30 days, the message text changes to orange.
+   - Within 10 days, the message text changes to red.
+   - Within 24 hours, the message displays as an hour and minute countdown in red text.
+   - After expiration, the message displays as ``EXPIRED``.
+
 .. _create-tenant-encryption-section:
 
-8) The :guilabel:`Encryption` Section
+1) The :guilabel:`Encryption` Section
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :guilabel:`Encryption` section displays the :ref:`Server-Side Encryption (SSE) <minio-sse>` settings for the MinIO Tenant. 
@@ -592,6 +607,10 @@ Enabling SSE also creates :minio-git:`MinIO Key Encryption Service <kes>` pods i
    :start-after: start-deprecate-audit-logs
    :end-before: end-deprecate-audit-logs
 
+.. versionchanged:: Console 0.23.1
+
+   New tenants have Audit Logs :guilabel:`Disabled` by default.
+
 .. list-table::
    :header-rows: 1
    :widths: 30 70
@@ -628,6 +647,10 @@ Enabling SSE also creates :minio-git:`MinIO Key Encryption Service <kes>` pods i
 .. include:: /includes/common/common-k8s-deprecation-audit-prometheus.rst
    :start-after: start-deprecate-prometheus
    :end-before: end-deprecate-prometheus
+
+.. versionchanged:: Console 0.23.1
+
+   New tenants have monitoring :guilabel:`Disabled` by default.
 
 .. list-table::
    :header-rows: 1

--- a/source/operations/install-deploy-manage/modify-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/modify-minio-tenant.rst
@@ -18,10 +18,30 @@ The procedures on this page use the :ref:`MinIO Operator Console <minio-operator
    :class: no-scaled-link
    :alt: MinIO Operator Tenant Console
 
+Certificate Management
+----------------------
+
+The Security section provides tools for adding and managing certificates for the tenant.
+
+Review Certificate expiration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: Console 0.23.1
+
+A message displays under the certificate with the date of expiration and length of time until expiration.
+
+The message adjusts depending on the length of time to expiration:
+   
+- More than 30 days, the message text displays in gray.
+- Within 30 days, the message text changes to orange.
+- Within 10 days, the message text changes to red.
+- Within 24 hours, the message displays as an hour and minute countdown in red text.
+- After expiration, the message displays as ``EXPIRED``.
+
 .. _minio-k8s-modify-minio-tenant-security:
 
 Modify Tenant TLS Configuration
--------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The MinIO Operator Console supports adding and removing TLS certificates from a MinIO Tenant.
 
@@ -49,11 +69,22 @@ Add Trusted Certificate Authorities
 
    If the MinIO Tenant cannot match an incoming client's TLS certificate issuer against either the container OS's trust store *or* an explicitly attached CA, MinIO rejects the connection as invalid.
 
+
+Manage Tenant Pools
+-------------------
+
+Specify Runtime Class
+~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: Console 0.23.1
+
+When adding a new pool or modifying an existing pool for a tenant, you can specify the :kube-docs:`Runtime Class Name <concepts/containers/runtime-class/>` for pools to use.
+
 .. Following link is intended for K8s only
 .. _minio-decommissioning:
 
 Decommission a Tenant Server Pool
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 MinIO Operator 4.4.13 and later support decommissioning a server pool in a Tenant.
 Specifically, you can follow the :minio-docs:`Decommission a Server pool <linux/operations/install-deploy-manage/decommission-server-pool.html>` procedure to remove the pool from the tenant, then edit the tenant YAML to drop the pool from the StatefulSet.


### PR DESCRIPTION
- Adds info about runtime configuration selector in operator docs
- Adds note about audit and monitoring disabled by default for new tenants
- Adds info about new server certificate expiration visibility
- Renames Notifications tab to Events in the managing objects console doc

Notifications > Events already previously changed in the managing objects doc.

Closes #733