### PR TITLE
Add changes for MinIO RELEASE.2023-03-20T20-16-18Z.

### DIFF
--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -62,6 +62,11 @@ Administrators typically control the creation and configuration of buckets.
 Client applications can then use :ref:`S3-compatible SDKs <minio-drivers>` to create, list, retrieve, and delete objects on the MinIO deployment.
 Clients therefore drive the overall hierarchy of data within a given bucket or prefix, where Administrators can exercise control using :ref:`policies <minio-policy>` to grant or deny access to an action or resource.
 
+.. cond:: windows
+
+   Unlike filenames on a Windows system, object names in MinIO cannot have a ``\`` character.
+   Use ``/`` as a delimiter in object names to have MinIO automatically create a folder structure using :term:`prefixes`.
+
 MinIO has no hard :ref:`thresholds <minio-server-limits>` on the number of buckets, objects, or prefixes on a given deployment.
 The relative performance of the hardware and networking underlying the MinIO deployment may create a practical limit to the number of objects in a given prefix or bucket.
 Specifically, hardware using slower drives or network infrastructures tend to exhibit poor performance in buckets or prefixes with a flat hierarchy of objects.

--- a/source/operations/external-iam/configure-ad-ldap-external-identity-management.rst
+++ b/source/operations/external-iam/configure-ad-ldap-external-identity-management.rst
@@ -13,7 +13,8 @@ Configure MinIO for Authentication using Active Directory / LDAP
 Overview
 --------
 
-MinIO supports configuring a single Active Directory / LDAP Connect for external management of user identities. 
+MinIO supports configuring a single Active Directory / LDAP Connect for external management of user identities.
+
 The procedure on this page provides instructions for:
 
 .. cond:: k8s
@@ -265,3 +266,14 @@ An AD/LDAP user with no assigned policy *and* with membership in groups with no 
    MinIO.
 
    See the :ref:`minio-sts-assumerolewithldapidentity` for reference documentation.
+
+
+Disable a Configured Active Directory / LDAP Connection
+-------------------------------------------------------
+
+.. versionadded:: RELEASE.2023-03-20T20-16-18Z
+
+You can enable and disable the configured AD/LDAP connection as needed.
+
+Use :mc-cmd:`mc admin idp ldap disable` to deactivate a configured connection.
+Use :mc-cmd:`mc admin idp ldap enable` to activate a previously configured connection.

--- a/source/operations/install-deploy-manage/decommission-server-pool.rst
+++ b/source/operations/install-deploy-manage/decommission-server-pool.rst
@@ -186,13 +186,10 @@ Decommissioning a Server with Tiering Enabled
 
 .. versionchanged:: RELEASE.2023-03-20T20-16-18Z
 
-For deployments with tiering enabled and active in one or more buckets, decommissioning proceeds as expected.
-Objects subject to tiering rules move to an active pool as expected.
+For deployments with tiering enabled and active, decommissioning moves the object references to a new active pool.
+Applications can continue issuing GET requests against those objects where MinIO handles transparently retrieving them from the remote tier.
 
-.. note:: 
-
-   For older versions, active tiering prevents decommissioning from starting. 
-   Upgrade to RELEASE.2023-03-20T20-16-18Z or later to decommission pools where tiering is active.
+In older MinIO versions, tiering configurations prevent decommissioning. 
 
 .. _minio-decommissioning-server-pool:
 

--- a/source/operations/install-deploy-manage/decommission-server-pool.rst
+++ b/source/operations/install-deploy-manage/decommission-server-pool.rst
@@ -181,6 +181,19 @@ If the decommission fails, customers should open a |SUBNET| issue for further as
 Community users without a SUBNET subscription can retry the decommission process or seek additional support through the `MinIO Community Slack <https://slack.min.io/>`__.
 MinIO provides Community Support at best-effort only and provides no :abbr:`SLA <Service Level Agreement>` around responsiveness.
 
+Decommissioning a Server with Tiering Enabled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionchanged:: RELEASE.2023-03-20T20-16-18Z
+
+For deployments with tiering enabled and active in one or more buckets, decommissioning proceeds as expected.
+Objects subject to tiering rules move to an active pool as expected.
+
+.. note:: 
+
+   For older versions, active tiering prevents decommissioning from starting. 
+   Upgrade to RELEASE.2023-03-20T20-16-18Z or later to decommission pools where tiering is active.
+
 .. _minio-decommissioning-server-pool:
 
 Decommission a Server Pool


### PR DESCRIPTION
Closes #767

- Adds behavior note about decommissioning pools with tiering enabled
- Adds info about enabling/disabling LDAP IDP connection
- Adds a Windows-only note in the Object Management about not using the \ character

Staged:
- http://192.241.195.202:9000/staging/minio-2023-03-20/index.html
- Windows at: http://192.241.195.202:9000/staging/minio-2023-03-20/windows/administration/object-management.html#object-organization-and-planning