### PR TITLE
Fixed MINIO_ROOT_PASSWORD to be secret key

### DIFF
--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -240,7 +240,7 @@ Root Credentials
 
 .. envvar:: MINIO_ROOT_PASSWORD
 
-   The access key for the :ref:`root <minio-users-root>` user.
+   The secret key for the :ref:`root <minio-users-root>` user.
 
    .. warning::
 


### PR DESCRIPTION
I’ve fixed a little typo that could save some minutes to users:

The MINIO_ROOT_PASSWORD is the secret key, not the access key.