### PR TITLE
Adds notes about expiration output for some mc commands

### DIFF
--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -175,9 +175,8 @@ Optionally, use :ref:`Call Home <minio-troubleshooting-call-home>` to start auto
 Call Home
 ---------
 
-.. versionadded:: 
-   
-   minio RELEASE.2022-11-17T23-20-09Z and mc RELEASE.2022-12-02T23-48-47Z
+.. versionadded:: minio RELEASE.2022-11-17T23-20-09Z
+   and mc RELEASE.2022-12-02T23-48-47Z
 
 MinIO's opt-in Call Home service automates the collection and uploading of diagnostic data or error logs to SUBNET.
 Call Home requires the cluster to have both an active SUBNET registration and reliable access to the internet.
@@ -196,7 +195,7 @@ Making these records automatically available in SUBNET simplifies visibility int
 If you submit an issue for support help from the MinIO engineers, the engineers have immediate access to the errors and/or logs you have uploaded.
 
 Diagnostic Report
-+++++++++++++++++
+~~~~~~~~~~~~~~~~~
 
 The diagnostic report upload happens every 24 hours from the time you enable Call Home.
 If you restart all nodes on the deployment after enabling Call Home, the upload happens every 24 hours from the deployment restart.
@@ -221,7 +220,7 @@ The report includes information such as:
 - MinIO version
 
 Error Logs
-++++++++++
+~~~~~~~~~~
 
 When the MinIO Server encounters an error, it writes it to a log.
 These logs can upload in real time to SUBNET, where you or MinIO engineers can view the errors.

--- a/source/reference/minio-mc-admin/mc-admin-user-sts.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-sts.rst
@@ -42,7 +42,7 @@ The :mc:`mc admin user sts` command has the following subcommands:
      - Description
 
    * - :mc-cmd:`mc admin user sts info`
-     - Retrieves information on the specified STS credential, including the parent user who generated the credentials and it's attached policies.
+     - Retrieves information on the specified STS credential, including the parent user who generated the credentials, attached policies, and expiration.
 
 Syntax
 ------
@@ -50,7 +50,7 @@ Syntax
 .. mc-cmd:: info
    :fullpath:
 
-   Retrieves information on the specified STS credential, such as the parent user who generated the credentials.
+   Retrieves information on the specified STS credential, such as the parent user who generated the credentials, associated policies, and expiration.
 
    .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-user-sts.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-sts.rst
@@ -42,7 +42,7 @@ The :mc:`mc admin user sts` command has the following subcommands:
      - Description
 
    * - :mc-cmd:`mc admin user sts info`
-     - Retrieves information on the specified STS credential, including the parent user who generated the credentials, attached policies, and expiration.
+     - Retrieves information on the specified STS credential, including the parent user who generated the credentials, associated policies, and expiration.
 
 Syntax
 ------

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct.rst
@@ -87,6 +87,8 @@ Syntax
                --policy "/path/to/policy.json"              \
                myminio myuser
 
+         The command returns an output of the access key and secret key for the new account.
+
       .. tab-item:: SYNTAX
 
          The command has the following syntax:
@@ -98,7 +100,7 @@ Syntax
                                         [--access-key]  \
                                         [--secret-key]  \
                                         [--policy]      \
-                                        [--commment]    \
+                                        [--comment]    \
                                         ALIAS           \
                                         USER
 
@@ -224,7 +226,15 @@ Syntax
 .. mc-cmd:: info
    :fullpath:
 
-   Returns a description of a access keys associated to the specified user. The description includes the parent user of the specified access keys, its status, and whether the access keys has an assigned inline policy.
+   Returns a description of a specified access keys. 
+   The description output includes the following details, as available:
+   
+   - Access Key
+   - Parent user of the specified access key
+   - Access key status (``on`` or ``off``)
+   - Policy or policies
+   - Comment
+   - Expiration
 
    .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct.rst
@@ -87,7 +87,7 @@ Syntax
                --policy "/path/to/policy.json"              \
                myminio myuser
 
-         The command returns an output of the access key and secret key for the new account.
+         The command returns the access key and secret key for the new account.
 
       .. tab-item:: SYNTAX
 
@@ -226,7 +226,7 @@ Syntax
 .. mc-cmd:: info
    :fullpath:
 
-   Returns a description of a specified access keys. 
+   Returns a description of the specified access key. 
    The description output includes the following details, as available:
    
    - Access Key


### PR DESCRIPTION
Adds info to `mc admin user svcacct` and `mc admin user sts` about exposing expiration for accounts.

Fixes some build errors from the troubleshooting doc.

Closes #786 