### PR TITLE
Link to systemctl update docs in rpm/deb install instructions

### DIFF
--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -1,10 +1,9 @@
 .. start-install-minio-binary-desc
 
-The following tabs provide examples of installing MinIO onto 64-bit Linux
-operating systems using RPM, DEB, or binary. The RPM and DEB packages
-automatically install MinIO to the necessary system paths and create a
-``systemd`` service file for running MinIO automatically. MinIO strongly
-recommends using RPM or DEB installation routes.
+The following tabs provide examples of installing MinIO onto 64-bit Linux operating systems using RPM, DEB, or binary.
+The RPM and DEB packages automatically install MinIO to the necessary system paths and create a ``minio`` service for ``systemctl``.
+MinIO strongly recommends using the RPM or DEB installation routes.
+To update deployments managed using ``systemctl``, see :ref:`minio-upgrade-systemctl`.
 
 .. tab-set::
 

--- a/source/includes/common-minio-mc.rst
+++ b/source/includes/common-minio-mc.rst
@@ -42,9 +42,10 @@ commands *may* work as documented, any such usage is at your own risk.
 
 - Brackets ``[]`` indicate optional parameters. 
 - Parameters sharing a line are mutually dependent.
-- Parameters seperated using the pipe ``|`` operator are mutually exclusive.
+- Parameters separated using the pipe ``|`` operator are mutually exclusive.
 
 Copy the example to a text editor and modify as-needed before running the
 command in the terminal/shell.
+You may need to use ``sudo`` if your user does not have write permissions for the path where ``mc`` is installed.
 
 .. end-minio-syntax

--- a/source/includes/linux/common-installation.rst
+++ b/source/includes/linux/common-installation.rst
@@ -1,11 +1,9 @@
 .. start-install-minio-binary-desc
 
-The following tabs provide examples of installing MinIO onto 64-bit Linux
-operating systems using RPM, DEB, or binary. The RPM and DEB packages
-automatically install MinIO to the necessary system paths and create a
-``systemd`` service file for running MinIO automatically. MinIO strongly
-recommends using RPM or DEB installation routes. To update deployments
-managed using ``systemd``, see :ref:`minio-upgrade-systemctl`.
+The following tabs provide examples of installing MinIO onto 64-bit Linux operating systems using RPM, DEB, or binary.
+The RPM and DEB packages automatically install MinIO to the necessary system paths and create a ``minio`` service for ``systemctl``.
+MinIO strongly recommends using the RPM or DEB installation routes.
+To update deployments managed using ``systemctl``, see :ref:`minio-upgrade-systemctl`.
 
 .. dropdown:: amd64 (Intel or AMD 64-bit processors)
    :open:

--- a/source/includes/linux/common-installation.rst
+++ b/source/includes/linux/common-installation.rst
@@ -4,8 +4,8 @@ The following tabs provide examples of installing MinIO onto 64-bit Linux
 operating systems using RPM, DEB, or binary. The RPM and DEB packages
 automatically install MinIO to the necessary system paths and create a
 ``systemd`` service file for running MinIO automatically. MinIO strongly
-recommends using RPM or DEB installation routes.
-
+recommends using RPM or DEB installation routes. To update deployments
+managed using ``systemd``, see :ref:`minio-upgrade-systemctl`.
 
 .. dropdown:: amd64 (Intel or AMD 64-bit processors)
    :open:
@@ -274,6 +274,8 @@ group on the system host with the necessary access and permissions.
 
 MinIO publishes additional startup script examples on 
 :minio-git:`github.com/minio/minio-service <minio-service>`.
+
+To update deployments managed using ``systemctl``, see :ref:`minio-upgrade-systemctl`.
 
 .. end-install-minio-systemd-desc
 

--- a/source/includes/linux/deploy-standalone.rst
+++ b/source/includes/linux/deploy-standalone.rst
@@ -1,11 +1,10 @@
 1) Download the MinIO Server
 ----------------------------
 
-The following tabs provide examples of installing MinIO onto 64-bit Linux
-operating systems using RPM, DEB, or binary. The RPM and DEB packages
-automatically install MinIO to the necessary system paths and create a
-``systemd`` service file for running MinIO automatically. MinIO strongly
-recommends using RPM or DEB installation routes.
+The following tabs provide examples of installing MinIO onto 64-bit Linux operating systems using RPM, DEB, or binary.
+The RPM and DEB packages automatically install MinIO to the necessary system paths and create a ``minio`` service for ``systemctl``.
+MinIO strongly recommends using the RPM or DEB installation routes.
+To update deployments managed using ``systemctl``, see :ref:`minio-upgrade-systemctl`.
 
 .. tab-set::
 


### PR DESCRIPTION
The update instructions in the "You are running an older version" banner are not correct for systemd managed deployments (also the process recommended for rpm/deb installs). 

Link to the correct update procedure in the install docs. This is not intended to be comprehensive, just pointers for future-admin who might have forgotten.

Staged:
http://192.241.195.202:9000/staging/deb-upgrades/linux/html/operations/install-deploy-manage/deploy-minio-single-node-single-drive.html#download-the-minio-server
