### PR TITLE
svcacct doc updates from RELEASE.2023-05-18T16-59-00Z

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
@@ -84,17 +84,33 @@ Parameters
 .. mc-cmd:: --access-key
    :optional:
 
-   A string to use as the access key for this account. Omit to let MinIO autogenerate a random value.
+   A string to use as the access key for this account.
+   Omit to let MinIO autogenerate a random 20 character value.
 
    Access Key names *must* be unique across all users.
 
 .. mc-cmd:: --comment
    :optional:
 
-   .. versionadded:: RELEASE.2023-01-28T20-29-38Z
+   .. versionchanged:: RELEASE.2023-05-18T16-59-00Z
 
-   Add a note to the service account.
+   This option has been removed.
+   Use ``--description`` or ``--name`` instead.
+
+.. mc-cmd:: --description
+   :optional:
+
+   .. versionadded:: RELEASE.2023-05-18T16-59-00Z
+
+   Add a description for the service account.
    For example, you might specify the reason the service account exists.
+
+.. mc-cmd:: --name
+   :optional:
+
+   .. versionadded:: RELEASE.2023-05-18T16-59-00Z
+
+   Add a friendly name for the service account.
 
 .. mc-cmd:: --policy
    :optional:
@@ -105,7 +121,8 @@ Parameters
 .. mc-cmd:: --secret-key
    :optional:
 
-   The secret key to associate with the new account. Omit to let MinIO autogenerate a random value.
+   The secret key to associate with the new account.
+   Omit to let MinIO autogenerate a random 40 character value.
 
 
 Global Flags

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
@@ -126,7 +126,7 @@ Parameters
    :optional:
 
    The secret key to associate with the new account.
-   Omit to let MinIO autogenerate a random 40 character value.
+   Omit to let MinIO autogenerate a random 40-character value.
 
 
 Global Flags

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
@@ -114,7 +114,7 @@ Parameters
 
    .. versionadded:: RELEASE.2023-05-18T16-59-00Z
 
-   Add a friendly name for the service account.
+   Add a human-readable name for the service account.
 
 .. mc-cmd:: --policy
    :optional:

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
@@ -93,6 +93,10 @@ Parameters
    :optional:
 
    .. versionchanged:: RELEASE.2023-05-18T16-59-00Z
+      Replaced by :mc-cmd:`~mc admin user svcacct add --description` and :mc-cmd:`~mc admin user svcacct add --name`.
+      
+      Originally added in version RELEASE.2023-01-28T20-29-38Z.
+
 
    This option has been removed.
    Use ``--description`` or ``--name`` instead.

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-edit.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-edit.rst
@@ -80,7 +80,7 @@ Parameters
 
    .. versionadded:: RELEASE.2023-05-18T16-59-00Z
 
-   Add a friendly name for the service account.
+   Add a human-readable name for the service account.
 
 .. mc-cmd:: --policy
    :optional:

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-edit.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-edit.rst
@@ -67,6 +67,21 @@ Parameters
 
    The service account to modify.
 
+.. mc-cmd:: --description
+   :optional:
+
+   .. versionadded:: RELEASE.2023-05-18T16-59-00Z
+
+   Add a description for the service account.
+   For example, you might specify the reason the service account exists.
+
+.. mc-cmd:: --name
+   :optional:
+
+   .. versionadded:: RELEASE.2023-05-18T16-59-00Z
+
+   Add a friendly name for the service account.
+
 .. mc-cmd:: --policy
    :optional:
 


### PR DESCRIPTION
Doc updates for `mc admin user svcacct add` and `edit`.

* `--comment` replaced with `--user` and `--description` for `add` and `edit`.
* Add detail on length of autogenerated keys. Autogeneration was already documented, the included change is a bug fix.

Partly addresses https://github.com/minio/docs/issues/859