### PR TITLE
Only mc admin update might need sudo

### DIFF
--- a/source/includes/common-minio-mc.rst
+++ b/source/includes/common-minio-mc.rst
@@ -44,8 +44,6 @@ commands *may* work as documented, any such usage is at your own risk.
 - Parameters sharing a line are mutually dependent.
 - Parameters separated using the pipe ``|`` operator are mutually exclusive.
 
-Copy the example to a text editor and modify as-needed before running the
-command in the terminal/shell.
-You may need to use ``sudo`` if your user does not have write permissions for the path where ``mc`` is installed.
+Copy the example to a text editor and modify as-needed before running the command in the terminal/shell.
 
 .. end-minio-syntax

--- a/source/reference/minio-mc-admin/mc-admin-update.rst
+++ b/source/reference/minio-mc-admin/mc-admin-update.rst
@@ -22,6 +22,7 @@ The command also supports using a private mirror server for environments where t
 
 After running the command, a prompt displays to confirm the update.
 Type ``y`` and ``[ENTER]`` to confirm and proceed with the update.
+You may need to use ``sudo`` if your user does not have write permissions for the path where ``mc`` is installed.
 
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only
    :class: note


### PR DESCRIPTION
`sudo` note from https://github.com/minio/docs/pull/822 really should only apply to `mc admin update`. Add there and remove from the common include.

Staged
http://192.241.195.202:9000/staging/remove-excessive-sudo-note/linux/html/reference/minio-mc-admin/mc-admin-update.html