### PR TITLE
General work on releases

### DIFF
--- a/source/administration/identity-access-management/ad-ldap-access-management.rst
+++ b/source/administration/identity-access-management/ad-ldap-access-management.rst
@@ -10,8 +10,7 @@ Active Directory / LDAP Access Management
    :local:
    :depth: 2
 
-MinIO supports using an Active Directory or LDAP (AD/LDAP) service for external
-management of user identities.
+MinIO supports configuring a single Active Directory or LDAP (AD/LDAP) service for external management of user identities.
 
 For identities managed by the external AD/LDAP provider, MinIO uses the user's Distinguished Name and attempts to map it against an existing :ref:`policy <minio-policy>`.
 

--- a/source/administration/minio-console.rst
+++ b/source/administration/minio-console.rst
@@ -121,14 +121,13 @@ or exhibit unexpected behavior with the the dynamic redirection behavior.
 Logging In
 ----------
 
-Logging into the MinIO Console depends on how you configured identity management for the deployment.
+.. versionchanged:: RELEASE.2023-03-09T23-16-13Z
 
-- When using the built-in MinIO identity management solution, the sign-in screen displays a standard login screen.
-  Enter your Username and Password to log in to the MinIO Console.
-- If logging in with a third party application and :ref:`MinIO's Security Token Service (STS) <minio-security-token-service>`, select :guilabel:`Use STS` and enter the Username, Secret, and Token.
-- If the deployment uses a single OpenID or Active Directory/LDAP identity provider solution, select the provider's button to proceed to the login screen.
-- If the deployment has multiple OpenID and/or Active Directory/LDAP identify management providers configured, the MinIO Console's sign-in screen provides a dropdown list of providers.
-  Select the provider you wish to use to log in to the MinIO Console, then enter the credentials.
+The MinIO Console displays a login screen for unauthenticated users.
+The Console defaults to providing a username and password prompt for a :ref:`MinIO-managed user <minio-internal-idp>`.
+
+For deployments configured with multiple :ref:`identity managers <minio-authentication-and-identity-management>`, select the :guilabel:`Other Authentication Methods` dropdown to select one of the other configured identity providers.
+You can also log in using credentials generated using a :ref:`Security Token Service (STS) <minio-security-token-service>` API.
 
 .. admonition:: Try out the Console using MinIO's Play testing environment
    :class: note

--- a/source/operations/external-iam/configure-ad-ldap-external-identity-management.rst
+++ b/source/operations/external-iam/configure-ad-ldap-external-identity-management.rst
@@ -13,7 +13,7 @@ Configure MinIO for Authentication using Active Directory / LDAP
 Overview
 --------
 
-MinIO supports using an Active Directory / LDAP Connect for external management of user identities. 
+MinIO supports configuring a single Active Directory / LDAP Connect for external management of user identities. 
 The procedure on this page provides instructions for:
 
 .. cond:: k8s

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -145,6 +145,11 @@ The following table lists :mc:`mc admin` commands:
           :start-after: start-mc-admin-user-svcacct-desc
           :end-before: end-mc-admin-user-svcacct-desc
 
+   * - :mc:`mc admin user sts`
+     - .. include:: /reference/minio-mc-admin/mc-admin-user-sts.rst
+          :start-after: start-mc-admin-user-sts-desc
+          :end-before: end-mc-admin-user-sts-desc
+
 .. _mc-admin-install:
 
 Installation

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -1984,7 +1984,7 @@ configuration settings.
       :class: copyable
 
       mc admin config set identity_ldap \
-         enabled="true"
+         enabled="true" \
          server_addr="https://ad-ldap.example.net/" \
          lookup_bind_dn="cn=miniolookupuser,dc=example,dc=net" \
          lookup_bind_dn_password="userpassword" \
@@ -2003,7 +2003,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-server-addr
          :end-before: end-minio-ad-ldap-server-addr
 
-      This environment configuration setting with the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_SERVER_ADDR` environment variable.
 
    .. mc-conf:: lookup_bind_dn
@@ -2015,7 +2015,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-lookup-bind-dn
          :end-before: end-minio-ad-ldap-lookup-bind-dn
 
-      This environment configuration setting with the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN` environment variable.
 
    .. mc-conf:: lookup_bind_password
@@ -2027,7 +2027,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-lookup-bind-password
          :end-before: end-minio-ad-ldap-lookup-bind-password
          
-      This environment variable configuration setting the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD` environment variable.
 
    .. mc-conf:: user_dn_search_base_dn
@@ -2039,7 +2039,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-user-dn-search-base-dn
          :end-before: end-minio-ad-ldap-user-dn-search-base-dn
          
-      This environment variable configuration setting the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN` environment variable.
 
    .. mc-conf:: user_dn_search_filter
@@ -2051,7 +2051,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-user-dn-search-filter
          :end-before: end-minio-ad-ldap-user-dn-search-filter
          
-      This environment variable configuration setting the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER` environment variable.
 
    .. mc-conf:: enabled
@@ -2061,7 +2061,7 @@ configuration settings.
 
       Set to ``false`` to disable the AD/LDAP configuration.
 
-      Applications cannot generate STS credentials or otherwise authenticate to MinIO using the configured provider if set to ``false``.
+      If ``false``, applications cannot generate STS credentials or otherwise authenticate to MinIO using the configured provider.
 
       Defaults to ``true`` or "enabled".
 
@@ -2074,7 +2074,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-sts-expiry
          :end-before: end-minio-ad-ldap-sts-expiry
 
-      This environment configuration setting with the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_STS_EXPIRY` environment variable.
 
    .. mc-conf:: username_format
@@ -2086,7 +2086,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-username-format
          :end-before: end-minio-ad-ldap-username-format
 
-      This environment configuration setting with the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_USERNAME_FORMAT` environment variable.
 
    .. mc-conf:: group_search_filter
@@ -2098,7 +2098,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-group-search-filter
          :end-before: end-minio-ad-ldap-group-search-filter
          
-      This environment variable configuration setting the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER` environment variable.
 
    .. mc-conf:: group_search_base_dn
@@ -2110,7 +2110,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-group-search-base-dn
          :end-before: end-minio-ad-ldap-group-search-base-dn
          
-      This environment variable configuration setting the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN` environment variable.
 
    .. mc-conf:: tls_skip_verify
@@ -2122,7 +2122,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-tls-skip-verify
          :end-before: end-minio-ad-ldap-tls-skip-verify
 
-      This environment configuration setting with the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY` environment variable.
 
    .. mc-conf:: server_insecure
@@ -2134,7 +2134,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-server-insecure
          :end-before: end-minio-ad-ldap-server-insecure
 
-      This environment configuration setting with the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_SERVER_INSECURE` environment variable.
 
    .. mc-conf:: server_starttls
@@ -2146,7 +2146,7 @@ configuration settings.
          :start-after: start-minio-ad-ldap-server-starttls
          :end-before: end-minio-ad-ldap-server-starttls
 
-      This environment configuration setting with the 
+      This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_LDAP_SERVER_STARTTLS` environment variable.
 
    .. mc-conf:: comment

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -1984,6 +1984,7 @@ configuration settings.
       :class: copyable
 
       mc admin config set identity_ldap \
+         enabled="true"
          server_addr="https://ad-ldap.example.net/" \
          lookup_bind_dn="cn=miniolookupuser,dc=example,dc=net" \
          lookup_bind_dn_password="userpassword" \
@@ -1996,26 +1997,14 @@ configuration settings.
    .. mc-conf:: server_addr
       :delimiter: " "
 
-   *Required*
-
-   .. include:: /includes/common-minio-external-auth.rst
-      :start-after: start-minio-ad-ldap-server-addr
-      :end-before: end-minio-ad-ldap-server-addr
-
-   This environment configuration setting with the 
-   :envvar:`MINIO_IDENTITY_LDAP_SERVER_ADDR` environment variable.
-
-   .. mc-conf:: sts_expiry
-      :delimiter: " "
-
-      *Optional*
+      *Required*
 
       .. include:: /includes/common-minio-external-auth.rst
-         :start-after: start-minio-ad-ldap-sts-expiry
-         :end-before: end-minio-ad-ldap-sts-expiry
+         :start-after: start-minio-ad-ldap-server-addr
+         :end-before: end-minio-ad-ldap-server-addr
 
       This environment configuration setting with the 
-      :envvar:`MINIO_IDENTITY_LDAP_STS_EXPIRY` environment variable.
+      :envvar:`MINIO_IDENTITY_LDAP_SERVER_ADDR` environment variable.
 
    .. mc-conf:: lookup_bind_dn
       :delimiter: " "
@@ -2064,6 +2053,29 @@ configuration settings.
          
       This environment variable configuration setting the 
       :envvar:`MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER` environment variable.
+
+   .. mc-conf:: enabled
+      :delimiter: " "
+
+      *Optional*
+
+      Set to ``false`` to disable the AD/LDAP configuration.
+
+      Applications cannot generate STS credentials or otherwise authenticate to MinIO using the configured provider if set to ``false``.
+
+      Defaults to ``true`` or "enabled".
+
+   .. mc-conf:: sts_expiry
+      :delimiter: " "
+
+      *Optional*
+
+      .. include:: /includes/common-minio-external-auth.rst
+         :start-after: start-minio-ad-ldap-sts-expiry
+         :end-before: end-minio-ad-ldap-sts-expiry
+
+      This environment configuration setting with the 
+      :envvar:`MINIO_IDENTITY_LDAP_STS_EXPIRY` environment variable.
 
    .. mc-conf:: username_format
       :delimiter: " "
@@ -2190,8 +2202,21 @@ configuration settings.
       This configuration setting corresponds with the 
       :envvar:`MINIO_IDENTITY_OPENID_CONFIG_URL` environment variable.
 
+   .. mc-conf:: enabled
+      :delimiter: " "
+
+      *Optional*
+
+      Set to ``false`` to disable the OpenID configuration.
+
+      Applications cannot generate STS credentials or otherwise authenticate to MinIO using the configured provider if set to ``false``.
+
+      Defaults to ``true`` or "enabled".
+
    .. mc-conf:: client_id
       :delimiter: " "
+
+      *Optional*
 
       .. include:: /includes/common-minio-external-auth.rst
          :start-after: start-minio-openid-client-id
@@ -2202,6 +2227,8 @@ configuration settings.
 
    .. mc-conf:: client_secret
       :delimiter: " "
+
+      *Optional*
 
       .. include:: /includes/common-minio-external-auth.rst
          :start-after: start-minio-openid-client-secret
@@ -2379,6 +2406,17 @@ See :ref:`minio-external-identity-management-plugin` for a tutorial on using the
       .. include:: /includes/common-minio-external-auth.rst
          :start-after: start-minio-identity-management-role-policy
          :end-before: end-minio-identity-management-role-policy
+
+   .. mc-conf:: enabled
+      :delimiter: " "
+
+      *Optional*
+
+      Set to ``false`` to disable the identity provider configuration.
+
+      Applications cannot generate STS credentials or otherwise authenticate to MinIO using the configured provider if set to ``false``.
+
+      Defaults to ``true`` or "enabled".
 
    .. mc-conf:: token
       :delimiter: " "

--- a/source/reference/minio-mc-admin/mc-admin-idp-ldap.rst
+++ b/source/reference/minio-mc-admin/mc-admin-idp-ldap.rst
@@ -46,9 +46,6 @@ The :mc-cmd:`mc admin idp ldap` command has the following subcommands:
    * - :mc-cmd:`mc admin idp ldap remove`
      - Remove an AD/LDAP IDP server configuration from a deployment.
 
-   * - :mc-cmd:`mc admin idp ldap list`
-     - Outputs a list of the existing AD/LDAP server configurations for a deployment.
-
    * - :mc-cmd:`mc admin idp ldap info`
      - Displays details for a specific AD/LDAP server configuration.
 
@@ -74,22 +71,20 @@ Syntax
 
 .. mc-cmd:: add
 
-   Create a new set of configurations for an AD/LDAP provider.
-
-   You can run the command multiple times to set up multiple Active Directory or LDAP providers.
+   Create a new configuration for an AD/LDAP provider.
+   MinIO supports no more than *one* (1) AD/LDAP provider per deployment.
 
    .. tab-set::
 
       .. tab-item:: EXAMPLE
 
-         The following example creates the configuration settings for the ``myminio`` deployment as defined in a new ``test-config`` setup for LDAP integration.
+         The following example sets the AD/LDAP configuration settings for the ``myminio`` deployment.
 
          .. code-block:: shell
             :class: copyable
 
              mc admin idp ldap add                                               \
-                  myminio                                                        \
-                  test-config                                                    \                                                        
+                  myminio                                                        \                                              
                   server_addr=myldapserver:636                                   \                                                       
                   lookup_bind_dn=cn=admin,dc=min,dc=io                           \                                               
                   lookup_bind_password=somesecret                                \                                                    
@@ -107,13 +102,10 @@ Syntax
 
             mc [GLOBALFLAGS] admin idp ldap add          \
                                        ALIAS             \
-                                       [CFG_NAME]        \
                                        [CFG_PARAM1]      \
                                        [CFG_PARAM2]...
 
-         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
-         - Replace ``CFG_NAME`` with a unique string for this configuration.
-           If not specified, the command creates default configuration values.
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to create for AD/LDAP integration.
          - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-ldap-config-settings>` key-value pairs in the format of ``PARAMETER="value"``.
 
 .. mc-cmd:: update
@@ -124,14 +116,13 @@ Syntax
 
       .. tab-item:: EXAMPLE
 
-         The following example changes two of the configuration settings for the ``myminio`` deployment as defined in the ``test-config`` setup for LDAP integration.
+         The following example changes two of the AD/LDAP configuration settings for the ``myminio`` deployment.
 
          .. code-block:: shell
             :class: copyable
 
             mc admin idp ldap update                                \
                               myminio                               \
-                              test_config                           \
                               lookup_bind_dn=cn=admin,dc=min,dc=io  \
                               lookup_bind_password=somesecret                                                              
                                     
@@ -144,29 +135,26 @@ Syntax
 
             mc [GLOBALFLAGS] admin idp ldap update           \
                                             ALIAS            \
-                                            [CFG_NAME]       \
                                             [CFG_PARAM1]     \
                                             [CFG_PARAM2]...
 
-         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
-         - Replace ``CFG_NAME`` with a unique string for this configuration.
-           If not specified, the command updates the default configuration.
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to update for AD/LDAP integration.
          - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-ldap-config-settings>` key-value pairs to update in the format of ``PARAMETER="value"``.
 
 .. mc-cmd:: remove
 
-   Remove an existing set of configurations for an AD/LDAP provider.
+   Remove the existing configuration for an AD/LDAP provider.
 
    .. tab-set::
 
       .. tab-item:: EXAMPLE
 
-         The following example removes the ``test-config`` settings for the ``myminio`` deployment.
+         The following example removes the AD/LDAP provider settings for the ``myminio`` deployment.
 
          .. code-block:: shell
             :class: copyable
 
-            mc admin idp ldap remove myminio test_config                                                              
+            mc admin idp ldap remove myminio                                                             
                                     
       .. tab-item:: SYNTAX
 
@@ -176,54 +164,25 @@ Syntax
             :class: copyable
 
             mc [GLOBALFLAGS] admin idp ldap remove     \
-                                            ALIAS      \
-                                            [CFG_NAME]
+                                            ALIAS
 
-         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
-         - Replace ``CFG_NAME`` with a unique string for this configuration.
-           If not specified, the command removes the default configurations. 
-
-.. mc-cmd:: list
-
-   Outputs a list of existing configuration sets for AD/LDAP providers.
-
-   .. tab-set::
-
-      .. tab-item:: EXAMPLE
-
-         The following example outputs a list of all AD/LDAP configuration sets defined for the ``myminio`` deployment.
-
-         .. code-block:: shell
-            :class: copyable
-
-            mc admin idp ldap list myminio                                                            
-                                    
-      .. tab-item:: SYNTAX
-
-         The command has the following syntax:
-
-         .. code-block:: shell
-            :class: copyable
-
-            mc [GLOBALFLAGS] admin idp ldap list ALIAS
-
-         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to list AD/LDAP integration for.
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to remove the AD/LDAP integration.
 
 
 .. mc-cmd:: info
 
-   Outputs the set of values defined for an existing set of server configurations for an AD/LDAP provider.
+   Outputs the current configuration for an AD/LDAP provider on a specified MinIO deployment.
 
    .. tab-set::
 
       .. tab-item:: EXAMPLE
 
-         The following example outputs the configuration settings defined for the ``test_config`` set of AD/LDAP settings on the ``myminio`` deployment.
+         The following example outputs the AD/LDAP configuration settings on the ``myminio`` deployment.
 
          .. code-block:: shell
             :class: copyable
 
-            mc admin idp ldap info myminio test_config
+            mc admin idp ldap info myminio
                                     
       .. tab-item:: SYNTAX
 
@@ -233,29 +192,25 @@ Syntax
             :class: copyable
 
             mc [GLOBALFLAGS] admin idp ldap info     \
-                                            ALIAS      \
-                                            [CFG_NAME]
+                                            ALIAS
 
-         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
-         - Replace ``CFG_NAME`` with a unique string for this configuration.
-           If not specified, the information displays for the default server configuration.
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to retrieve info on the AD/LDAP integration.
 
 .. mc-cmd:: enable
 
-   Begin using an existing set of configurations for an AD/LDAP provider.
+   Enables the currently configured AD/LDAP provider.
 
    .. tab-set::
 
       .. tab-item:: EXAMPLE
 
-         The following example enables the server configurations defined as ``test_config`` on the ``myminio`` deployment.
+         The following example enables the AD/LDAP configuration on the ``myminio`` deployment.
 
          .. code-block:: shell
             :class: copyable
 
             mc admin idp ldap enable       \
-                              myminio      \
-                              test_config
+                              myminio
 
       .. tab-item:: SYNTAX
 
@@ -265,29 +220,24 @@ Syntax
             :class: copyable
 
             mc [GLOBALFLAGS] admin idp ldap enable     \
-                                            ALIAS      \
-                                            [CFG_NAME]
-
-         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
-         - Replace ``CFG_NAME`` with a unique string for this configuration.
-           If not specified, the command enables the default configuration values.
+                                            ALIAS
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to enable the AD/LDAP integration.
 
 .. mc-cmd:: disable
 
-   Stop using a set of configurations for an AD/LDAP provider.
+   Disables the currently configured AD/LDAP provider.
 
    .. tab-set::
 
       .. tab-item:: EXAMPLE
 
-         The following example disables the server configurations defined as ``test_config`` on the ``myminio`` deployment.
+         The following example disables the AD/LDAP configurations on the ``myminio`` deployment.
 
          .. code-block:: shell
             :class: copyable
 
             mc admin idp ldap disable      \
-                              myminio      \
-                              test_config
+                              myminio
 
       .. tab-item:: SYNTAX
 
@@ -297,12 +247,9 @@ Syntax
             :class: copyable
 
             mc [GLOBALFLAGS] admin idp ldap disable       \
-                                            ALIAS         \
-                                            [CFG_NAME]
+                                            ALIAS
 
-         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
-         - Replace ``CFG_NAME`` with a unique string for this configuration.
-           If not specified, the command disables the default configuration values.
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to disable the AD/LDAP integration.
 
 Global Flags
 ------------

--- a/source/reference/minio-mc-admin/mc-admin-idp-ldap.rst
+++ b/source/reference/minio-mc-admin/mc-admin-idp-ldap.rst
@@ -221,6 +221,7 @@ Syntax
 
             mc [GLOBALFLAGS] admin idp ldap enable     \
                                             ALIAS
+
          - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to enable the AD/LDAP integration.
 
 .. mc-cmd:: disable

--- a/source/reference/minio-mc-admin/mc-admin-user-sts.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-sts.rst
@@ -1,0 +1,89 @@
+.. _minio-mc-admin-user-sts:
+
+=====================
+``mc admin user sts``
+=====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin user sts
+
+Description
+-----------
+
+.. versionadded:: RELEASE.2023-02-16T19-20-11Z
+
+.. start-mc-admin-user-sts-desc
+
+The :mc:`mc admin user sts` command operates on credentials generated using a :ref:`Security Token Service (STS) <minio-security-token-service>` API.
+
+.. end-mc-admin-user-sts-desc
+
+:abbr:`STS (Security Token Service)` credentials provide temporary access to the MinIO deployment.
+
+.. admonition:: Use ``mc admin`` on MinIO Deployments Only
+   :class: note
+
+   .. include:: /includes/facts-mc-admin.rst
+      :start-after: start-minio-only
+      :end-before: end-minio-only
+
+The :mc:`mc admin user sts` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc admin user sts info`
+     - Retrieves information on the specified STS credential, including the parent user who generated the credentials and it's attached policies.
+
+Syntax
+------
+
+.. mc-cmd:: info
+   :fullpath:
+
+   Retrieves information on the specified STS credential, such as the parent user who generated the credentials.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following command retrieves information on the STS credentials with specified access key:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin user sts info myminio/ "J123C4ZXEQN8RK6ND35I"
+
+      .. tab-item:: SYNTAX
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] admin user sts info \
+               [--policy]                        \
+               ALIAS                             \
+               STSACCESSKEY
+
+   .. mc-cmd:: ALIAS
+      :required:
+
+      The :ref:`alias <alias>` of the MinIO deployment for which the STS credentials were generated.
+
+   .. mc-cmd:: STSACCESSKEY
+      :required:
+
+      The access key for the STS credentials.
+
+   .. mc-cmd:: --policy
+      :optional:
+
+      Prints the policy attached to the specified STS credentials in JSON format.


### PR DESCRIPTION
Closes #750 
Closes #736 
Partially Address #767 767

I noticed that for `mc admin config get`, `enable` is like a global flag that everyone gets. The entire page needs restructuring so that is something to tackle down the line.