### PR TITLE
DOCS-660: Add note for Linux gateway migration docs pointing to Container docs

### DIFF
--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -20,6 +20,10 @@ Along with the deprecation announcement, MinIO also announced that the feature w
 As of :minio-release:`RELEASE.2022-10-29T06-21-33Z`, the MinIO Gateway and the related filesystem mode code have been removed.
 Deployments still using the `standalone` or `filesystem` MinIO modes that upgrade to :minio-release:`RELEASE.2022-10-29T06-21-33Z` or later receive an error when attempting to start MinIO.
 
+.. cond:: linux
+
+   For deployments running in a container, see the `Container - Migrate from Gateway or Filesystem Mode <https://min.io/docs/minio/container/operations/install-deploy-manage/migrate-fs-gateway.html>`__ tutorial instead.
+
 Overview
 --------
 

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -22,7 +22,9 @@ Deployments still using the `standalone` or `filesystem` MinIO modes that upgrad
 
 .. cond:: linux
 
-   For deployments running in a container, see the `Container - Migrate from Gateway or Filesystem Mode <https://min.io/docs/minio/container/operations/install-deploy-manage/migrate-fs-gateway.html>`__ tutorial instead.
+   .. note::
+
+      For deployments running in a container, see the `Container - Migrate from Gateway or Filesystem Mode <https://min.io/docs/minio/container/operations/install-deploy-manage/migrate-fs-gateway.html>`__ tutorial instead.
 
 Overview
 --------


### PR DESCRIPTION
Closes #660 

There's no promise of a simple fix for being able to link to the container docs for when MinIO server runs in a containerized context. So the easiest thing to do is just link users to the Container docs, which themselves link to the correct deploy tutorials for a container context.

Worth noting that this already existed from the start, it's just that users may not think to change context from "Linux" to "Container" in the top-nav. Maybe we could explore JS to automatically inject the current page subpath into the nav bar when switching contexts for good measure, but we would also need to include some sort of 404-capture for when a page does not exist to at least route to the platform index. Problems for later.