### PR TITLE
Broken link to decommission page

### DIFF
--- a/source/operations/install-deploy-manage/modify-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/modify-minio-tenant.rst
@@ -87,5 +87,5 @@ Decommission a Tenant Server Pool
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 MinIO Operator 4.4.13 and later support decommissioning a server pool in a Tenant.
-Specifically, you can follow the :minio-docs:`Decommission a Server pool <linux/operations/install-deploy-manage/decommission-server-pool.html>` procedure to remove the pool from the tenant, then edit the tenant YAML to drop the pool from the StatefulSet.
+Specifically, you can follow the :minio-docs:`Decommission a Server pool <minio/linux/operations/install-deploy-manage/decommission-server-pool.html>` procedure to remove the pool from the tenant, then edit the tenant YAML to drop the pool from the StatefulSet.
 When removing the Tenant pool, ensure the ``spec.pools.[n].name`` fields have values for all remaining pools.


### PR DESCRIPTION
Corrects a link that resulted in a 404 from K8s tenant page to decommission page.