### PR TITLE
Update docs build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ python3 -m venv venv && source venv/bin/activate
 pip install -r requirements.txt && npm install && npm run build
 ```
 
-4. Build all targets at once:
+4. Build your desired platform target.
 
 ```
-make all
+make k8s
 ```
 
-5. View the generated documentation visit http://localhost:8000:
+5. View the generated documentation at http://localhost:8000.
 
 ```
 python -m http.server --directory build/YOUR_BRANCH/<PLATFORM>/html

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ MinIO uses [Sphinx](https://www.sphinx-doc.org/en/master/index.html) to generate
 
 - Any GNU/Linux Operating System.
 - python 3.10.x and python-pip
+- python3.10-venv
 - sphinx 4.3.2
 - nodejs 14.5.0 or later
+- npm
 - `git` or a git-compatible client
 
 ### Build


### PR DESCRIPTION
The docs build instructions in README.md should not recommend the outdated command `make all`. Instead, recommend building/viewing one docs target at a time.

Also add `venv` and `npm` to the prerequisites, they may not be installed by default on some OSes. (Specifically, Ubuntu. Tested on 22.04 LTS.)

Addresses https://github.com/minio/docs/issues/757