### PR TITLE
Correcting mc admin policy command links

### DIFF
--- a/source/administration/identity-access-management.rst
+++ b/source/administration/identity-access-management.rst
@@ -72,7 +72,7 @@ assigning a policy to a user or group depends on the configured
 
 MinIO deployments using the :ref:`MinIO Internal IDP <minio-internal-idp>`
 require explicitly associating a user to a policy or policies using the
-:mc-cmd:`mc admin policy set`  command. A user can also inherit the policies
+:mc-cmd:`mc admin policy attach` command. A user can also inherit the policies
 attached to the :ref:`groups <minio-groups>` in which they have membership.
 
 By default, MinIO *denies* access to actions or resources not explicitly allowed

--- a/source/administration/identity-access-management/minio-user-management.rst
+++ b/source/administration/identity-access-management/minio-user-management.rst
@@ -142,7 +142,7 @@ Specify a unique, random, and long string for both the ``ACCESSKEY`` and
 ``SECRETKEY``. Your organization may have specific internal or regulatory
 requirements around generating values for use with access or secret keys. 
 
-After creating the user, use :mc-cmd:`mc admin policy set` to associate a
+After creating the user, use :mc-cmd:`mc admin policy attach` to associate a
 :ref:`MinIO Policy Based Access Control <minio-policy>` to the new user. 
 The following command assigns the built-in :userpolicy:`readwrite` policy:
 

--- a/source/administration/identity-access-management/policy-based-access-control.rst
+++ b/source/administration/identity-access-management/policy-based-access-control.rst
@@ -97,7 +97,7 @@ MinIO provides the following built-in policies for assigning to
    location without requiring any listing. 
    Equivalent to the :policy-action:`s3:PutObject` action.
 
-Use :mc-cmd:`mc admin policy set` to associate a policy to a 
+Use :mc-cmd:`mc admin policy attach` to associate a policy to a 
 user or group on a MinIO deployment.
 
 For example, consider the following table of users. Each user is assigned

--- a/source/operations/external-iam.rst
+++ b/source/operations/external-iam.rst
@@ -176,7 +176,7 @@ MinIO uses :ref:`Policy Based Access Control (PBAC) <minio-access-management>` t
 When using an Active Directory/LDAP server for identity management (authentication), MinIO maintains control over access (authorization) through PBAC. 
 
 When a user successfully authenticates to MinIO using their AD/LDAP credentials, MinIO searches for all :ref:`policies <minio-policy>` which are explicitly associated to that user's Distinguished Name (DN). 
-Specifically, the policy must be assigned to a user with a matching DN using the :mc-cmd:`mc admin policy set` command. 
+Specifically, the policy must be assigned to a user with a matching DN using the :mc-cmd:`mc admin policy attach` command. 
 
 MinIO also supports querying for the user's AD/LDAP group membership. 
 MinIO attempts to match existing policies to the DN for each of the user's groups. 

--- a/source/reference/minio-mc-admin/mc-admin-group.rst
+++ b/source/reference/minio-mc-admin/mc-admin-group.rst
@@ -46,7 +46,7 @@ includes their explicitly assigned policies *and* any policies inherited
 via group membership.
 
 Newly created groups have *no* policies by default. To configure a group's
-assigned policies, use the :mc-cmd:`mc admin policy set` command.
+assigned policies, use the :mc-cmd:`mc admin policy attach` command.
 
 For more information on MinIO users and groups, see
 :ref:`minio-users` and :ref:`minio-groups`. For 

--- a/source/reference/minio-mc-admin/mc-admin-user.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user.rst
@@ -45,8 +45,7 @@ Newly created users have *no* policies by default and therefore cannot perform
 any operations on the MinIO deployment. To configure a user's assigned policies,
 you can do either or both of the following:
 
-- Use :mc-cmd:`mc admin policy set` to associate one or more policies to
-  the user.
+- Use :mc-cmd:`mc admin policy attach` to associate one or more policies to the user.
 
 - Use :mc-cmd:`mc admin group add` to associate the user to the group. Users
   inherit any policies assigned to the group.

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -379,8 +379,8 @@ See :mc:`mc admin user` and :mc:`mc admin policy` for more complete documentatio
         The ``"arn:aws:s3:::*`` resource applies the replication permissions to *any* bucket on the source deployment. 
         You can restrict the user policy to specific buckets as-needed.
 
-      Use the :mc-cmd:`mc admin policy add` to add this policy to each deployment acting as a replication source. 
-      Use :mc-cmd:`mc admin user add` to create a user on the deployment and :mc-cmd:`mc admin policy set` to associate the policy to that new user.
+      Use the :mc-cmd:`mc admin policy create` to add this policy to each deployment acting as a replication source. 
+      Use :mc-cmd:`mc admin user add` to create a user on the deployment and :mc-cmd:`mc admin policy attach` to associate the policy to that new user.
 
    .. tab-item:: Replication Remote User
 
@@ -396,8 +396,8 @@ See :mc:`mc admin user` and :mc:`mc admin policy` for more complete documentatio
       - The ``"EnableReplicatingDataIntoBucket"`` statement grants permission for a remote target to synchronize data into *any* bucket in the MinIO deployment. 
         To restrict the policy to specific buckets, specify those buckets as an element in the ``Resource`` array similar to ``"arn:aws:s3:::bucketName/*"``.
 
-      Use the :mc-cmd:`mc admin policy add` to add this policy to each deployment acting as a replication target. 
-      Use :mc-cmd:`mc admin user add` to create a user on the deployment and :mc-cmd:`mc admin policy set` to associate the policy to that new user.
+      Use the :mc-cmd:`mc admin policy create` to add this policy to each deployment acting as a replication target. 
+      Use :mc-cmd:`mc admin user add` to create a user on the deployment and :mc-cmd:`mc admin policy attach` to associate the policy to that new user.
 
 Replication of Existing Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-replicate-update.rst
+++ b/source/reference/minio-mc/mc-replicate-update.rst
@@ -388,9 +388,9 @@ See :mc:`mc admin user` and :mc:`mc admin policy` for more complete documentatio
         source deployment. You can restrict the user policy to specific buckets
         as-needed.
 
-      Use the :mc-cmd:`mc admin policy add` to add this policy to each
+      Use the :mc-cmd:`mc admin policy create` to add this policy to each
       deployment acting as a replication source. Use :mc-cmd:`mc admin user add`
-      to create a user on the deployment and :mc-cmd:`mc admin policy set`
+      to create a user on the deployment and :mc-cmd:`mc admin policy attach`
       to associate the policy to that new user.
 
    .. tab-item:: Replication Remote User
@@ -415,9 +415,9 @@ See :mc:`mc admin user` and :mc:`mc admin policy` for more complete documentatio
         buckets as an element in the ``Resource`` array similar to 
         ``"arn:aws:s3:::bucketName/*"``.
 
-      Use the :mc-cmd:`mc admin policy add` to add this policy to each
+      Use the :mc-cmd:`mc admin policy create` to add this policy to each
       deployment acting as a replication target. Use :mc-cmd:`mc admin user add`
-      to create a user on the deployment and :mc-cmd:`mc admin policy set`
+      to create a user on the deployment and :mc-cmd:`mc admin policy attach`
       to associate the policy to that new user.
 
 S3 Compatibility


### PR DESCRIPTION
Missed some references to deprecated commands during an mc release doc update (PR #799).
This fixes those references to the new commands.