### PR TITLE
Add --incomplete to mc rm --incomplete example

### DIFF
--- a/source/reference/minio-mc/mc-rm.rst
+++ b/source/reference/minio-mc/mc-rm.rst
@@ -323,7 +323,7 @@ incomplete upload files for an object.
 .. code-block:: shell
    :class: copyable
 
-   mc rm --recursive --force ALIAS/PATH
+   mc rm --incomplete --recursive --force ALIAS/PATH
 
 - Replace :mc-cmd:`ALIAS <mc rm ALIAS>` with the :mc:`alias <mc alias>` of
   a configured S3-compatible service.


### PR DESCRIPTION
Current example for `Remove All Incomplete Upload Files for an Object` shows the command for `Recursively Remove a Bucket's Contents`.

This PR adds the `--incomplete` flag to the `Remove All Incomplete Upload Files for an Object` example.