### PR TITLE
Doc updates for mc RELEASE.2023-03-20T17-17-53Z

### DIFF
--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -199,4 +199,27 @@ See :ref:`minio-mc-global-options`.
    :hidden:
    :glob:
 
-   /reference/minio-mc-admin/*
+   /reference/minio-mc-admin/mc-admin-bucket-remote.rst
+   /reference/minio-mc-admin/mc-admin-config
+   /reference/minio-mc-admin/mc-admin-console
+   /reference/minio-mc-admin/mc-admin-decommission
+   /reference/minio-mc-admin/mc-admin-group
+   /reference/minio-mc-admin/mc-admin-heal
+   /reference/minio-mc-admin/mc-admin-idp-ldap
+   /reference/minio-mc-admin/mc-admin-idp-ldap-policy
+   /reference/minio-mc-admin/mc-admin-idp-openid
+   /reference/minio-mc-admin/mc-admin-info
+   /reference/minio-mc-admin/mc-admin-kms-key
+   /reference/minio-mc-admin/mc-admin-logs
+   /reference/minio-mc-admin/mc-admin-obd
+   /reference/minio-mc-admin/mc-admin-policy
+   /reference/minio-mc-admin/mc-admin-profile
+   /reference/minio-mc-admin/mc-admin-prometheus
+   /reference/minio-mc-admin/mc-admin-rebalance
+   /reference/minio-mc-admin/mc-admin-replicate
+   /reference/minio-mc-admin/mc-admin-service
+   /reference/minio-mc-admin/mc-admin-top
+   /reference/minio-mc-admin/mc-admin-trace
+   /reference/minio-mc-admin/mc-admin-update
+   /reference/minio-mc-admin/mc-admin-user
+   /reference/minio-mc-admin/mc-admin-user-svcacct

--- a/source/reference/minio-mc-admin/mc-admin-policy-attach.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-attach.rst
@@ -1,0 +1,122 @@
+==========================
+``mc admin policy attach``
+==========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin policy attach
+
+Syntax
+------
+
+.. start-mc-admin-policy-attach-desc
+
+Attaches one or more IAM policies to either a user or a group. 
+
+.. end-mc-admin-policy-attach-desc
+
+
+Exactly one :mc-cmd:`~mc admin policy attach --user` or one :mc-cmd:`~mc admin policy attach --group` is required.
+
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command displays the current in-progress S3 API calls on the :term:`alias` ``myminio``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy attach myminio readonly --user james  
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy attach                       \
+                         TARGET                       \
+                         POLICY                       \
+                         [POLICY...]                  \
+                         [--user USER | --group GROUP] 
+
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+The :mc-cmd:`mc admin policy attach` command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment with the user or group for which you want to attach one or more policies.
+
+.. mc-cmd:: POLICY
+   :required:
+
+   The name of the policy to attach to either the user or the group. 
+      
+   You may attach multiple policies at once by separating each policy name with a space.
+
+   MinIO deployments include the following :ref:`built-in policies <minio-policy-built-in>` by default:
+
+   - :userpolicy:`readonly` 
+   - :userpolicy:`readwrite`
+   - :userpolicy:`diagnostics`
+   - :userpolicy:`writeonly`
+
+.. mc-cmd:: --user
+   :optional:
+
+   The username of the identity you want to attach the policy or policies to.
+   You may only list one user.
+
+   You must include either the ``--user`` flag or the ``--group`` flag.
+   You may not use the ``--user`` flag at the same time as the ``--group`` flag.
+
+.. mc-cmd:: --group
+   :optional:
+
+   The name of the group identity you want to attach the policy or policies to.
+   You may only list one group.
+
+   All users with membership in the group inherit the policies associated to the group.
+
+   You must include either the ``--group`` flag or the ``--user`` flag.
+   You may not use the ``--group`` flag at the same time as the ``--user`` flag.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Attach the ``readonly`` policy to user ``james`` on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy attach myminio readonly --user james
+
+Attach the ``audit-policy`` and ``acct-policy`` policies to group ``legal`` on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy attach myminio audit-policy acct-policy --group legal

--- a/source/reference/minio-mc-admin/mc-admin-policy-create.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-create.rst
@@ -1,0 +1,114 @@
+==========================
+``mc admin policy create``
+==========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin policy create
+
+Syntax
+------
+
+.. start-mc-admin-policy-create-desc
+
+Creates a new policy on the target MinIO deployment. 
+
+.. end-mc-admin-policy-create-desc
+
+MinIO deployments include the following :ref:`built-in policies <minio-policy-built-in>` by default:
+
+- :userpolicy:`readonly` 
+- :userpolicy:`readwrite`
+- :userpolicy:`diagnostics`
+- :userpolicy:`writeonly`
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+
+      Consider the following JSON policy document saved at a file called ``/tmp/listmybuckets.json``:
+      
+      .. code-block:: javascript
+         :class: copyable
+      
+         {
+            "Version": "2012-10-17",
+            "Statement": [
+               {
+                  "Effect": "Allow",
+                  "Action": [
+                     "s3:ListAllMyBuckets"
+                  ],
+                  "Resource": [
+                     "arn:aws:s3:::*"
+                  ]
+               }
+            ]
+         }
+
+      The following command creates a new policy called ``listmybuckets`` on the :term:`alias` ``myminio`` using the policy found at the file ``/tmp/listmybuckets.json``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy create myminio listmybuckets /tmp/listmybuckets.json  
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy create     \
+                         TARGET     \
+                         POLICYNAME \
+                         POLICYPATH
+
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+The :mc-cmd:`mc admin policy create` command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment on which to add the new policy.
+
+.. mc-cmd:: POLICYNAME
+
+   The name of the policy to add. 
+      
+   Specifying the name of an existing policy overwrites that policy on the :mc-cmd:`~mc admin policy create TARGET` MinIO deployment.
+
+.. mc-cmd:: POLICYPATH
+
+   The file path of the policy to add. 
+   The file *must* be a JSON-formatted file with :iam-docs:`IAM-compatible syntax <reference_policies.html>`. 
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Create a new policy called ``writeonly`` from the JSON file at ``/tmp/writeonly.json`` on the deployment at the alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy create myminio writeonly /tmp/writeonly.json

--- a/source/reference/minio-mc-admin/mc-admin-policy-detach.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-detach.rst
@@ -1,0 +1,119 @@
+==========================
+``mc admin policy detach``
+==========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin policy detach
+
+Syntax
+------
+
+.. start-mc-admin-policy-detach-desc
+
+Remove one or more IAM policies from a user or group identity. 
+
+.. end-mc-admin-policy-detach-desc
+
+Exactly one :mc-cmd:`~mc admin policy detach --user` or one :mc-cmd:`~mc admin policy detach --group` is required.
+
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command detaches the policy ``readonly`` from the user ``james`` on the deployment at alias ``myminio``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy detach myminio readonly --user james   
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy detach TARGET                         \
+                                POLICY                         \
+                                [POLICY...]                    \
+                                [--user USER | --group GROUP]
+
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+The :mc-cmd:`mc admin policy detach` command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment with the user or group for which you want to detach one or more policies.
+
+.. mc-cmd:: POLICY
+   :required:
+
+   The name of the policy to detach from either the user or the group. 
+   You may detach multiple policies at once by separating each policy name with a space.
+
+   MinIO deployments include the following :ref:`built-in policies <minio-policy-built-in>` by default:
+
+   - :userpolicy:`readonly` 
+   - :userpolicy:`readwrite`
+   - :userpolicy:`diagnostics`
+   - :userpolicy:`writeonly`
+
+.. mc-cmd:: --user
+   :optional:
+
+   The username of the identity you want to detach the policy or policies from.
+   You may only list one user.
+
+   You must include either the ``--user`` flag or the ``--group`` flag.
+   You may not use the ``--user`` flag at the same time as the ``--group`` flag.
+
+.. mc-cmd:: --group
+   :optional:
+
+   The name of the group identity you want to detach the policy or policies from.
+   You may only list one group.
+
+   All users with membership in the group lose access to any permissions granted by the policies associated to the group, unless those are granted by other policies or groups the users belong to.
+
+   You must include either the ``--group`` flag or the ``--user`` flag.
+   You may not use the ``--group`` flag at the same time as the ``--user`` flag.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Detach the policy ``readonly`` from the user ``james`` on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy detach myminio readonly --user james
+
+Detach the ``audit-policy`` and ``acct-policy`` policies from group ``legal`` on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy detach myminio audit-policy acct-policy --group legal

--- a/source/reference/minio-mc-admin/mc-admin-policy-entities.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-entities.rst
@@ -1,0 +1,182 @@
+============================
+``mc admin policy entities``
+============================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin policy entities
+
+Syntax
+------
+
+.. start-mc-admin-policy-entities-desc
+
+List the entities associated with a policy, user, or group on a target MinIO deployment. 
+
+.. end-mc-admin-policy-entities-desc
+
+For example, you can list all of the users and groups attached to a policy or list all of the policies attached to a specific user or group.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command returns a list of the policies associated with the user ``bob`` on the deployment at alias ``myminio``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy entities myminio/ --user bob  
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy entities         \
+                         TARGET           \
+                         [--user value]   \
+                         [--group value]  \
+                         [--policy value]
+
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+The :mc-cmd:`mc admin policy entities` command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment on which to add the new policy.
+
+.. mc-cmd:: --group
+   :optional:
+
+   The name of the group identity for which you want to list attached policies.
+
+   You may include multiple groups by repeating the flag multiple times.
+   The command returns each group with a list of associated entities.
+
+.. mc-cmd:: --policy
+   :optional:
+
+   The name of a policy for which to list associated entities. 
+      
+   You may include multiple policies by repeating the flag multiple times.
+   The command returns each policy with a list of all associated entities.
+
+.. mc-cmd:: --user
+   :optional:
+
+   The username of the identity for which you want to list attached policies.
+
+   You may include multiple users by repeating the flag multiple times.
+   The command returns each user with a list of associated policies.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+List all entities and policy associations for a deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command lists all policies and the entity mappings associated with them on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy entities myminio/
+
+List entities associated with two different policies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command lists all entities associated with the policies ``inteam-policy`` and ``mlteam-policy`` on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy entities myminio/ --policy finteam-policy --policy mlteam-policy
+
+List policies associated with two different users
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command lists all policies associated with the users ``bob`` and ``james`` on the deployment at alias ``myminio``.
+
+The command outputs the list of policies associated with ``bob`` then the list of policies associated with ``james`` on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy entities myminio/ --user bob --user james 
+
+List policies associated with two different groups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command lists all policies associated with the groups ``auditors`` and ``accounting`` on the deployment at alias ``myminio``.
+
+The command outputs the list of policies associated with the group ``auditors`` then the list of policies associated with the group ``accounting`` on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy entities play/ --group auditors --group accounting
+
+List policies associated with a policy, a group, and a user
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command lists all policies associated with the policy ``finteam-policy``, the user ``bobfisher``, and the group ``consulting`` on the deployment at alias ``myminio``.
+
+The command outputs the list of groups and users associated with the policy ``finteam-policy``, then lists the policies associated with the user ``bobfisher``, and finally lists the policies associated with the group ``consulting`` on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy entities play/ \                                                                        
+              --policy finteam-policy --user bobfisher --group consulting 
+
+Output
+------
+
+The output of the commands resembles the following:
+
+.. code-block:: shell
+
+   Query time: 2023-04-04T20:39:27Z
+     Policy -> Entity Mappings:
+       Policy: finteam-policy
+         User Mappings:
+           bobfisher
+       Policy: diagnostics
+         User Mappings:
+           james
+           bobfisher
+           marcia
+         Group Mappings:
+           consulting
+           auditors
+     User -> Policy Mappings:
+       User: bobfisher
+         ALLOW_PUBLIC_READ
+         finteam-policy
+         diagnostics
+         readonly
+         readwrite
+         writeonly

--- a/source/reference/minio-mc-admin/mc-admin-policy-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-info.rst
@@ -1,0 +1,113 @@
+========================
+``mc admin policy info``
+========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin policy info
+
+Syntax
+------
+
+.. start-mc-admin-policy-info-desc
+
+Returns the specified policy in JSON format if it exists on the target MinIO deployment. 
+
+.. end-mc-admin-policy-info-desc
+
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command displays the contents of the ``writeonly`` policy on the :term:`alias` ``myminio``.
+
+      .. code-block:: shell
+         :class: copyable
+
+          mc admin policy info myminio writeonly  
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy info TARGET POLICYNAME
+                              [--policy-file, -f <path>]
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+The :mc-cmd:`mc admin policy info` command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment from which to display the specified policy.
+
+.. mc-cmd:: POLICYNAME
+   :required:
+
+   The name of the policy whose details you want to display. 
+
+.. mc-cmd:: --policy-file
+   :optional:
+
+   Specifly the path of a file to write the contents of the specified policy JSON.
+   If the path already exists, the command overwrites the existing file with the contents of the specified file.
+      
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Display the contents of the ``writeonly`` policy on the :term:`alias` ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy info myminio writeonly
+
+Show information on a given policy and write the policy JSON content to /tmp/policy.json.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy info myminio writeonly --policy-file /tmp/policy.json
+
+Output
+~~~~~~
+
+The command returns output that resembles the following:
+
+.. code-block:: json
+
+   {
+      "Version": "2012-10-17",
+      "Statement": [
+         {
+            "Effect": "Allow",
+            "Action": [
+               "s3:PutObject"
+            ],
+            "Resource": [
+               "arn:aws:s3:::*"
+            ]
+         }
+      ]
+   }

--- a/source/reference/minio-mc-admin/mc-admin-policy-list.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-list.rst
@@ -1,0 +1,82 @@
+========================
+``mc admin policy list``
+========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin policy list
+
+Syntax
+------
+
+.. start-mc-admin-policy-list-desc
+
+Lists all policies on the target MinIO deployment.. 
+
+.. end-mc-admin-policy-list-desc
+
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command displays a list of the policies currently current on the :term:`alias` ``play``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy list play
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy list TARGET
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+The :mc-cmd:`mc admin policy list` command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+   
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment from which the command lists the available policies.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+List the policies that exist on the deployment at alias ``myminio``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy list myminio
+
+Output
+~~~~~~
+
+The command returns output that resembles the following:
+
+.. code-block:: shell
+
+   readwrite
+   writeonly

--- a/source/reference/minio-mc-admin/mc-admin-policy-remove.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-remove.rst
@@ -1,0 +1,76 @@
+==========================
+``mc admin policy remove``
+==========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc admin policy remove
+
+Syntax
+------
+
+.. start-mc-admin-policy-remove-desc
+
+Removes an IAM policy from the target MinIO deployment. 
+
+.. end-mc-admin-policy-remove-desc
+
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command removes the policy names ``writeonly`` from the ``myminio`` MinIO deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy remove myminio writeonly
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin policy remove TARGET POLICYNAME 
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+The :mc-cmd:`mc admin policy create` command accepts the following arguments:
+
+.. mc-cmd:: TARGET
+
+   The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment from which to remove the policy.
+
+.. mc-cmd:: POLICYNAME
+
+   The name of the policy to remove. 
+      
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Remove a policy called ``listbuckets``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin policy remove myminio listbuckets

--- a/source/reference/minio-mc-admin/mc-admin-policy.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy.rst
@@ -10,312 +10,87 @@
 
 .. mc:: mc admin policy
 
+.. versionchanged:: mc RELEASE.2023-03-20T17-17-53Z
+
+   The following commands are deprecated:
+   
+   - ``mc admin policy add`` use :mc:`mc admin policy create` instead
+   - ``mc admin policy set`` use :mc:`mc admin policy attach` instead
+   - ``mc admin policy unset`` use :mc:`mc admin policy detach` instead
+   - ``mc admin policy update`` use :mc:`~mc admin policy attach` or :mc:`~mc admin policy detach` instead
+
+   The following command is added:
+
+   - :mc-cmd:`mc admin policy entities`
+
 Description
 -----------
 
 .. start-mc-admin-policy-desc
 
-The :mc:`mc admin policy` command manages policies for use with MinIO
-Policy-Based Access Control (PBAC). MinIO PBAC uses IAM-compatible policy JSON
-documents to define rules for accessing resources on a MinIO server.
+The :mc:`mc admin policy` commands manage policies for use with :ref:`MinIO Policy-Based Access Control <minio-policy>` (PBAC). 
+MinIO PBAC uses IAM-compatible policy JSON documents to define rules for accessing resources on a MinIO server.
 
 .. end-mc-admin-policy-desc
 
-For complete documentation on MinIO PBAC, including policy document JSON
-structure and syntax, see
-:ref:`minio-access-management`.
-
-Examples
---------
-
-Create a Policy
-~~~~~~~~~~~~~~~
-
-.. include:: /includes/play-alias-available.rst
-   :start-after: myminio-alias
-   :end-before: end-myminio-alias
-
-Consider the following JSON policy document:
-
-.. code-block:: javascript
-   :class: copyable
-
-   {
-      "Version": "2012-10-17",
-      "Statement": [
-         {
-            "Effect": "Allow",
-            "Action": [
-               "s3:ListAllMyBuckets"
-            ],
-            "Resource": [
-               "arn:aws:s3:::*"
-            ]
-         }
-      ]
-   }
-
-The following :mc-cmd:`mc admin policy add` command creates a new policy
-``listbucketsonly`` on the ``myminio`` MinIO deployment using the
-example JSON policy document:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc admin policy add myminio listbucketsonly /path/to/listbucketsonly.json
-
-You can associate the new ``listbucketsonly`` policy to users or groups on the
-``myminio`` deployment using the :mc-cmd:`mc admin policy set` command.
-
-List Available Policies
-~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/play-alias-available.rst
-   :start-after: myminio-alias
-   :end-before: end-myminio-alias
-
-The following :mc-cmd:`mc admin policy list` command lists the available
-policies on the ``myminio`` MinIO deployment:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc admin policy list myminio
-
-The command returns output that resembles the following:
-
-.. code-block:: shell
-
-   readwrite
-   writeonly
-
-To retrieve information on a specific policy, use the 
-:mc-cmd:`mc admin policy info` command:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc admin policy info myminio writeonly
-
-The command returns output that resembles the following:
-
-.. code-block:: javascript
-
-   {
-      "Version": "2012-10-17",
-      "Statement": [
-         {
-            "Effect": "Allow",
-            "Action": [
-               "s3:PutObject"
-            ],
-            "Resource": [
-               "arn:aws:s3:::*"
-            ]
-         }
-      ]
-   }
-
-Remove a Policy
-~~~~~~~~~~~~~~~
-
-.. include:: /includes/play-alias-available.rst
-   :start-after: myminio-alias
-   :end-before: end-myminio-alias
-
-The following :mc-cmd:`mc admin policy remove` command removes a policy
-on the ``myminio`` MinIO deployment:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc admin policy remove myminio listbucketsonly
-
-
-Apply a Policy to a User or Group
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/play-alias-available.rst
-   :start-after: myminio-alias
-   :end-before: end-myminio-alias
-
-- Use the :mc-cmd:`mc admin user list` command to return a list of
-  users on the target MinIO deployment. 
-
-- Use the :mc-cmd:`mc admin group list` command to return a list of
-  users on the target MinIO deployment.
-
-The following :mc-cmd:`mc admin policy set` command associates the 
-``listbucketsonly`` policy to a user on the ``myminio`` MinIO deployment. 
-Replace the ``<USER>`` with the name of a user that exists on the deployment.
-
-.. code-block:: shell
-   :class: copyable
-
-   mc admin policy set myminio listbucketsonly user=<USER>
-
-The following :mc-cmd:`mc admin policy set` command associates the 
-``listbucketsonly`` policy to a group on the ``myminio`` MinIO deployment. 
-Replace the ``<GROUP>`` with the name of a user that exists on the deployment.
-
-.. code-block:: shell
-   :class: copyable
-
-   mc admin policy set myminio listbucketsonly group=<GROUP>
-
-Syntax
-------
-
-.. mc-cmd:: add
-   :fullpath:
-
-   Creates a new policy on the target MinIO
-   deployment. The command has the following syntax:
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc admin policy add TARGET POLICYNAME POLICYPATH
-
-   The :mc-cmd:`mc admin policy add` command accepts the following arguments:
-
-   .. mc-cmd:: TARGET
-
-      The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment on which
-      to add the new policy.
-
-   .. mc-cmd:: POLICYNAME
-
-      The name of the policy to add. 
-      
-      Specifying the name of an existing policy overwrites that policy on the
-      :mc-cmd:`~mc admin policy add TARGET` MinIO deployment.
-
-   .. mc-cmd:: POLICYPATH
-
-      The file path to the policy to add. The file *must* be a JSON-formatted
-      file with :iam-docs:`IAM-compatible syntax <reference_policies.html>`. 
-
-.. mc-cmd:: list
-   :fullpath:
-
-   Lists all policies on the target MinIO deployment. The command
-   has the following syntax:
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc admin policy list TARGET
-
-   For example, the following command lists all policies on the 
-   ``myminio`` MinIO deployment:
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc admin policy list play
-
-   The :mc-cmd:`mc admin policy list` command accepts the following arguments:
-
-   .. mc-cmd:: TARGET
-
-      The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment from which
-      the command lists the available policies.
-
-.. mc-cmd:: info
-   :fullpath:
-
-   Returns the specified policy in JSON format if it exists 
-   on the target MinIO deployment. The command has the following syntax:
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc admin policy info TARGET POLICYNAME
-
-   :mc-cmd:`mc admin policy info` accepts the following arguments:
-
-   .. mc-cmd:: TARGET
-
-      The :mc-cmd:`alias <mc alias>` of a configured MinIO deployment from
-      which the command returns information on the specified policy.
-
-   .. mc-cmd:: POLICYNAME
-
-      The name of the policy whose details the command returns.
-
-.. mc-cmd:: set
-   :fullpath:
-
-   Applies an existing policy to a user or group on the 
-   target MinIO deployment. :mc-cmd:`mc admin policy set` overwrites the
-   existing policy associated to the user or group.
+For complete documentation on MinIO PBAC, including policy document JSON structure and syntax, see :ref:`minio-policy`.
+
+Subcommands
+-----------
+
+:mc:`mc admin policy` includes the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Subcommand
+     - Description
+
+   * - :mc:`~mc admin policy attach`
+     - .. include:: /reference/minio-mc-admin/mc-admin-policy-attach.rst
+          :start-after: start-mc-admin-policy-attach-desc
+          :end-before: end-mc-admin-policy-attach-desc
+
+   * - :mc:`~mc admin policy create`
+     - .. include:: /reference/minio-mc-admin/mc-admin-policy-create.rst
+          :start-after: start-mc-admin-policy-create-desc
+          :end-before: end-mc-admin-policy-create-desc
+
+   * - :mc:`~mc admin policy detach`
+     - .. include:: /reference/minio-mc-admin/mc-admin-policy-detach.rst
+          :start-after: start-mc-admin-policy-detach-desc
+          :end-before: end-mc-admin-policy-detach-desc
+
+   * - :mc:`~mc admin policy entities`
+     - .. include:: /reference/minio-mc-admin/mc-admin-policy-entities.rst
+          :start-after: start-mc-admin-policy-entities-desc
+          :end-before: end-mc-admin-policy-entities-desc
+
+   * - :mc:`~mc admin policy info`
+     - .. include:: /reference/minio-mc-admin/mc-admin-policy-info.rst
+          :start-after: start-mc-admin-policy-info-desc
+          :end-before: end-mc-admin-policy-info-desc
+
+   * - :mc:`~mc admin policy list`
+     - .. include:: /reference/minio-mc-admin/mc-admin-policy-list.rst
+          :start-after: start-mc-admin-policy-list-desc
+          :end-before: end-mc-admin-policy-list-desc
+
+   * - :mc:`~mc admin policy remove`
+     - .. include:: /reference/minio-mc-admin/mc-admin-policy-remove.rst
+          :start-after: start-mc-admin-policy-remove-desc
+          :end-before: end-mc-admin-policy-remove-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
    
-   The command has the following syntax:
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc admin policy set TARGET POLICYNAME[,POLICYNAME,...] [ user=USERNAME | group=GROUPNAME ]
-
-   The command accepts the following arguments:
-
-   .. mc-cmd:: TARGET
-
-      The :mc:`alias <mc alias>` of a configured MinIO deployment on which
-      the command associates the :mc-cmd:`~mc admin policy set POLICYNAME`
-      to the :mc-cmd:`~mc admin policy set user` or
-      :mc-cmd:`~mc admin policy set group`.
-
-   .. mc-cmd:: POLICYNAME
-
-      The name of the policy which the command associates to the specified
-      :mc-cmd:`~mc admin policy set user` or 
-      :mc-cmd:`~mc admin policy set group`. Specify multiple policies
-      as a comma-separated list.
-
-      MinIO deployments include the following :ref:`built-in policies
-      <minio-policy-built-in>` policies by default:
-
-      - :userpolicy:`readonly` 
-      - :userpolicy:`readwrite`
-      - :userpolicy:`diagnostics`
-      - :userpolicy:`writeonly`
-
-   .. mc-cmd:: user
-
-      The name of the user to which the command associates the
-      :mc-cmd:`~mc admin policy set POLICYNAME`. 
-
-      Mutually exclusive with :mc-cmd:`~mc admin policy set group`
-
-   .. mc-cmd:: group
-
-      The name of the group to which the command associates the 
-      :mc-cmd:`~mc admin policy set POLICYNAME`. All users with membership in
-      the group inherit the policies associated to the group.
-
-      Mutually exclusive with :mc-cmd:`~mc admin policy set user`
-
-.. mc-cmd:: remove
-   :fullpath:
-
-   This command removes an existing policy from the target MinIO deployment. The
-   command has the following syntax:
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc admin policy remove TARGET POLICYNAME
-
-   The command accepts the following arguments:
-
-   .. mc-cmd:: TARGET
-
-      The :mc:`alias <mc alias>` of a configured MinIO deployment on which
-      the command removes the :mc-cmd:`~mc admin policy remove POLICYNAME`.
-
-   .. mc-cmd:: POLICYNAME
-
-      The name of the policy which the command removes from the
-      :mc-cmd:`~mc admin policy remove TARGET` deployment.
+   /reference/minio-mc-admin/mc-admin-policy-attach
+   /reference/minio-mc-admin/mc-admin-policy-create
+   /reference/minio-mc-admin/mc-admin-policy-detach
+   /reference/minio-mc-admin/mc-admin-policy-entities
+   /reference/minio-mc-admin/mc-admin-policy-info
+   /reference/minio-mc-admin/mc-admin-policy-list
+   /reference/minio-mc-admin/mc-admin-policy-remove

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -64,6 +64,22 @@ Table of Deprecated Admin Commands
      - Replacement Command
      - Version of Change
 
+   * - ``mc admin policy add``
+     - :mc-cmd:`mc admin policy create`
+     - mc RELEASE.2023-03-20T17-17-53Z 
+
+   * - ``mc admin policy set``
+     - :mc-cmd:`mc admin policy attach`
+     - mc RELEASE.2023-03-20T17-17-53Z 
+
+   * - ``mc admin policy unset``
+     - :mc-cmd:`mc admin policy detach`
+     - mc RELEASE.2023-03-20T17-17-53Z 
+
+   * - ``mc admin policy update``
+     - :mc-cmd:`mc admin policy attach` or :mc-cmd:`mc admin policy detach`
+     - mc RELEASE.2023-03-20T17-17-53Z 
+
    * - ``mc admin replicate edit``
      - :mc:`mc admin replicate update`
      - mc RELEASE.2023-01-11T03-14-16Z
@@ -107,6 +123,7 @@ Table of Deprecated Admin Commands
    * - ``mc admin bucket quota``
      - :mc-cmd:`mc quota clear`, :mc-cmd:`mc quota info`, :mc-cmd:`mc quota set`
      - mc RELEASE.2022-12-13T00-23-28Z
+
 
 .. toctree::
    :titlesonly:

--- a/source/reference/minio-mc/mc-batch-cancel.rst
+++ b/source/reference/minio-mc/mc-batch-cancel.rst
@@ -1,0 +1,92 @@
+.. _minio-mc-batch-cancel:
+
+===================
+``mc batch cancel``
+===================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc batch cancel
+
+.. versionadded:: mc RELEASE.2023-03-20T17-17-53Z
+
+Syntax
+------
+
+.. start-mc-batch-cancel-desc
+
+The :mc:`mc batch cancel` stops an ongoing batch job.
+
+.. end-mc-batch-cancel-desc
+
+You must specify the job ID.
+To find the job ID, use :mc-cmd:`mc batch list`.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command outputs the job definition for the job identified as ``KwSysDpxcBU9FNhGkn2dCf``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc batch cancel myminio KwSysDpxcBU9FNhGkn2dCf
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] batch cancel TARGET JOBID
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+   
+   The :ref:`alias <alias>` for the MinIO deployment on which the job is currently running. 
+
+.. mc-cmd:: JOBID
+   :required:
+
+   The unique identifier of the batch job to cancel.
+   To find the ID of a job, use :mc:`mc batch list`.
+   
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Example
+-------
+
+Cancel an ongoing batch job
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command cancels the job with ID ``KwSysDpxcBU9FNhGkn2dCf`` on the deployment at alias ``myminio``:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc batch cancel myminio KwSysDpxcBU9FNhGkn2dCf
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-batch.rst
+++ b/source/reference/minio-mc/mc-batch.rst
@@ -11,6 +11,11 @@
 .. mc:: mc batch
 
 
+.. versionadded:: mc RELEASE.2023-03-20T17-17-53Z
+
+   Added the ability to cancel jobs with the :mc:`mc batch cancel` command.
+
+
 Description
 -----------
 
@@ -33,11 +38,16 @@ Subcommands
    * - Subcommand
      - Description
 
+   * - :mc:`~mc batch cancel`
+     - .. include:: /reference/minio-mc/mc-batch-cancel.rst
+          :start-after: start-mc-batch-cancel-desc
+          :end-before: end-mc-batch-cancel-desc
+
    * - :mc:`~mc batch describe`
      - .. include:: /reference/minio-mc/mc-batch-describe.rst
           :start-after: start-mc-batch-describe-desc
           :end-before: end-mc-batch-describe-desc
-
+   
    * - :mc:`~mc batch generate`
      - .. include:: /reference/minio-mc/mc-batch-generate.rst
           :start-after: start-mc-batch-generate-desc
@@ -62,6 +72,7 @@ Subcommands
    :titlesonly:
    :hidden:
    
+   /reference/minio-mc/mc-batch-cancel
    /reference/minio-mc/mc-batch-describe
    /reference/minio-mc/mc-batch-generate
    /reference/minio-mc/mc-batch-list

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -52,9 +52,9 @@ The :mc:`mc mirror` command synchronizes content to MinIO deployment, similar to
          mc [GLOBALFLAGS] mirror                           \
                           [--attr "string"]                \
                           [--disable-multipart]            \
+                          [--dry-run]                      \
                           [--encrypt-key "string"]         \
                           [--exclude "string"]             \
-                          [--fake]                         \
                           [--md5]                          \
                           [--monitoring-address "string"]  \
                           [--newer-than "string"]          \
@@ -141,10 +141,11 @@ Parameters
 
    Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified object name pattern.
 
-.. mc-cmd:: --fake
+.. mc-cmd:: --dry-run
    
 
-   Perform a fake mirror operation. Use this operation to perform validate that the :mc:`mc mirror` operation will only mirror the desired objects or buckets.
+   Perform a mock mirror operation. 
+   Use this operation to test that the :mc:`mc mirror` operation will only mirror the desired objects or buckets.
 
 .. mc-cmd:: md5
    

--- a/source/reference/minio-mc/mc-replicate-status.rst
+++ b/source/reference/minio-mc/mc-replicate-status.rst
@@ -131,3 +131,19 @@ Use :mc:`mc replicate status` to show bucket replication status:
 - Replace :mc-cmd:`ALIAS <mc replicate status ALIAS>` with the :mc:`alias <mc alias>` of the MinIO deployment.
 
 - Replace :mc-cmd:`PATH <mc replicate status ALIAS>` with the path to the bucket or bucket prefix.
+
+Behavior
+--------
+
+Removed and Re-added ARNs
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionchanged:: mc RELEASE.2023-03-20T17-17-53Z
+
+ARNs no longer part of replication configurations do not display with the standard output of this command.
+
+To list all ARNs, including ARNs no longer part of the replication, use the ``--json`` flag.
+The ``json`` output continues to show data replicated under old ARNs.
+This may be valuable if an ARN was removed and re-added for the same bucket.
+
+New ARNs do **not** cause re-replication of previously synced objects.

--- a/source/reference/minio-mc/mc-rm.rst
+++ b/source/reference/minio-mc/mc-rm.rst
@@ -32,7 +32,7 @@ results to the ``rm`` commandline tool.
 .. important::
 
    :mc:`mc rm` supports removing multiple objects *or* files in a single
-   command. Consider using the :mc-cmd:`~mc rm --fake`
+   command. Consider using the :mc-cmd:`~mc rm --dry-run`
    option to validate that the operation targets only the desired objects/files.
 
 .. tab-set::
@@ -57,7 +57,7 @@ results to the ``rm`` commandline tool.
          mc [GLOBALFLAGS] rm  \
                           [--bypass]               \
                           [--dangerous]            \
-                          [--fake]                 \
+                          [--dry-run]              \
                           [--force]*               \
                           [--incomplete]           \
                           [--newer-than "string"]  \
@@ -82,8 +82,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
-
-   *Required* The :ref:`alias <alias>` of a MinIO deployment and the full path to
+   :required:
+   
+   The :ref:`alias <alias>` of a MinIO deployment and the full path to
    the object to remove. For example:
 
    .. code-block:: shell
@@ -108,7 +109,7 @@ Parameters
       mc rm --recursive --force play/mybucket/myprefix/
 
    Consider first running the command with the
-   :mc-cmd:`~mc rm --fake` flag to validate the scope of the
+   :mc-cmd:`~mc rm --dry-run` flag to validate the scope of the
    recursive delete operation.
 
    For removing a file from a local filesystem, specify the full path to that
@@ -119,22 +120,22 @@ Parameters
       mc rm ~/data/myoldobject.txt
 
 .. mc-cmd:: --bypass
+   :optional:
    
-   
-   *Optional* Allows removing an object held under 
+   Allows removing an object held under 
    :ref:`GOVERNANCE <minio-object-locking-governance>` object locking. 
 
 .. mc-cmd:: --dangerous
+   :optional:
    
-   
-   *Optional* Allows running :mc:`mc rm` when the :mc-cmd:`~mc rm ALIAS`
+   Allows running :mc:`mc rm` when the :mc-cmd:`~mc rm ALIAS`
    specifies the root (all buckets) on the MinIO deployment.
 
    When combined with :mc-cmd:`~mc rm --versions`, this flag
    directs :mc:`mc rm` to permanently remove all objects *and* versions from
    the ``ALIAS`` target.
 
-   Consider first running the command with the :mc-cmd:`~mc rm --fake` to
+   Consider first running the command with the :mc-cmd:`~mc rm --dry-run` to
    validate the scope of the site-wide delete operation.
 
    .. warning::
@@ -144,10 +145,16 @@ Parameters
       possible due diligence in ensuring the command applies to only the desired
       ``ALIAS`` targets prior to execution.
 
-.. mc-cmd:: --encrypt-key
-   
+.. mc-cmd:: --dry-run
+   :optional:
 
-   *Optional* The encryption key to use for performing Server-Side Encryption
+   Outputs the results of a command without actually removing any files.
+   Use this flag to test that your command configuration removes only the objects you wish to remove.
+
+.. mc-cmd:: --encrypt-key
+   :optional:
+
+   The encryption key to use for performing Server-Side Encryption
    with Client Keys (SSE-C). Specify comma separated key-value pairs as
    ``KEY=VALUE,...``.
    
@@ -163,61 +170,53 @@ Parameters
    environment variable for populating the list of encryption key-value
    pairs as an alternative to specifying them on the command line.
 
-.. mc-cmd:: --fake
-   
-
-   *Optional* Perform a fake remove operation. Use this operation to perform 
-   validate that the :mc:`mc rm` operation will only
-   remove the desired objects or buckets.
-
 .. mc-cmd:: --force
-   
+   :optional:
 
-   *Optional* Allows running :mc:`mc rm` with any of the following arguments:
+   Allows running :mc:`mc rm` with any of the following arguments:
    
    - :mc-cmd:`~mc rm --recursive`
    - :mc-cmd:`~mc rm --versions`
    - :mc-cmd:`~mc rm --stdin`
 
 .. mc-cmd:: --incomplete, I
-   
+   :optional:
 
-   *Optional* Remove incomplete uploads for the specified object.
+   Remove incomplete uploads for the specified object.
 
    If any :mc-cmd:`~mc rm ALIAS` specifies a bucket, 
    you **must** also specify :mc-cmd:`~mc rm --recursive`
    and :mc-cmd:`~mc rm --force`.
 
 .. mc-cmd:: --newer-than
-   
+   :optional:
 
-   *Optional* Remove object(s) newer than the specified number of days. Specify
+   Remove object(s) newer than the specified number of days. Specify
    a string in ``#d#hh#mm#ss`` format. For example: ``--newer-than 1d2hh3mm4ss``
 
    Defaults to ``0`` (all objects).
 
 .. mc-cmd:: --non-current
-   
+   :optional:
 
-   *Optional* Removes all :ref:`non-current <minio-bucket-versioning-delete>`
+   Removes all :ref:`non-current <minio-bucket-versioning-delete>`
    object versions from the specified :mc-cmd:`~mc rm ALIAS`.
 
    This option has no effect on buckets without 
    :ref:`versioning <minio-bucket-versioning>` enabled.
 
 .. mc-cmd:: --older-than
-   
+   :optional:
 
-   *Optional* Remove object(s) older than the specified time limit. Specify a
+   Remove object(s) older than the specified time limit. Specify a
    string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``.
-
       
    Defaults to ``0`` (all objects).
 
 .. mc-cmd:: --recursive, r
+   :optional:
    
-   
-   *Optional* Recursively remove the contents of each :mc-cmd:`~mc rm ALIAS`
+   Recursively remove the contents of each :mc-cmd:`~mc rm ALIAS`
    bucket or bucket prefix.
 
    If specifying :mc-cmd:`~mc rm --recursive`, you **must** also
@@ -229,7 +228,7 @@ Parameters
    all objects *and* object versions from the bucket.
 
    Consider first running the command with the 
-   :mc-cmd:`~mc rm --fake` flag to validate the scope of the
+   :mc-cmd:`~mc rm --dry-run` flag to validate the scope of the
    recursive delete operation.
 
    Mutually exclusive with :mc-cmd:`mc rm --version-id`
@@ -242,9 +241,9 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: --stdin
-   
+   :optional:   
 
-   *Optional* Read object names or buckets from ``STDIN``.
+   Read object names or buckets from ``STDIN``.
 
 .. mc-cmd:: --versions
    :optional:   
@@ -258,7 +257,7 @@ Parameters
    versions which existed at a specific point in time.
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
@@ -403,6 +402,10 @@ object.
 - To remove all non-current versions of an object from a bucket, use
   :mc-cmd:`mc rm --non-current`
 
+.. versionchanged:: mc RELEASE.2023-03-20T17-17-53Z
+
+   The output shows the modification time of versioned files.
+   When using ``--dry-run``, this can be helpful to determine that you select the correct object(s) for removal.
 
 S3 Compatibility
 ~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-support.rst
+++ b/source/reference/minio-mc/mc-support.rst
@@ -24,6 +24,8 @@ You can also upload generated health reports for further analysis by MinIO engin
 .. important::
 
    The ``mc support`` commands require an active |SUBNET| registration.
+   
+   :mc-cmd:`mc support proxy set` and :mc-cmd:`mc support proxy remove` are exceptions, as you may need to set up a proxy to complete the deployment registration.
 
 
 Subcommands


### PR DESCRIPTION
- Adds note that `mc support proxy set|remove` no longer require registration
- Adds info about stale ARNs for `mc replicate status` command
- Additional information for --dry-run flag in `mc rm`
- Thoroughly updates and restructures `mc admin policy` commands
- Adds new `mc batch cancel` command
- Updates deprecated commands for newly deprecated mc admin policy functions
- Fixes toctree on mc admin page to allow for mc admin policy subcommand nesting

Closes #766

Other fixes not part of the release:
- Updates `--fake` flag on `mc rm` to `--dry-run`
- Updates `--fake` flag on `mc mirror` to `--dry-run`