### PR TITLE
Patching replication docs for version match requirement

### DIFF
--- a/source/administration/bucket-replication.rst
+++ b/source/administration/bucket-replication.rst
@@ -45,7 +45,7 @@ Server-Side Bucket Replication
 ------------------------------
 
 MinIO server-side bucket replication is an automatic bucket-level configuration that synchronizes objects between a source and destination bucket. 
-MinIO server-side replication *requires* the source and destination bucket be two separate MinIO clusters running the same MinIO server version.
+MinIO server-side replication *requires* the source and destination bucket be two separate MinIO clusters running the same MinIO Server version.
 
 For each write operation to the bucket, MinIO checks all configured replication rules for the bucket and applies the matching rule with highest configured priority. 
 MinIO synchronizes new objects *and* object mutations, such as new object versions or changes to object metadata. 

--- a/source/administration/bucket-replication.rst
+++ b/source/administration/bucket-replication.rst
@@ -45,7 +45,7 @@ Server-Side Bucket Replication
 ------------------------------
 
 MinIO server-side bucket replication is an automatic bucket-level configuration that synchronizes objects between a source and destination bucket. 
-MinIO server-side replication *requires* the source and destination bucket be two separate MinIO clusters.
+MinIO server-side replication *requires* the source and destination bucket be two separate MinIO clusters running the same MinIO server version.
 
 For each write operation to the bucket, MinIO checks all configured replication rules for the bucket and applies the matching rule with highest configured priority. 
 MinIO synchronizes new objects *and* object mutations, such as new object versions or changes to object metadata. 

--- a/source/includes/common-replication.rst
+++ b/source/includes/common-replication.rst
@@ -17,7 +17,7 @@ MinIO does *not* support replicating client-side encrypted objects (SSE-C).
 .. start-replication-minio-only
 
 MinIO server-side replication only works between MinIO deployments. 
-Both the source and destination deployments *must* run MinIO server with matching versions. 
+Both the source and destination deployments *must* run MinIO Server with matching versions. 
 
 To configure replication between arbitrary S3-compatible services, use :mc:`mc mirror`.
 

--- a/source/includes/common-replication.rst
+++ b/source/includes/common-replication.rst
@@ -17,7 +17,7 @@ MinIO does *not* support replicating client-side encrypted objects (SSE-C).
 .. start-replication-minio-only
 
 MinIO server-side replication only works between MinIO deployments. 
-Both the source and destination deployments *must* run MinIO. 
+Both the source and destination deployments *must* run MinIO server with matching versions. 
 
 To configure replication between arbitrary S3-compatible services, use :mc:`mc mirror`.
 

--- a/source/operations/data-recovery/recover-after-site-failure.rst
+++ b/source/operations/data-recovery/recover-after-site-failure.rst
@@ -67,7 +67,7 @@ This procedure assumes a *total loss* of one or more peer sites versus replicati
 
    - Do not upload any data or otherwise configure the deployment beyond the stated requirements.
    - Validate that the new MinIO deployment functions normally and has bidirectional connectivity to the other peer sites.
-   - Ensure the new site has the matching server version as the existing peer sites
+   - Ensure the new site matches the server version on the existing peer sites
 
    .. warning::
 

--- a/source/operations/data-recovery/recover-after-site-failure.rst
+++ b/source/operations/data-recovery/recover-after-site-failure.rst
@@ -65,8 +65,9 @@ This procedure assumes a *total loss* of one or more peer sites versus replicati
 
 2. Deploy a new MinIO site following the :ref:`site replication requirements <minio-expand-site-replication>`.
 
-   Do not upload any data or otherwise configure the deployment beyond the stated requirements.
-   Validate that the new MinIO deployment functions normally and has bidirectional connectivity to the other peer sites.
+   - Do not upload any data or otherwise configure the deployment beyond the stated requirements.
+   - Validate that the new MinIO deployment functions normally and has bidirectional connectivity to the other peer sites.
+   - Ensure the new site has the matching server version as the existing peer sites
 
    .. warning::
 

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -109,7 +109,7 @@ All Sites Must use the Same MinIO Server Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 All sites must have a matching and consistent MinIO Server version. 
-Configuring replication between sites with mismatched MinIO servers may result in unexpected or undesired replication behavior.
+Configuring replication between sites with mismatched MinIO Server versions may result in unexpected or undesired replication behavior.
 
 You should also ensure the :mc:`mc` version used to configure replication closely matches the server version.
 

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -105,6 +105,14 @@ All Sites Must Use the Same IDP
 All sites must use the same :ref:`Identity Provider <minio-authentication-and-identity-management>`.
 Site replication supports the included MinIO IDP, OIDC, or LDAP.
 
+All Sites Must use the Same MinIO Server Version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All sites must have a matching and consistent MinIO Server version. 
+Configuring replication between sites with mismatched MinIO servers may result in unexpected or undesired replication behavior.
+
+You should also ensure the :mc:`mc` version used to configure replication closely matches the server version.
+
 Access to the Same Encryption Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Title is description. 

As per internal discussion, server versions need to match between deployments for site or bucket replication.

This change ensures we call that requirement out.