### PR TITLE
DOCS-784: Fix Kafka TLS Client Auth reference

### DIFF
--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -846,7 +846,7 @@ MinIO supports the following mechanisms:
 .. start-minio-notify-kafka-tls-client-auth
 
 Specify the client authentication type of the Kafka broker(s).
-The following table lists the supported values and their mapping:
+The following table lists the supported values and their mappings
 
 .. list-table::
    :header-rows: 1

--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -845,12 +845,34 @@ MinIO supports the following mechanisms:
 
 .. start-minio-notify-kafka-tls-client-auth
 
-Specify the client authentication policy of the Kafka broker(s). See
-`ClientAuthType <https://golang.org/pkg/crypto/tls/#ClientAuthType>`__ for 
-more information on possible values for this field.
+Specify the client authentication type of the Kafka broker(s).
+The following table lists the supported values and their mapping:
 
-.. https://pkg.go.dev/crypto/tls#ClientAuthType ?
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+   :width: 100%
 
+   * - Value
+     - Authentication Type
+
+   * - 0
+     - ``NoClientCert``
+
+   * - 1
+     - ``RequestClientCert``
+
+   * - 2
+     - ``RequireAnyClientCert``
+
+   * - 3
+     - ``VerifyClientCertIfGiven``
+
+   * - 4
+     - ``RequireAndVerifyClientCert``
+
+
+See `ClientAuthType <https://golang.org/pkg/crypto/tls/#ClientAuthType>`__ for more information on each client auth type.
 .. end-minio-notify-kafka-tls-client-auth
 
 .. start-minio-notify-kafka-sasl-root


### PR DESCRIPTION
Minor fix since apparently Go structs don't work the way I thought they did.

Can stage on request.

Closes #784 