### PR TITLE
Adds info on certificates with the MinIO Client

### DIFF
--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -302,7 +302,7 @@ You can exclude up to 10 prefixes for each bucket.
 To add or remove prefixes, repeat the :mc-cmd:`mc version enable` command with an updated list.
 The new list of prefixes replaces the previous one.
 
-To view the currently excluded prefixes, use :mc-cmd:`mc version info` with the :mc-cmd:`~mc version enable --JSON` option:
+To view the currently excluded prefixes, use :mc-cmd:`mc version info` with the ``--JSON`` option:
 
   .. code-block:: shell
      :class: copyable

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -418,6 +418,34 @@ The following list describes each possible file path location in the order
 
 You can use the ``--config-dir``
 
+.. _minio-mc-certificates:
+
+Certificates
+------------
+
+The MinIO Client stores certificates and CAs for deployments with :ref:`server side encryption <minio-sse>` to the following paths:
+
+Linux, MacOS, and other Unix-like systems:
+
+.. code-block:: shell
+
+   ~/.mc/certs/ # certificates
+   ~/.mc/certs/CAs/ # Certificate Authorities
+
+Windows systems:
+
+.. code-block:: shell
+
+   C:\Users\[username]\mc\certs\ # certificates
+   C:\Users\[username]\mc\certs\CAs\ # Certificate Authorities
+
+When creating a new :ref:`alias <minio-mc-alias>`, the MinIO Client prompts the user whether to accept the deployment's certificates.
+If you decide to trust the certificate, the MinIO Client adds the certificate to the above paths.
+
+.. note::
+
+   In testing environments, you can bypass the certificate check for selected mc commands by passing the ``--insecure`` flag.
+
 .. _minio-mc-global-options:
 
 Global Options

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -423,7 +423,7 @@ You can use the ``--config-dir``
 Certificates
 ------------
 
-The MinIO Client stores certificates and CAs for deployments with :ref:`server side encryption <minio-sse>` to the following paths:
+The MinIO Client stores certificates and CAs for deployments to the following paths:
 
 Linux, MacOS, and other Unix-like systems:
 
@@ -439,12 +439,12 @@ Windows systems:
    C:\Users\[username]\mc\certs\ # certificates
    C:\Users\[username]\mc\certs\CAs\ # Certificate Authorities
 
-When creating a new :ref:`alias <minio-mc-alias>`, the MinIO Client prompts the user whether to accept the deployment's certificates.
-If you decide to trust the certificate, the MinIO Client adds the certificate to the above paths.
+When creating a new :ref:`alias <minio-mc-alias>`, the MinIO Client fetches the peer certificate, computes the public key fingerprint, and asks the user whether to accept the deployment's certificate.
+If you decide to trust the certificate, the MinIO Client adds the certificate to the certificate authority path listed above.
 
 .. note::
 
-   In testing environments, you can bypass the certificate check for selected mc commands by passing the ``--insecure`` flag.
+   In testing environments, you can bypass the certificate check for selected MinIO Client commands by passing the ``--insecure`` flag.
 
 .. _minio-mc-global-options:
 

--- a/source/reference/minio-mc/mc-alias-set.rst
+++ b/source/reference/minio-mc/mc-alias-set.rst
@@ -200,12 +200,12 @@ For more complete documentation on S3 Access Control, see
 For all other S3-compatible services, defer to the documentation for that
 service.
 
-Server-Side Encryption
-~~~~~~~~~~~~~~~~~~~~~~
+Certificates
+~~~~~~~~~~~~
 
-For deployments with :ref:`server side encryption <minio-sse>` enabled, the MinIO Client asks the user whether to trust the certificates for the deployment when creating the alias.
+The MinIO Client fetches the peer certificate, computes the public key fingerprint, and asks the user whether to accept the deployment's certificate.
 
-If trusted, the MinIO Client automatically adds the certificate and certificate authority to:
+If trusted, the MinIO Client automatically adds the certificate authority to:
 
--  ``~/.mc/certs/`` on Linux and other Unix-like systems.
--  ``C:\Users\[username]\mc\certs`` on Windows systems.
+-  ``~/.mc/certs/CAs/`` on Linux and other Unix-like systems.
+-  ``C:\Users\[username]\mc\certs\CAs\`` on Windows systems.

--- a/source/reference/minio-mc/mc-alias-set.rst
+++ b/source/reference/minio-mc/mc-alias-set.rst
@@ -199,3 +199,13 @@ For more complete documentation on S3 Access Control, see
 
 For all other S3-compatible services, defer to the documentation for that
 service.
+
+Server-Side Encryption
+~~~~~~~~~~~~~~~~~~~~~~
+
+For deployments with :ref:`server side encryption <minio-sse>` enabled, the MinIO Client asks the user whether to trust the certificates for the deployment when creating the alias.
+
+If trusted, the MinIO Client automatically adds the certificate and certificate authority to:
+
+-  ``~/.mc/certs/`` on Linux and other Unix-like systems.
+-  ``C:\Users\[username]\mc\certs`` on Windows systems.


### PR DESCRIPTION
- Adds a new section on certificates to the MinIO Client page
- Adds a new section in Behaviors to the mc alias set page
- Minor fix to a --json flag command in version doc

Closes #781

Staged:
- http://192.241.195.202:9000/staging/certificates/reference/minio-mc.html#certificates
- http://192.241.195.202:9000/staging/certificates/reference/minio-mc/mc-alias-set.html#server-side-encryption