### PR TITLE
Add minio_bucket_objects_version_distribution to metrics list

### DIFF
--- a/source/operations/monitoring/metrics-and-alerts.rst
+++ b/source/operations/monitoring/metrics-and-alerts.rst
@@ -87,6 +87,11 @@ Object and Bucket Metrics
    Distribution of object sizes in a given bucket.
    You can identify the bucket using the ``{ bucket="STRING" }`` label.
 
+.. metric:: minio_bucket_objects_version_distribution
+
+   Distribution of number of versions per object in a given bucket.
+   You can identify the bucket using the ``{ bucket="STRING" }`` label.
+
 .. metric:: minio_bucket_usage_object_total
 
    Total number of objects in a given bucket.


### PR DESCRIPTION
Add a new metric to the list of object and bucket metrics. `minio_bucket_objects_version_distribution`, similar to the existing `minio_bucket_objects_size_distribution`, is a histogram of object version counts. (As in: "How many objects in this bucket have between 10 and 100 versions?")

Adding the new one following the established pattern, more comprehensive info about each metric is a future task.

Staged:
http://192.241.195.202:9000/staging/DOCS-756/linux/html/operations/monitoring/metrics-and-alerts.html#object-and-bucket-metrics

Fixes https://github.com/minio/docs/issues/756