### PR TITLE
Adding staging logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 GITDIR        = $(shell git rev-parse --abbrev-ref HEAD)
+STAGINGURL    = http://192.241.195.202:9000/staging
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -28,8 +29,18 @@ clean-%:
 	@rm -rf $(BUILDDIR)/$(GITDIR)/$*
 
 stage-%:
-	python -m http.server --directory $(BUILDDIR)/$(GITDIR)/$*/html/
-	@echo "Visit http://localhost:8000 to view the staged output"
+	@if [ ! -d "$(BUILDDIR)/$(GITDIR)/$*" ]; then \
+		echo "$* build not found in $(BUILDDIR)/$(GITDIR)"; \
+		exit 1; \
+	fi
+
+	@echo "Copying contents of $(BUILDDIR)/$(GITDIR)/$*/html/* to docs-staging/staging/$(GITDIR)/$*/"
+	@mc cp -r $(BUILDDIR)/$(GITDIR)/$*/html/* docs-staging/staging/$(GITDIR)/$*/
+	@echo "Copy complete, visit $(STAGINGURL)/$(GITDIR)/$*/index.html"
+
+# Commenting out the older method
+# python -m http.server --directory $(BUILDDIR)/$(GITDIR)/$*/html/
+# @echo "Visit http://localhost:8000 to view the staged output"
 
 # Platform build commands
 # All platforms follow the same general pattern:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,21 @@ stage-%:
 		exit 1; \
 	fi
 
+	@if [ ! $(shell command -v mc) ]; then \
+	   echo "mc not found on this host, exiting" ; \
+		exit 1; \
+	fi
+
+	@if [ $(shell mc alias list --json docs-staging | jq '.status') = "error" ]; then \
+		echo "doc-staging alias not found on for host mc configuration, exiting" ; \
+		exit 1; \
+	fi
+
+	@if [ $(shell mc stat --json docs-staging/staging | jq '.status') = "error" ]; then \
+		echo "docs-staging/staging bucket not found, exiting" ; \
+		exit 1; \
+	fi
+
 	@echo "Copying contents of $(BUILDDIR)/$(GITDIR)/$*/html/* to docs-staging/staging/$(GITDIR)/$*/"
 	@mc cp -r $(BUILDDIR)/$(GITDIR)/$*/html/* docs-staging/staging/$(GITDIR)/$*/
 	@echo "Copy complete, visit $(STAGINGURL)/$(GITDIR)/$*/index.html"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ make linux k8s container
 python -m http.server --directory build/YOUR_BRANCH/<PLATFORM>/html
 ```
 
+### Stage
+
+The `make stage-PLATFORM` command uses the `mc` utility to copy the contents of the current git branch build output for the specified `PLATFORM` to a configured MinIO or S3-compatible bucket.
+
+For the command to work, you must have a configured `mc` alias `docs-staging` with general read/write (`s3:*`) permissions on the `staging` bucket.
+The `staging` bucket should have public or anonymous access enabled.
+
+For example:
+
+```
+make stage-linux
+```
+
+Does the following:
+
+1. Check that the `build/GITDIR/linux` folder exists
+2. Copies the contents of `build/GITDIR/linux/html/*` to `docs-staging/staging/GITDIR/linux`
+
+The command does not have any further error checking, such as whether `mc` is installed or if the necessary alias is configured correctly. 
+
 # License
 
 This project is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/legalcode). See [CONTRIBUTING.md](https://github.com/minio/docs/tree/master/CONTRIBUTING.md) guide for more information on contributing to the MinIO Documentation project.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ Does the following:
 1. Check that the `build/GITDIR/linux` folder exists
 2. Copies the contents of `build/GITDIR/linux/html/*` to `docs-staging/staging/GITDIR/linux`
 
-The command does not have any further error checking, such as whether `mc` is installed or if the necessary alias is configured correctly. 
-
 # License
 
 This project is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/legalcode). See [CONTRIBUTING.md](https://github.com/minio/docs/tree/master/CONTRIBUTING.md) guide for more information on contributing to the MinIO Documentation project.


### PR DESCRIPTION
# Summary

The actual logic is pretty straightforward - run `mc cp -r` to recursively copy the contents of the correct directory out to a MinIO alias and bucket.

For now, the alias and bucket are hardcoded. We could make that more variable, but this is easier.

This will require you to install `mc` locally and ensure you have the `docs-staging` access setup . check slack for the details - if `mc ls docs-staging/staging` shows you a list of already staged docs, you're in good shape.