### PR TITLE
Applied changes for Console v0.24.0

### DIFF
--- a/source/administration/console/managing-deployment.rst
+++ b/source/administration/console/managing-deployment.rst
@@ -155,7 +155,7 @@ This section contains the following subsections.
 .. versionadded:: Console v0.24.0
 
    Environment variable configuration settings override any customizations added in the MinIO Console.
-   When environment variables control an option, hover the mouse cursor over a configuration field to show a tooltip message that specifies which environment variable overrides the configuration.
+   Hover your mouse cover over a configuration field to display a tooltip that indicates whether an environment variable controls the setting.
 
 Some subsections may not be visible if the authenticated user does not have the :ref:`required administrative permissions <minio-policy-mc-admin-actions>`.
 

--- a/source/administration/console/managing-deployment.rst
+++ b/source/administration/console/managing-deployment.rst
@@ -139,6 +139,7 @@ Settings
 --------
 
 The :guilabel:`Settings` section provides an interface for viewing and retrieving :ref:`configuration settings <minio-server-configuration-settings>` for all MinIO Servers in the deployment. 
+Use the buttons to :guilabel:`Export` and :guilabel:`Import` the settings between deployments.
 
 This section contains the following subsections.
 
@@ -150,6 +151,11 @@ This section contains the following subsections.
 - Etcd
 - Logger Webhook
 - Audit Webhook
+
+.. versionadded:: Console v0.24.0
+
+   Environment variable configuration settings override any customizations added in the MinIO Console.
+   When environment variables control an option, hover the mouse cursor over a configuration field to show a tooltip message that specifies which environment variable overrides the configuration.
 
 Some subsections may not be visible if the authenticated user does not have the :ref:`required administrative permissions <minio-policy-mc-admin-actions>`.
 

--- a/source/administration/console/managing-objects.rst
+++ b/source/administration/console/managing-objects.rst
@@ -37,7 +37,8 @@ Example actions the user may be able to perform include:
 - Rewind to a previous version
 - Create prefixes
 - View deleted objects
-- Download
+- Upload objects
+- Download objects
 - Share
 - Preview
 - Manage legal holds
@@ -46,6 +47,11 @@ Example actions the user may be able to perform include:
 - Inspect
 - Display versions
 - Delete
+
+.. versionadded:: Console v0.24.0
+
+   View the status of uploading or downloading objects with the object manager button available on the top right corner of many Console screens.
+   If you have not uploaded or downloaded any objects during the current session, the button does not appear.
 
 .. _minio-console-buckets:
 

--- a/source/administration/console/managing-objects.rst
+++ b/source/administration/console/managing-objects.rst
@@ -50,7 +50,7 @@ Example actions the user may be able to perform include:
 
 .. versionadded:: Console v0.24.0
 
-   View the status of uploading or downloading objects with the object manager button available on the top right corner of many Console screens.
+   View the status of uploading or downloading objects with the object manager button available on the top right corner of the Console.
    If you have not uploaded or downloaded any objects during the current session, the button does not appear.
 
 .. _minio-console-buckets:

--- a/source/administration/console/subnet-registration.rst
+++ b/source/administration/console/subnet-registration.rst
@@ -39,7 +39,7 @@ Applications using MinIO — or any other OSS-licensed code — without validati
 Support
 -------
 
-Proprietary application stacks that register for a commerical license choose engineering support under either the :guilabel:`Standard` or :guilabel:`Enterprise` License and Support plans.
+Proprietary application stacks that register for a commercial license choose engineering support under either the :guilabel:`Standard` or :guilabel:`Enterprise` License and Support plans.
 Both support plans share the same commercial license to MinIO.
 
 The :guilabel:`Support` section provides an interface for generating health and performance reports.
@@ -83,3 +83,21 @@ MinIO Engineering may request this output as part of diagnostics in |subnet|.
 The resulting object may be read using MinIO's :minio-git:`debugging tool <minio/tree/master/docs/debugging#decoding-metadata>`. 
 Independent or third-party use of the output for diagnostics or remediation is done at your own risk.
 You can optionally encrypt the object such that it can only be read if the generated encryption key is included as part of the debugging toolchain.
+
+Call Home
+---------
+
+.. versionadded:: Console v0.24.0
+
+Call Home is an optional feature where a deployment registered for |SUBNET| can automatically send daily health diagnostic reports or real-time error logs to SUBNET.
+Having these reports equips engineering support with a record of diagnostics, logs, or both when responding to support requests.
+
+MinIO installs with Call Home options disabled by default.
+
+.. important:: 
+
+   Call Home requires an active SUBNET subscription.
+
+Use the :guilabel:`Call Home` section to enable or disable uploading either once-per-day health diagnostic reports or real-time error logs to SUBNET.
+The health reports and real-time logs are separate functions you can enable or disable separately.
+You can enable both diagnostics and logs at the same time, if desired.


### PR DESCRIPTION
- Adds information about call home to the console subnet registration page
- Mentions viewing environment variables with the tooltip
- Adds info about excporitng or importing settings
- Adds object manager button to the managing objects page

Closes #747