### PR TITLE
Exclude prefixes or folders from versioning

### DIFF
--- a/source/administration/concepts.rst
+++ b/source/administration/concepts.rst
@@ -67,6 +67,8 @@ Once authenticated, TLS provides the cipher to encrypt and then decrypt the tran
 
 MinIO supports several methods of :ref:`Server-Side Encryption <minio-encryption-overview>`.
 
+.. _minio-admin-concepts-organize-objects:
+
 Can I organize objects in a folder structure within buckets?
 ------------------------------------------------------------
 

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -288,7 +288,7 @@ This is useful for Spark/Hadoop workloads or others that initially create object
 
   - Replace ``BUCKET`` with the name of the :s3-docs:`bucket <UsingBucket.html>` you want to exclude :ref:`prefixes <minio-admin-concepts-organize-objects>` for.
 
-The list of :mc-cmd:`~mc version --excluded-prefixes` prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``*prefix*``.
+The list of :mc-cmd:`~mc version --excluded-prefixes` prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``prefix*``.
 To match objects by prefix only, use ``prefix/*``.
 
 For example, the following command excludes any objects containing ``_test`` or ``_temp`` in their prefix or name from versioning:

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -270,41 +270,50 @@ Objects created prior to enabling versioning have a
 Exclude a Prefix From Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can exclude certain prefixes from versioning using the MinIO :mc:`mc` CLI.
-This is useful for Spark/Hadoop workloads or others that initially create objects
-with temporary prefixes.
+You can exclude certain prefixes from versioning using the :ref:`MinIO Client <minio-client>`.
+This is useful for Spark/Hadoop workloads or others that initially create objects with temporary prefixes. 
 
-- Use the :mc-cmd:`mc version enable` command with the ``--excluded-prefixes``
-  option:
+.. admonition:: Object locking
+   :class: note
+
+   Buckets with :ref:`object locking enabled <minio-object-locking>` require versioning and do not support excluding prefixes.
+
+Testing links:
+
+:mc-cmd:`~mc mb --with-lock`
+
+:mc-cmd:`~mc version enable`
+
+:mc-cmd:`~mc version enable --excluded-prefixes`
+   
+- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version enable --excluded-prefixes` option:
 
   .. code-block:: shell
      :class: copyable
 
      mc version enable --excluded-prefixes ALIAS/BUCKET "prefix1, prefix2"
 
-  - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured 
-    MinIO deployment.
+  - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-  - Replace ``BUCKET`` with the 
-    :mc-cmd:`target bucket <mc version ALIAS>` for which the prefixes should
-    be excluded from versioning.
+  - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` for which the :ref:`prefixes <minio-admin-concepts-organize-objects>` should be excluded from versioning.
 
 Something about wildcards and globbing
     
-You can exclude up to 10 prefixes for each bucket. To add or remove excluded prefixes,
-repeat your ``mc version enable`` command with an updated list. The new list of
-prefixes replaces the previous one.
+You can exclude up to 10 prefixes for each bucket.
+To add or remove excluded prefixes, repeat the ``mc version enable`` command with an updated list.
+The new list of prefixes replaces the previous one.
 
-To view the currently excluded prefixes, use the :mc-cmd:`mc version enable`
-command with the ``--json`` option. The ``ExcludedPrefixes`` property contains a list
-of excluded prefixes:
+To view the currently excluded prefixes, use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version enable --JSON` option.
+The ``ExcludedPrefixes`` property contains a list of excluded prefixes:
 
   .. code-block:: shell
      :class: copyable
 
      mc version enable --excluded-prefixes ALIAS/BUCKET --json
 
-  .. code-block:: shell
+The command output resembles the following:
+
+.. code-block:: shell
 
      $ mc version info local/test-bucket --json
      {
@@ -320,37 +329,46 @@ of excluded prefixes:
       }
      }
 
+To disable prefix exclusion and resume versioning all prefixes, repeat the ``mc version enable`` command without ``--excluded-prefixes``:
 
+  .. code-block:: shell
+     :class: copyable
+
+     mc version enable ALIAS/BUCKET
+
+     
 Exclude Folders from Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can exclude folders from versioning using the MinIO :mc:`mc` CLI.
 
-- Use the :mc-cmd:`mc version enable` command with the ``--exclude-folders``
-  option to exclude objects with names ending in `/` from versioning:
+.. admonition:: Object locking
+   :class: note
+
+   Buckets with :ref:`object locking enabled <minio-object-locking>` require versioning and do not support excluding folders.
+
+- Use the :mc-cmd:`mc version enable` command with the ``--exclude-folders`` option to exclude objects with names ending in `/` from versioning:
 
   .. code-block:: shell
      :class: copyable
 
      mc version enable --exclude-folders ALIAS/BUCKET
 
-  - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured
-    MinIO deployment.
+  - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-  - Replace ``BUCKET`` with the
-    :mc-cmd:`target bucket <mc version ALIAS>` for which the folders should
-    be excluded from versioning.
+  - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` for which the :ref:`folders <minio-admin-concepts-organize-objects>` should be excluded from versioning.
 
-To check whether folders are versioned for a bucket, use the :mc-cmd:`mc version enable`
-command with the ``--json`` option. If the ``ExcludeFolders`` property is ``true``,
-folders in that bucket are not versioned.
+To check whether folders are versioned for a bucket, use the :mc-cmd:`mc version enable` command with the ``--json`` option.
+If the ``ExcludeFolders`` property is ``true``, folders in that bucket are not versioned.
 
   .. code-block:: shell
      :class: copyable
 
      mc version enable --excluded-prefixes ALIAS/BUCKET --json
 
-  .. code-block:: shell
+The command output resembles the following:
+
+.. code-block:: shell
 
      $ mc version info local/test-bucket --json
      {
@@ -363,6 +381,13 @@ folders in that bucket are not versioned.
        "ExcludeFolders": true
       }
      }
+
+To disable folder exclusion and resume versioning all folders, repeat the ``mc version enable`` command without ``--exclude-folders``:
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc version enable ALIAS/BUCKET
 
 
 Suspend Bucket Versioning

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -266,6 +266,105 @@ enable versioning on only a prefix or subset of objects in a bucket.
 Objects created prior to enabling versioning have a 
 ``null`` :ref:`version ID <minio-bucket-versioning-id>`.
 
+
+Exclude a Prefix From Versioning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can exclude certain prefixes from versioning using the MinIO :mc:`mc` CLI.
+This is useful for Spark/Hadoop workloads or others that initially create objects
+with temporary prefixes.
+
+- Use the :mc-cmd:`mc version enable` command with the ``--excluded-prefixes``
+  option:
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc version enable --excluded-prefixes ALIAS/BUCKET "prefix1, prefix2"
+
+  - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured 
+    MinIO deployment.
+
+  - Replace ``BUCKET`` with the 
+    :mc-cmd:`target bucket <mc version ALIAS>` for which the prefixes should
+    be excluded from versioning.
+
+Something about wildcards and globbing
+    
+You can exclude up to 10 prefixes for each bucket. To add or remove excluded prefixes,
+repeat your ``mc version enable`` command with an updated list. The new list of
+prefixes replaces the previous one.
+
+To view the currently excluded prefixes, use the :mc-cmd:`mc version enable`
+command with the ``--json`` option. The ``ExcludedPrefixes`` property contains a list
+of excluded prefixes:
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc version enable --excluded-prefixes ALIAS/BUCKET --json
+
+  .. code-block:: shell
+
+     $ mc version info local/test-bucket --json
+     {
+      "Op": "info",
+      "status": "success",
+      "url": "local/test-bucket",
+      "versioning": {
+       "status": "Enabled",
+       "MFADelete": "",
+       "ExcludedPrefixes": [
+        "TempPrefix-"
+       ]
+      }
+     }
+
+
+Exclude Folders from Versioning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can exclude folders from versioning using the MinIO :mc:`mc` CLI.
+
+- Use the :mc-cmd:`mc version enable` command with the ``--exclude-folders``
+  option to exclude objects with names ending in `/` from versioning:
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc version enable --exclude-folders ALIAS/BUCKET
+
+  - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured
+    MinIO deployment.
+
+  - Replace ``BUCKET`` with the
+    :mc-cmd:`target bucket <mc version ALIAS>` for which the folders should
+    be excluded from versioning.
+
+To check whether folders are versioned for a bucket, use the :mc-cmd:`mc version enable`
+command with the ``--json`` option. If the ``ExcludeFolders`` property is ``true``,
+folders in that bucket are not versioned.
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc version enable --excluded-prefixes ALIAS/BUCKET --json
+
+  .. code-block:: shell
+
+     $ mc version info local/test-bucket --json
+     {
+      "Op": "info",
+      "status": "success",
+      "url": "local/test-bucket",
+      "versioning": {
+       "status": "Enabled",
+       "MFADelete": "",
+       "ExcludeFolders": true
+      }
+     }
+
+
 Suspend Bucket Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -345,7 +345,7 @@ You can exclude folders from versioning using the :ref:`MinIO Client <minio-clie
 
    Buckets with :ref:`object locking enabled <minio-object-locking>` require versioning and do not support excluding folders.
 
-- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version --excluded-prefixes` option to exclude objects with names ending in ``/`` from versioning:
+- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version --exclude-folders` option to exclude objects with names ending in ``/`` from versioning:
 
   .. code-block:: shell
      :class: copyable

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -307,7 +307,7 @@ To view the currently excluded prefixes, use :mc-cmd:`mc version enable` with th
   .. code-block:: shell
      :class: copyable
 
-     mc version enable --excluded-prefixes ALIAS/BUCKET --json
+     mc version info ALIAS/BUCKET --json
 
 The command output resembles the following, with the list of excluded prefixes in the ``ExcludedPrefixes`` property:
 

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -302,7 +302,7 @@ You can exclude up to 10 prefixes for each bucket.
 To add or remove prefixes, repeat the :mc-cmd:`mc version enable` command with an updated list.
 The new list of prefixes replaces the previous one.
 
-To view the currently excluded prefixes, use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version enable --JSON` option:
+To view the currently excluded prefixes, use :mc-cmd:`mc version info` with the :mc-cmd:`~mc version enable --JSON` option:
 
   .. code-block:: shell
      :class: copyable

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -219,8 +219,7 @@ Enable Bucket Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can enable versioning using the MinIO Console, the MinIO :mc:`mc` CLI, or
-using an S3-compatible SDK. Versioning is a bucket-scoped feature. You cannot
-enable versioning on only a prefix or subset of objects in a bucket.
+using an S3-compatible SDK.
 
 .. tab-set::
 
@@ -289,14 +288,21 @@ This is useful for Spark/Hadoop workloads or others that initially create object
 
   - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` you want to exclude :ref:`prefixes <minio-admin-concepts-organize-objects>` for.
 
-Something about wildcards and globbing
+The list of :mc-cmd:`~mc version --excluded-prefixes` prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``*prefix*``.
+To match objects by prefix only, use ``prefix/*``.
+
+For example, the following command excludes any objects containing ``abc`` or ``d3f`` in their prefix or name from versioning:
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc version enable local/test-bucket --excluded-prefixes "abc, d3f"
 
 You can exclude up to 10 prefixes for each bucket.
 To add or remove prefixes, repeat the :mc-cmd:`mc version enable` command with an updated list.
 The new list of prefixes replaces the previous one.
 
 To view the currently excluded prefixes, use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version enable --JSON` option:
-
 
   .. code-block:: shell
      :class: copyable
@@ -316,7 +322,7 @@ The command output resembles the following, with the list of excluded prefixes i
        "status": "Enabled",
        "MFADelete": "",
        "ExcludedPrefixes": [
-        "TempPrefix-"
+        "abc, d3f"
        ]
       }
      }
@@ -339,7 +345,7 @@ You can exclude folders from versioning using the :ref:`MinIO Client <minio-clie
 
    Buckets with :ref:`object locking enabled <minio-object-locking>` require versioning and do not support excluding folders.
 
-- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version --excluded-prefixes` option to exclude objects with names ending in `/` from versioning:
+- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version --excluded-prefixes` option to exclude objects with names ending in ``/`` from versioning:
 
   .. code-block:: shell
      :class: copyable
@@ -348,7 +354,7 @@ You can exclude folders from versioning using the :ref:`MinIO Client <minio-clie
 
   - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-  - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` for which the :ref:`folders <minio-admin-concepts-organize-objects>` should be excluded from versioning.
+  - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` you want to exclude :ref:`folders <minio-admin-concepts-organize-objects>` for.
 
 To check whether folders are versioned for a bucket, use the :mc-cmd:`mc version enable` command with the ``--json`` option.
 If the ``ExcludeFolders`` property is ``true``, folders in that bucket are not versioned.

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -270,7 +270,7 @@ Objects created prior to enabling versioning have a
 Exclude a Prefix From Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can exclude certain prefixes from versioning using the :ref:`MinIO Client <minio-client>`.
+You can exclude certain :ref:`prefixes <minio-admin-concepts-organize-objects>` from versioning using the :ref:`MinIO Client <minio-client>`.
 This is useful for Spark/Hadoop workloads or others that initially create objects with temporary prefixes. 
 
 .. admonition:: Object locking
@@ -278,15 +278,7 @@ This is useful for Spark/Hadoop workloads or others that initially create object
 
    Buckets with :ref:`object locking enabled <minio-object-locking>` require versioning and do not support excluding prefixes.
 
-Testing links:
-
-:mc-cmd:`~mc mb --with-lock`
-
-:mc-cmd:`~mc version enable`
-
-:mc-cmd:`~mc version enable --excluded-prefixes`
-   
-- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version enable --excluded-prefixes` option:
+- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version --excluded-prefixes` option:
 
   .. code-block:: shell
      :class: copyable
@@ -295,23 +287,23 @@ Testing links:
 
   - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-  - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` for which the :ref:`prefixes <minio-admin-concepts-organize-objects>` should be excluded from versioning.
+  - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` you want to exclude :ref:`prefixes <minio-admin-concepts-organize-objects>` for.
 
 Something about wildcards and globbing
-    
+
 You can exclude up to 10 prefixes for each bucket.
-To add or remove excluded prefixes, repeat the ``mc version enable`` command with an updated list.
+To add or remove prefixes, repeat the :mc-cmd:`mc version enable` command with an updated list.
 The new list of prefixes replaces the previous one.
 
-To view the currently excluded prefixes, use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version enable --JSON` option.
-The ``ExcludedPrefixes`` property contains a list of excluded prefixes:
+To view the currently excluded prefixes, use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version enable --JSON` option:
+
 
   .. code-block:: shell
      :class: copyable
 
      mc version enable --excluded-prefixes ALIAS/BUCKET --json
 
-The command output resembles the following:
+The command output resembles the following, with the list of excluded prefixes in the ``ExcludedPrefixes`` property:
 
 .. code-block:: shell
 
@@ -329,7 +321,7 @@ The command output resembles the following:
       }
      }
 
-To disable prefix exclusion and resume versioning all prefixes, repeat the ``mc version enable`` command without ``--excluded-prefixes``:
+To disable prefix exclusion and resume versioning all prefixes, repeat the :mc-cmd:`mc version enable` command without :mc-cmd:`~mc version --excluded-prefixes`:
 
   .. code-block:: shell
      :class: copyable
@@ -340,14 +332,14 @@ To disable prefix exclusion and resume versioning all prefixes, repeat the ``mc 
 Exclude Folders from Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can exclude folders from versioning using the MinIO :mc:`mc` CLI.
+You can exclude folders from versioning using the :ref:`MinIO Client <minio-client>`.
 
 .. admonition:: Object locking
    :class: note
 
    Buckets with :ref:`object locking enabled <minio-object-locking>` require versioning and do not support excluding folders.
 
-- Use the :mc-cmd:`mc version enable` command with the ``--exclude-folders`` option to exclude objects with names ending in `/` from versioning:
+- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version --excluded-prefixes` option to exclude objects with names ending in `/` from versioning:
 
   .. code-block:: shell
      :class: copyable
@@ -382,7 +374,7 @@ The command output resembles the following:
       }
      }
 
-To disable folder exclusion and resume versioning all folders, repeat the ``mc version enable`` command without ``--exclude-folders``:
+To disable folder exclusion and resume versioning all folders, repeat the :mc-cmd:`mc version enable` command without :mc-cmd:`~mc version --exclude-folders`:
 
   .. code-block:: shell
      :class: copyable

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -282,21 +282,21 @@ This is useful for Spark/Hadoop workloads or others that initially create object
   .. code-block:: shell
      :class: copyable
 
-     mc version enable --excluded-prefixes ALIAS/BUCKET "prefix1, prefix2"
+     mc version enable --excluded-prefixes "prefix1, prefix2" ALIAS/BUCKET
 
   - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-  - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` you want to exclude :ref:`prefixes <minio-admin-concepts-organize-objects>` for.
+  - Replace ``BUCKET`` with the name of the :s3-docs:`bucket <UsingBucket.html>` you want to exclude :ref:`prefixes <minio-admin-concepts-organize-objects>` for.
 
 The list of :mc-cmd:`~mc version --excluded-prefixes` prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``*prefix*``.
 To match objects by prefix only, use ``prefix/*``.
 
-For example, the following command excludes any objects containing ``abc`` or ``d3f`` in their prefix or name from versioning:
+For example, the following command excludes any objects containing ``_test`` or ``_temp`` in their prefix or name from versioning:
 
   .. code-block:: shell
      :class: copyable
 
-     mc version enable local/test-bucket --excluded-prefixes "abc, d3f"
+     mc version enable --excluded-prefixes "_test, _temp" local/my-bucket
 
 You can exclude up to 10 prefixes for each bucket.
 To add or remove prefixes, repeat the :mc-cmd:`mc version enable` command with an updated list.
@@ -313,16 +313,16 @@ The command output resembles the following, with the list of excluded prefixes i
 
 .. code-block:: shell
 
-     $ mc version info local/test-bucket --json
+     $ mc version info local/my-bucket --json
      {
       "Op": "info",
       "status": "success",
-      "url": "local/test-bucket",
+      "url": "local/my-bucket",
       "versioning": {
        "status": "Enabled",
        "MFADelete": "",
        "ExcludedPrefixes": [
-        "abc, d3f"
+        "prefix1, prefix2"
        ]
       }
      }
@@ -354,7 +354,7 @@ You can exclude folders from versioning using the :ref:`MinIO Client <minio-clie
 
   - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-  - Replace ``BUCKET`` with the :mc-cmd:`target bucket <mc version ALIAS>` you want to exclude :ref:`folders <minio-admin-concepts-organize-objects>` for.
+  - Replace ``BUCKET`` with the :s3-docs:`bucket <UsingBucket.html>` you want to exclude :ref:`folders <minio-admin-concepts-organize-objects>` for.
 
 To check whether folders are versioned for a bucket, use the :mc-cmd:`mc version enable` command with the ``--json`` option.
 If the ``ExcludeFolders`` property is ``true``, folders in that bucket are not versioned.
@@ -368,11 +368,11 @@ The command output resembles the following:
 
 .. code-block:: shell
 
-     $ mc version info local/test-bucket --json
+     $ mc version info local/my-bucket --json
      {
       "Op": "info",
       "status": "success",
-      "url": "local/test-bucket",
+      "url": "local/my-bucket",
       "versioning": {
        "status": "Enabled",
        "MFADelete": "",

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -52,7 +52,18 @@ The :mc:`mc version` command enables, suspends, and retrieves the
 Parameters
 ~~~~~~~~~~
 
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of a MinIO deployment and the full path
+   to the bucket for which to set the versioning configuration. For example:
+
+   .. code-block:: shell
+
+      mc version enable myminio/mybucket
+
 .. mc-cmd:: enable
+   :optional:
 
    Enables versioning on the MinIO bucket specified to
    :mc-cmd:`ALIAS <mc version ALIAS>`.
@@ -74,20 +85,13 @@ Parameters
 
    For example, the following command excludes any objects containing ``_test`` or ``_temp`` in their prefix or name from versioning:
 
-  .. code-block:: shell
-     :class: copyable
+   .. code-block:: shell
+      :class: copyable
 
-     mc version enable --excluded-prefixes "_test, _temp" local/my-bucket
-
-.. mc-cmd:: suspend
-
-   Disables versioning on the MinIO bucket specified to
-   :mc-cmd:`ALIAS <mc version ALIAS>`.
-
-   Mutually exclusive with :mc-cmd:`~mc version suspend` and
-   :mc-cmd:`~mc version info`
+      mc version enable --excluded-prefixes "_test, _temp" local/my-bucket
 
 .. mc-cmd:: info
+   :optional:
 
    Returns the versioning configuration for the MinIO bucket specified to
    :mc-cmd:`ALIAS <mc version ALIAS>`.
@@ -95,16 +99,14 @@ Parameters
    Mutually exclusive with :mc-cmd:`~mc version suspend` and
    :mc-cmd:`~mc version info`
 
-.. mc-cmd:: ALIAS
+.. mc-cmd:: suspend
+   :optional:
 
-   *Required*
+   Disables versioning on the MinIO bucket specified to
+   :mc-cmd:`ALIAS <mc version ALIAS>`.
 
-   The :ref:`alias <alias>` of a MinIO deployment and the full path
-   to the bucket for which to set the versioning configuration. For example:
-
-   .. code-block:: shell
-
-      mc version enable myminio/mybucket
+   Mutually exclusive with :mc-cmd:`~mc version suspend` and
+   :mc-cmd:`~mc version info`
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -60,6 +60,11 @@ Parameters
    Mutually exclusive with :mc-cmd:`~mc version suspend` and
    :mc-cmd:`~mc version info`
 
+   .. mc-cmd:: enable --excluded-prefixes
+      :optional:
+
+      something
+	   
 .. mc-cmd:: suspend
 
    Disables versioning on the MinIO bucket specified to

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -72,6 +72,13 @@ Parameters
    The list of prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``*prefix*``.
    To match objects by prefix only, use ``prefix/*``.
 
+   For example, the following command excludes any objects containing ``_test`` or ``_temp`` in their prefix or name from versioning:
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc version enable --excluded-prefixes "_test, _temp" local/my-bucket
+
 .. mc-cmd:: suspend
 
    Disables versioning on the MinIO bucket specified to

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -60,10 +60,15 @@ Parameters
    Mutually exclusive with :mc-cmd:`~mc version suspend` and
    :mc-cmd:`~mc version info`
 
-   .. mc-cmd:: enable --excluded-prefixes
-      :optional:
+.. mc-cmd:: --exclude-folders
+   :optional:
 
-      something
+   something
+
+.. mc-cmd:: --excluded-prefixes
+   :optional:
+
+   something
 	   
 .. mc-cmd:: suspend
 

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -63,13 +63,15 @@ Parameters
 .. mc-cmd:: --exclude-folders
    :optional:
 
-   something
+   Use with :mc-cmd:`mc version enable` to disable versioning on all folders (objects whose name ends with ``/``) in the specified bucket.
 
 .. mc-cmd:: --excluded-prefixes
    :optional:
 
-   something
-	   
+   Use with :mc-cmd:`mc version enable` to disable versioning on objects matching a list of prefixes, up to 10.
+   The list of prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``*prefix*``.
+   To match objects by prefix only, use ``prefix/*``.
+
 .. mc-cmd:: suspend
 
    Disables versioning on the MinIO bucket specified to
@@ -88,7 +90,9 @@ Parameters
 
 .. mc-cmd:: ALIAS
 
-   *Required* The :ref:`alias <alias>` of a MinIO deployment and the full path
+   *Required*
+
+   The :ref:`alias <alias>` of a MinIO deployment and the full path
    to the bucket for which to set the versioning configuration. For example:
 
    .. code-block:: shell

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -80,7 +80,7 @@ Parameters
    :optional:
 
    Use with :mc-cmd:`mc version enable` to disable versioning on objects matching a list of prefixes, up to 10.
-   The list of prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``*prefix*``.
+   The list of prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``prefix*``.
    To match objects by prefix only, use ``prefix/*``.
 
    For example, the following command excludes any objects containing ``_test`` or ``_temp`` in their prefix or name from versioning:


### PR DESCRIPTION
Object versioning can now be configured with certain exclusions (no longer strictly on a per-bucket basis). Add documentation about how to use the new options:
* `--excluded-prefixes` to exclude objects with certain prefixes
* `--exclude-folders` to exclude anything with name ending in `/` (folders)

- [x] Exclude prefixes
- [x] Exclude folders
- [x] Wildcards/globbing
- [x] Limitations
- [x] View versioning exclusion configuration

Staged:
[Bucket Versioning](http://192.241.195.202:9000/staging/DOCS-760/linux/html/administration/object-management/object-versioning.html)
[mc version](http://192.241.195.202:9000/staging/DOCS-760/linux/html/reference/minio-mc/mc-version.html)

Fixes https://github.com/minio/docs/issues/760