### PR TITLE
DOCS-779: Fix permission set for MinIO on KES

### DIFF
--- a/source/includes/common/common-minio-kes-aws.rst
+++ b/source/includes/common/common-minio-kes-aws.rst
@@ -30,12 +30,15 @@ Manager:
    policy:
      minio:
        allow:
-       - /v1/key/create/*
-       - /v1/key/generate/*
+       - /v1/key/create/*   # You can replace these wildcard '*' with a string prefix to restrict key names
+       - /v1/key/generate/* # e.g. '/minio-'
        - /v1/key/decrypt/*
-       - /v1/key/list*
+       - /v1/key/bulk/decrypt
+       - /v1/key/list
        - /v1/status
        - /v1/metrics
+       - /v1/log/audit
+       - /v1/log/error
        identities:
        - ${MINIO_IDENTITY_HASH} # Replace with the output of 'kes identity of minio-kes.cert'
 

--- a/source/includes/common/common-minio-kes-aws.rst
+++ b/source/includes/common/common-minio-kes-aws.rst
@@ -33,6 +33,9 @@ Manager:
        - /v1/key/create/*
        - /v1/key/generate/*
        - /v1/key/decrypt/*
+       - /v1/key/list*
+       - /v1/status
+       - /v1/metrics
        identities:
        - ${MINIO_IDENTITY_HASH} # Replace with the output of 'kes identity of minio-kes.cert'
 

--- a/source/includes/common/common-minio-kes-azure.rst
+++ b/source/includes/common/common-minio-kes-azure.rst
@@ -31,12 +31,15 @@ Manager:
    policy:
      minio:
        allow:
-       - /v1/key/create/*
-       - /v1/key/generate/*
+       - /v1/key/create/*   # You can replace these wildcard '*' with a string prefix to restrict key names
+       - /v1/key/generate/* # e.g. '/minio-'
        - /v1/key/decrypt/*
-       - /v1/key/list*
+       - /v1/key/bulk/decrypt
+       - /v1/key/list
        - /v1/status
        - /v1/metrics
+       - /v1/log/audit
+       - /v1/log/error
        identities:
        - ${MINIO_IDENTITY_HASH} # Replace with the output of 'kes identity of minio-kes.cert'
 

--- a/source/includes/common/common-minio-kes-azure.rst
+++ b/source/includes/common/common-minio-kes-azure.rst
@@ -34,6 +34,9 @@ Manager:
        - /v1/key/create/*
        - /v1/key/generate/*
        - /v1/key/decrypt/*
+       - /v1/key/list*
+       - /v1/status
+       - /v1/metrics
        identities:
        - ${MINIO_IDENTITY_HASH} # Replace with the output of 'kes identity of minio-kes.cert'
 

--- a/source/includes/common/common-minio-kes-gcp.rst
+++ b/source/includes/common/common-minio-kes-gcp.rst
@@ -30,12 +30,15 @@ Manager:
    policy:
      minio:
        allow:
-       - /v1/key/create/*
-       - /v1/key/generate/*
+       - /v1/key/create/*   # You can replace these wildcard '*' with a string prefix to restrict key names
+       - /v1/key/generate/* # e.g. '/minio-'
        - /v1/key/decrypt/*
-       - /v1/key/list*
+       - /v1/key/bulk/decrypt
+       - /v1/key/list
        - /v1/status
        - /v1/metrics
+       - /v1/log/audit
+       - /v1/log/error
        identities:
        - ${MINIO_IDENTITY_HASH} # Replace with the output of 'kes identity of minio-kes.cert'
 

--- a/source/includes/common/common-minio-kes-gcp.rst
+++ b/source/includes/common/common-minio-kes-gcp.rst
@@ -33,6 +33,9 @@ Manager:
        - /v1/key/create/*
        - /v1/key/generate/*
        - /v1/key/decrypt/*
+       - /v1/key/list*
+       - /v1/status
+       - /v1/metrics
        identities:
        - ${MINIO_IDENTITY_HASH} # Replace with the output of 'kes identity of minio-kes.cert'
 

--- a/source/includes/common/common-minio-kes-hashicorp.rst
+++ b/source/includes/common/common-minio-kes-hashicorp.rst
@@ -30,6 +30,9 @@ You must modify this YAML to reflect your deployment environment.
        - /v1/key/create/*   # You can replace these wildcard '*' with a string prefix to restrict key names
        - /v1/key/generate/* # e.g. '/minio-'
        - /v1/key/decrypt/*
+       - /v1/key/list*
+       - /v1/status
+       - /v1/metrics
        identities:
        - MINIO_IDENTITY_HASH # Replace with the output of 'kes identity of minio-kes.cert'
                                 # In production environments, each client connecting to KES must

--- a/source/includes/common/common-minio-kes-hashicorp.rst
+++ b/source/includes/common/common-minio-kes-hashicorp.rst
@@ -30,9 +30,12 @@ You must modify this YAML to reflect your deployment environment.
        - /v1/key/create/*   # You can replace these wildcard '*' with a string prefix to restrict key names
        - /v1/key/generate/* # e.g. '/minio-'
        - /v1/key/decrypt/*
-       - /v1/key/list*
+       - /v1/key/bulk/decrypt
+       - /v1/key/list
        - /v1/status
        - /v1/metrics
+       - /v1/log/audit
+       - /v1/log/error
        identities:
        - MINIO_IDENTITY_HASH # Replace with the output of 'kes identity of minio-kes.cert'
                                 # In production environments, each client connecting to KES must

--- a/source/includes/linux/steps-configure-minio-kes-aws.rst
+++ b/source/includes/linux/steps-configure-minio-kes-aws.rst
@@ -36,6 +36,11 @@ b. Create the Service File
 3) Create the KES and MinIO Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. important::
+
+   Starting with :minio-release:`RELEASE.2023-02-17T17-52-43Z`, MinIO requires expanded KES permissions for functionality.
+   The example configuration in this section contains all required permissions.
+
 a. Create the KES Configuration File
 
    Create the configuration file using your preferred text editor.

--- a/source/includes/linux/steps-configure-minio-kes-azure.rst
+++ b/source/includes/linux/steps-configure-minio-kes-azure.rst
@@ -36,6 +36,11 @@ b. Create the Service File
 3) Create the KES and MinIO Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. important::
+
+   Starting with :minio-release:`RELEASE.2023-02-17T17-52-43Z`, MinIO requires expanded KES permissions for functionality.
+   The example configuration in this section contains all required permissions.
+
 a. Create the KES Configuration File
 
    Create the configuration file using your preferred text editor.

--- a/source/includes/linux/steps-configure-minio-kes-gcp.rst
+++ b/source/includes/linux/steps-configure-minio-kes-gcp.rst
@@ -14,6 +14,11 @@ Prior to starting these steps, create the following folders if they do not alrea
 1) Download KES and Create the Service File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. important::
+
+   Starting with :minio-release:`RELEASE.2023-02-17T17-52-43Z`, MinIO requires expanded KES permissions for functionality.
+   The example configuration in this section contains all required permissions.
+
 a. Download KES
 
    .. include:: /includes/linux/common-minio-kes.rst

--- a/source/includes/linux/steps-configure-minio-kes-hashicorp.rst
+++ b/source/includes/linux/steps-configure-minio-kes-hashicorp.rst
@@ -66,6 +66,11 @@ Defer to the client documentation for instructions on trusting a third-party CA.
 3) Create the KES and MinIO Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. important::
+
+   Starting with :minio-release:`RELEASE.2023-02-17T17-52-43Z`, MinIO requires expanded KES permissions for functionality.
+   The example configuration in this section contains all required permissions.
+
 .. container:: procedure
 
    a. Create the KES Configuration File

--- a/source/operations/server-side-encryption/configure-minio-kes-aws.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-aws.rst
@@ -242,7 +242,7 @@ MinIO specifically requires the following AWS settings or configurations:
 Configuration Reference for AWS Root KMS
 ----------------------------------------
 
-The following section describes each of the |KES-git| configuration settings for using AWS Secrets Manager and AWS KMS as the root Key Management Service (KMS) for |SSE|:
+The following section describes each of the |KES-git| configuration settings for using AWS Secrets Manager and AWS Key Management System as the root :abbr:`KMS (Key Management System)` for |SSE|:
 
 .. important::
 
@@ -253,7 +253,7 @@ The following section describes each of the |KES-git| configuration settings for
 
    .. tab-item:: YAML Overview
 
-      Any field with value ``${VARIABLE}`` uses the environment variable with matching name as the value. 
+      Fields with ``${<STRING>}`` use the environment variable matching the ``<STRING>`` value. 
       You can use this functionality to set credentials without writing them to the configuration file.
 
       The YAML assumes a minimal set of permissions for the MinIO deployment accessing KES.
@@ -271,12 +271,15 @@ The following section describes each of the |KES-git| configuration settings for
          policy:
            minio-server:
              allow:
-               - /v1/key/create/*
-               - /v1/key/generate/*
-               - /v1/key/decrypt/*
-               - /v1/key/list*
-               - /v1/status
-               - /v1/metrics
+             - /v1/key/create/*
+             - /v1/key/generate/*
+             - /v1/key/decrypt/*
+             - /v1/key/bulk/decrypt
+             - /v1/key/list
+             - /v1/status
+             - /v1/metrics
+             - /v1/log/audit
+             - /v1/log/error
              identities:
              - ${MINIO_IDENTITY}
          

--- a/source/operations/server-side-encryption/configure-minio-kes-aws.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-aws.rst
@@ -16,7 +16,7 @@ Server-Side Object Encryption with AWS Secrets Manager Root KMS
 .. |KES-git|       replace:: :minio-git:`Key Encryption Service (KES) <kes>`
 .. |KES|           replace:: :abbr:`KES (Key Encryption Service)`
 .. |rootkms|       replace:: `AWS Secrets Manager <https://aws.amazon.com/secrets-manager/>`__
-.. |rootkms-short| replace:: AWS Secrets Manager
+.. |rootkms-short| replace:: `AWS Key Management Service <https://aws.amazon.com/kms/>`__
 
 MinIO Server-Side Encryption (SSE) protects objects as part of write operations, allowing clients to take advantage of server processing power to secure objects at the storage layer (encryption-at-rest). 
 SSE also provides key functionality to regulatory and compliance requirements around secure locking and erasure.
@@ -115,7 +115,7 @@ Prerequisites
 Ensure Access to the AWS Secrets Manager and Key Management Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This procedure assumes access to and familiarity with |rootkms| and `|rootkms-short| <https://aws.amazon.com/kms/>`__.
+This procedure assumes access to and familiarity with |rootkms| and |rootkms-short|.
 
 .. cond:: k8s
 
@@ -242,20 +242,22 @@ MinIO specifically requires the following AWS settings or configurations:
 Configuration Reference for AWS Root KMS
 ----------------------------------------
 
-The following section describes each of the |KES-git| configuration settings for
-using AWS Secrets Manager and AWS KMS as the root Key Management Service
-(KMS) for |SSE|:
+The following section describes each of the |KES-git| configuration settings for using AWS Secrets Manager and AWS KMS as the root Key Management Service (KMS) for |SSE|:
+
+.. important::
+
+   Starting with :minio-release:`RELEASE.2023-02-17T17-52-43Z`, MinIO requires expanded KES permissions for functionality.
+   The example configuration in this section contains all required permissions.
 
 .. tab-set::
 
    .. tab-item:: YAML Overview
 
-      The following YAML describes the minimum required fields for configuring
-      AWS Secrets Manager as an external KMS for supporting |SSE|. 
+      Any field with value ``${VARIABLE}`` uses the environment variable with matching name as the value. 
+      You can use this functionality to set credentials without writing them to the configuration file.
 
-      Any field with value ``${VARIABLE}`` uses the environment variable 
-      with matching name as the value. You can use this functionality to set
-      credentials without writing them to the configuration file.
+      The YAML assumes a minimal set of permissions for the MinIO deployment accessing KES.
+      As an alternative, you can omit the ``policy.minio-server`` section and instead set the ``${MINIO_IDENTITY}`` hash as the ``${ROOT_IDENTITY}``.
 
       .. code-block:: yaml
 
@@ -272,6 +274,9 @@ using AWS Secrets Manager and AWS KMS as the root Key Management Service
                - /v1/key/create/*
                - /v1/key/generate/*
                - /v1/key/decrypt/*
+               - /v1/key/list*
+               - /v1/status
+               - /v1/metrics
              identities:
              - ${MINIO_IDENTITY}
          

--- a/source/operations/server-side-encryption/configure-minio-kes-azure.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-azure.rst
@@ -228,16 +228,20 @@ The following section describes each of the |KES-git| configuration settings for
 using Azure Key Vault as the root Key Management Service
 (KMS) for |SSE|:
 
+.. important::
+
+   Starting with :minio-release:`RELEASE.2023-02-17T17-52-43Z`, MinIO requires expanded KES permissions for functionality.
+   The example configuration in this section contains all required permissions.
+
 .. tab-set::
 
    .. tab-item:: YAML Overview
 
-      The following YAML describes the minimum required fields for configuring
-      Azure Key Vault as an external KMS for supporting |SSE|. 
+      Any field with value ``${VARIABLE}`` uses the environment variable with matching name as the value. 
+      You can use this functionality to set credentials without writing them to the configuration file.
 
-      Any field with value ``${VARIABLE}`` uses the environment variable 
-      with matching name as the value. You can use this functionality to set
-      credentials without writing them to the configuration file.
+      The YAML assumes a minimal set of permissions for the MinIO deployment accessing KES.
+      As an alternative, you can omit the ``policy.minio-server`` section and instead set the ``${MINIO_IDENTITY}`` hash as the ``${ROOT_IDENTITY}``.
 
       .. code-block:: yaml
 
@@ -254,6 +258,9 @@ using Azure Key Vault as the root Key Management Service
                - /v1/key/create/*
                - /v1/key/generate/*
                - /v1/key/decrypt/*
+               - /v1/key/list*
+               - /v1/status
+               - /v1/metrics
              identities:
              - ${MINIO_IDENTITY}
 

--- a/source/operations/server-side-encryption/configure-minio-kes-azure.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-azure.rst
@@ -237,7 +237,7 @@ using Azure Key Vault as the root Key Management Service
 
    .. tab-item:: YAML Overview
 
-      Any field with value ``${VARIABLE}`` uses the environment variable with matching name as the value. 
+      Fields with ``${<STRING>}`` use the environment variable matching the ``<STRING>`` value. 
       You can use this functionality to set credentials without writing them to the configuration file.
 
       The YAML assumes a minimal set of permissions for the MinIO deployment accessing KES.
@@ -255,12 +255,15 @@ using Azure Key Vault as the root Key Management Service
          policy:
            minio-server:
              allow:
-               - /v1/key/create/*
-               - /v1/key/generate/*
-               - /v1/key/decrypt/*
-               - /v1/key/list*
-               - /v1/status
-               - /v1/metrics
+             - /v1/key/create/*
+             - /v1/key/generate/*
+             - /v1/key/decrypt/*
+             - /v1/key/bulk/decrypt
+             - /v1/key/list
+             - /v1/status
+             - /v1/metrics
+             - /v1/log/audit
+             - /v1/log/error
              identities:
              - ${MINIO_IDENTITY}
 

--- a/source/operations/server-side-encryption/configure-minio-kes-gcp.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-gcp.rst
@@ -243,7 +243,7 @@ The following section describes each of the |KES-git| configuration settings for
 
    .. tab-item:: YAML Overview
 
-      Any field with value ``${VARIABLE}`` uses the environment variable with matching name as the value. 
+      Fields with ``${<STRING>}`` use the environment variable matching the ``<STRING>`` value. 
       You can use this functionality to set credentials without writing them to the configuration file.
 
       The YAML assumes a minimal set of permissions for the MinIO deployment accessing KES.
@@ -261,12 +261,15 @@ The following section describes each of the |KES-git| configuration settings for
          policy:
            minio-server:
              allow:
-               - /v1/key/create/*
-               - /v1/key/generate/*
-               - /v1/key/decrypt/*
-               - /v1/key/list*
-               - /v1/status
-               - /v1/metrics
+             - /v1/key/create/*
+             - /v1/key/generate/*
+             - /v1/key/decrypt/*
+             - /v1/key/bulk/decrypt
+             - /v1/key/list
+             - /v1/status
+             - /v1/metrics
+             - /v1/log/audit
+             - /v1/log/error
              identities:
              - ${MINIO_IDENTITY}
 

--- a/source/operations/server-side-encryption/configure-minio-kes-gcp.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-gcp.rst
@@ -232,20 +232,22 @@ configurations:
 Configuration Reference for GCP Secret Manager Root KMS
 -------------------------------------------------------
 
-The following section describes each of the |KES-git| configuration settings for
-using GCP Secrets Manager as the root Key Management Service
-(KMS) for |SSE|:
+The following section describes each of the |KES-git| configuration settings for using GCP Secrets Manager as the root Key Management Service (KMS) for |SSE|:
+
+.. important::
+
+   Starting with :minio-release:`RELEASE.2023-02-17T17-52-43Z`, MinIO requires expanded KES permissions for functionality.
+   The example configuration in this section contains all required permissions.
 
 .. tab-set::
 
    .. tab-item:: YAML Overview
 
-      The following YAML describes the minimum required fields for configuring
-      GCP Secret Manager as an external KMS for supporting |SSE|. 
+      Any field with value ``${VARIABLE}`` uses the environment variable with matching name as the value. 
+      You can use this functionality to set credentials without writing them to the configuration file.
 
-      Any field with value ``${VARIABLE}`` uses the environment variable 
-      with matching name as the value. You can use this functionality to set
-      credentials without writing them to the configuration file.
+      The YAML assumes a minimal set of permissions for the MinIO deployment accessing KES.
+      As an alternative, you can omit the ``policy.minio-server`` section and instead set the ``${MINIO_IDENTITY}`` hash as the ``${ROOT_IDENTITY}``.
 
       .. code-block:: yaml
 
@@ -262,6 +264,9 @@ using GCP Secrets Manager as the root Key Management Service
                - /v1/key/create/*
                - /v1/key/generate/*
                - /v1/key/decrypt/*
+               - /v1/key/list*
+               - /v1/status
+               - /v1/metrics
              identities:
              - ${MINIO_IDENTITY}
 

--- a/source/operations/server-side-encryption/configure-minio-kes-hashicorp.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-hashicorp.rst
@@ -287,7 +287,7 @@ The following section describes each of the |KES-git| configuration settings for
 
       The following YAML describes the minimum required fields for configuring Hashicorp Vault as an external KMS for supporting |SSE|. 
 
-      Any field with value ``${VARIABLE}`` uses the environment variable with matching name as the value. 
+      Fields with ``${<STRING>}`` use the environment variable matching the ``<STRING>`` value. 
       You can use this functionality to set credentials without writing them to the configuration file.
 
       The YAML assumes a minimal set of permissions for the MinIO deployment accessing KES.
@@ -305,12 +305,15 @@ The following section describes each of the |KES-git| configuration settings for
          policy:
            minio-server:
              allow:
-               - /v1/key/create/*
-               - /v1/key/generate/*
-               - /v1/key/decrypt/*
-               - /v1/key/list*
-               - /v1/status
-               - /v1/metrics
+             - /v1/key/create/*
+             - /v1/key/generate/*
+             - /v1/key/decrypt/*
+             - /v1/key/bulk/decrypt
+             - /v1/key/list
+             - /v1/status
+             - /v1/metrics
+             - /v1/log/audit
+             - /v1/log/error
              identities:
              - ${MINIO_IDENTITY}
 

--- a/source/operations/server-side-encryption/configure-minio-kes-hashicorp.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-hashicorp.rst
@@ -274,19 +274,24 @@ You can use the following steps to enable AppRole authentication and create the 
 Configuration Reference for Hashicorp Vault
 -------------------------------------------
 
-The following section describes each of the |KES-git| configuration settings for
-using Hashicorp Vault as the root Key Management Service (KMS) for |SSE|:
+The following section describes each of the |KES-git| configuration settings for using Hashicorp Vault as the root Key Management Service (KMS) for |SSE|.
+
+.. important::
+
+   Starting with :minio-release:`RELEASE.2023-02-17T17-52-43Z`, MinIO requires expanded KES permissions for functionality.
+   The example configuration in this section contains all required permissions.
 
 .. tab-set::
 
    .. tab-item:: YAML Overview
 
-      The following YAML describes the minimum required fields for configuring
-      Hashicorp Vault as an external KMS for supporting |SSE|. 
+      The following YAML describes the minimum required fields for configuring Hashicorp Vault as an external KMS for supporting |SSE|. 
 
-      Any field with value ``${VARIABLE}`` uses the environment variable 
-      with matching name as the value. You can use this functionality to set
-      credentials without writing them to the configuration file.
+      Any field with value ``${VARIABLE}`` uses the environment variable with matching name as the value. 
+      You can use this functionality to set credentials without writing them to the configuration file.
+
+      The YAML assumes a minimal set of permissions for the MinIO deployment accessing KES.
+      As an alternative, you can omit the ``policy.minio-server`` section and instead set the ``${MINIO_IDENTITY}`` hash as the ``${ROOT_IDENTITY}``.
 
       .. code-block:: yaml
 
@@ -303,6 +308,9 @@ using Hashicorp Vault as the root Key Management Service (KMS) for |SSE|:
                - /v1/key/create/*
                - /v1/key/generate/*
                - /v1/key/decrypt/*
+               - /v1/key/list*
+               - /v1/status
+               - /v1/metrics
              identities:
              - ${MINIO_IDENTITY}
 


### PR DESCRIPTION
Partially addresses #779 

# Summary

As part of the February 2023 release, MinIO requires expanded permissions for KES.

This PR captures the expanded permissions and warns users of what to look for. This should hopefully be a lifeline for anyone running into issues post-upgrade.

Out of scope for *this* PR but necessary to further tidy this up is the work done to implement the KES API Key behavior, which would substantially decrease the complexity of all related tutorials (see https://github.com/minio/minio/pull/16617)

Finally, also out of scope for *this* PR is to provide explicit guidance for setting the MinIO server API Key as the KES root, since that simplifies _all_ of this. We can still call attention to the limited permission set if necessary. 

Staged:

- http://192.241.195.202:9000/staging/DOCS-779/linux/operations/server-side-encryption/configure-minio-kes-hashicorp.html
- http://localhost:8000/DOCS-779/linux/html/operations/server-side-encryption/configure-minio-kes-aws.html
- http://localhost:8000/DOCS-779/linux/html/operations/server-side-encryption/configure-minio-kes-gcp.html
- http://localhost:8000/DOCS-779/linux/html/operations/server-side-encryption/configure-minio-kes-azure.html