### PR TITLE
Move reference docs for mc admin idp commands to mc idp

### DIFF
--- a/source/includes/common/common-configure-keycloak-identity-management.rst
+++ b/source/includes/common/common-configure-keycloak-identity-management.rst
@@ -266,14 +266,14 @@ Select :guilabel:`Save` to apply the configuration.
 .. start-configure-keycloak-minio-cli
 
 
-You can use the :mc-cmd:`mc admin idp openid add` command to create a new configuration for the Keycloak service.
+You can use the :mc-cmd:`mc idp openid add` command to create a new configuration for the Keycloak service.
 The command takes all supported :ref:`OpenID Configuration Settings <minio-open-id-config-settings>`:
 
 .. code-block:: shell
    :class: copyable
    :substitutions:
 
-   mc admin idp openid add ALIAS PRIMARY_IAM \
+   mc idp openid add ALIAS PRIMARY_IAM \
       client_id=MINIO_CLIENT \
       client_secret=MINIO_CLIENT_SECRET \
       config_url="https://|KEYCLOAK_URL|/realms/REALM/.well-known/openid-configuration" \

--- a/source/includes/container/steps-configure-keycloak-identity-management.rst
+++ b/source/includes/container/steps-configure-keycloak-identity-management.rst
@@ -92,7 +92,7 @@ Log in using the default credentials ``minioadmin:minioadmin``.
 MinIO supports multiple methods for configuring Keycloak authentication:
 
 - Using the MinIO Console
-- Using a terminal/shell and the :mc:`mc admin idp openid` command
+- Using a terminal/shell and the :mc:`mc idp openid` command
 - Using environment variables set prior to starting MinIO
 
 .. tab-set::

--- a/source/includes/k8s/steps-configure-keycloak-identity-management.rst
+++ b/source/includes/k8s/steps-configure-keycloak-identity-management.rst
@@ -39,7 +39,7 @@ MinIO supports multiple methods for configuring Keycloak authentication:
 
 - Using the MinIO Operator Console
 - Using the MinIO Tenant Console
-- Using a terminal/shell and the :mc:`mc admin idp openid` command
+- Using a terminal/shell and the :mc:`mc idp openid` command
 
 .. tab-set::
 

--- a/source/includes/linux/steps-configure-keycloak-identity-management.rst
+++ b/source/includes/linux/steps-configure-keycloak-identity-management.rst
@@ -38,7 +38,7 @@ Set the value to any :ref:`policy <minio-policy>` on the MinIO deployment.
 MinIO supports multiple methods for configuring Keycloak authentication:
 
 - Using the MinIO Console
-- Using a terminal/shell and the :mc:`mc admin idp openid` command
+- Using a terminal/shell and the :mc:`mc idp openid` command
 - Using environment variables set prior to starting MinIO
 
 .. tab-set::

--- a/source/operations/external-iam/configure-ad-ldap-external-identity-management.rst
+++ b/source/operations/external-iam/configure-ad-ldap-external-identity-management.rst
@@ -275,5 +275,5 @@ Disable a Configured Active Directory / LDAP Connection
 
 You can enable and disable the configured AD/LDAP connection as needed.
 
-Use :mc-cmd:`mc admin idp ldap disable` to deactivate a configured connection.
-Use :mc-cmd:`mc admin idp ldap enable` to activate a previously configured connection.
+Use :mc-cmd:`mc idp ldap disable` to deactivate a configured connection.
+Use :mc-cmd:`mc idp ldap enable` to activate a previously configured connection.

--- a/source/operations/external-iam/configure-keycloak-identity-management.rst
+++ b/source/operations/external-iam/configure-keycloak-identity-management.rst
@@ -221,27 +221,27 @@ You can validate the functionality by using the Admin REST API with the MinIO cl
 
 MinIO supports multiple methods for configuring Keycloak Admin API Support:
 
-- Using a terminal/shell and the :mc:`mc admin idp openid` command
+- Using a terminal/shell and the :mc:`mc idp openid` command
 - Using environment variables set prior to starting MinIO
 
 .. tab-set::
 
    .. tab-item:: CLI
 
-      You can use the :mc-cmd:`mc admin idp openid update` command to modify the configuration settings for an existing Keycloak service.
+      You can use the :mc-cmd:`mc idp openid update` command to modify the configuration settings for an existing Keycloak service.
       You can alternatively include the following configuration settings when setting up Keycloak for the first time.
       The command takes all supported :ref:`OpenID Configuration Settings <minio-open-id-config-settings>`:
 
       .. code-block:: shell
          :class: copyable
 
-         mc admin idp openid update ALIAS KEYCLOAK_IDENTIFIER \
+         mc idp openid update ALIAS KEYCLOAK_IDENTIFIER \
             vendor="keycloak" \
             keycloak_admin_url="https://keycloak-url:port/admin"
             keycloak_realm="REALM"
 
       - Replace ``KEYCLOAK_IDENTIFIER`` with the name of the configured Keycloak IDP.
-        You can use :mc-cmd:`mc admin idp openid list` to view all configured IDP configurations on the MinIO deployment
+        You can use :mc-cmd:`mc idp openid ls` to view all configured IDP configurations on the MinIO deployment
         
       - Specify the Keycloak admin URL in the :mc-conf:`keycloak_admin_url <identity_openid.keycloak_admin_url>` configuration setting
 

--- a/source/operations/install-deploy-manage/deploy-operator-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-helm.rst
@@ -419,7 +419,7 @@ To deploy a Tenant with Helm:
 
 #. Expose the Tenant MinIO port
 
-   To test the MinIO Client :mc-cmd:`mc` from your local machine, forward the MinIO port and create an alias.
+   To test the MinIO Client :mc:`mc` from your local machine, forward the MinIO port and create an alias.
 
    * Forward the Tenant's MinIO port:
 

--- a/source/reference/deprecated/mc-admin-idp-ldap-policy.rst
+++ b/source/reference/deprecated/mc-admin-idp-ldap-policy.rst
@@ -12,6 +12,10 @@
 
 .. mc:: mc admin idp ldap policy
 
+.. versionchanged:: RELEASE.2023-05-26T23-31-54Z
+
+   ``mc admin idp ldap policy`` has moved to  :mc-cmd:`mc idp ldap policy`.
+
 Description
 -----------
 

--- a/source/reference/deprecated/mc-admin-idp-ldap.rst
+++ b/source/reference/deprecated/mc-admin-idp-ldap.rst
@@ -12,6 +12,10 @@
 
 .. mc:: mc admin idp ldap
 
+.. versionchanged:: RELEASE.2023-05-26T23-31-54Z
+
+   ``mc admin idp ldap`` and its subcommands have moved to  :mc-cmd:`mc idp ldap`.
+
 Description
 -----------
 

--- a/source/reference/deprecated/mc-admin-idp-openid.rst
+++ b/source/reference/deprecated/mc-admin-idp-openid.rst
@@ -12,6 +12,10 @@
 
 .. mc:: mc admin idp openid
 
+.. versionchanged:: RELEASE.2023-05-26T23-31-54Z
+
+   ``mc admin idp openid`` and its subcommands have moved to  :mc-cmd:`mc idp openid`.
+
 Description
 -----------
 
@@ -39,10 +43,10 @@ The :mc-cmd:`mc admin idp openid` command has the following subcommands:
    * - :mc-cmd:`mc admin idp openid update`
      - Modify an existing OpenID IDP server configuration.
 
-   * - :mc-cmd:`mc admin idp openid remove`
+   * - :mc-cmd:`mc admin idp openid rm`
      - Remove an OpenID IDP server configuration from a deployment.
 
-   * - :mc-cmd:`mc admin idp openid list`
+   * - :mc-cmd:`mc admin idp openid ls`
      - Outputs a list of the existing OpenID server configurations for a deployment.
 
    * - :mc-cmd:`mc admin idp openid info`

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -70,11 +70,6 @@ The following table lists :mc:`mc admin` commands:
           :start-after: start-mc-admin-heal-desc
           :end-before: end-mc-admin-heal-desc
   
-   * - :mc-cmd:`mc admin idp openid`
-     - .. include:: /reference/minio-mc-admin/mc-admin-idp-openid.rst
-          :start-after: start-mc-admin-idp-openid-desc
-          :end-before: end-mc-admin-idp-openid-desc
-
    * - :mc-cmd:`mc admin info`
      - .. include:: /reference/minio-mc-admin/mc-admin-info.rst
           :start-after: start-mc-admin-info-desc
@@ -208,7 +203,6 @@ See :ref:`minio-mc-global-options`.
    /reference/minio-mc-admin/mc-admin-group
    /reference/minio-mc-admin/mc-admin-heal
    /reference/minio-mc-admin/mc-admin-idp-ldap-policy
-   /reference/minio-mc-admin/mc-admin-idp-openid
    /reference/minio-mc-admin/mc-admin-info
    /reference/minio-mc-admin/mc-admin-kms-key
    /reference/minio-mc-admin/mc-admin-logs

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -202,7 +202,6 @@ See :ref:`minio-mc-global-options`.
    /reference/minio-mc-admin/mc-admin-decommission
    /reference/minio-mc-admin/mc-admin-group
    /reference/minio-mc-admin/mc-admin-heal
-   /reference/minio-mc-admin/mc-admin-idp-ldap-policy
    /reference/minio-mc-admin/mc-admin-info
    /reference/minio-mc-admin/mc-admin-kms-key
    /reference/minio-mc-admin/mc-admin-logs

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -69,11 +69,6 @@ The following table lists :mc:`mc admin` commands:
      - .. include:: /reference/minio-mc-admin/mc-admin-heal.rst
           :start-after: start-mc-admin-heal-desc
           :end-before: end-mc-admin-heal-desc
-
-   * - :mc-cmd:`mc admin idp ldap`
-     - .. include:: /reference/minio-mc-admin/mc-admin-idp-ldap.rst
-          :start-after: start-mc-admin-idp-ldap-desc
-          :end-before: end-mc-admin-idp-ldap-desc
   
    * - :mc-cmd:`mc admin idp openid`
      - .. include:: /reference/minio-mc-admin/mc-admin-idp-openid.rst
@@ -212,7 +207,6 @@ See :ref:`minio-mc-global-options`.
    /reference/minio-mc-admin/mc-admin-decommission
    /reference/minio-mc-admin/mc-admin-group
    /reference/minio-mc-admin/mc-admin-heal
-   /reference/minio-mc-admin/mc-admin-idp-ldap
    /reference/minio-mc-admin/mc-admin-idp-ldap-policy
    /reference/minio-mc-admin/mc-admin-idp-openid
    /reference/minio-mc-admin/mc-admin-info

--- a/source/reference/minio-mc-admin/mc-admin-policy.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy.rst
@@ -33,7 +33,7 @@ MinIO PBAC uses IAM-compatible policy JSON documents to define rules for accessi
 
 .. end-mc-admin-policy-desc
 
-For complete documentation on MinIO PBAC, including policy document JSON structure and syntax, see :ref:`minio-policy`.
+For complete documentation on MinIO PBAC, including policy document JSON structure and syntax, see :ref:`minio-policy`. To manage policies for deployments that use LDAP authentication, see :mc:`mc idp ldap policy`.
 
 Subcommands
 -----------

--- a/source/reference/minio-mc-admin/mc-admin-user-add.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-add.rst
@@ -22,7 +22,7 @@ The :mc:`mc admin user add` command adds a new :ref:`MinIO user <minio-internal-
 
 .. end-mc-admin-user-add-desc
 
-To manage external Identity Provider users, see :mc:`OIDC <mc admin idp openid>` or :mc:`AD/LDAP <mc admin idp ldap>`.
+To manage external Identity Provider users, see :mc:`OIDC <mc idp openid>` or :mc:`AD/LDAP <mc idp ldap>`.
 
 .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-user-disable.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-disable.rst
@@ -26,7 +26,7 @@ Clients cannot use the user credentials to authenticate to the MinIO deployment.
 Disabling a user does *not* remove that user from the deployment.
 Use :mc-cmd:`mc admin user enable` to enable a disabled user on a MinIO deployment.
 
-To manage external Identity Provider users, see :mc:`OIDC <mc admin idp openid>` or :mc:`AD/LDAP <mc admin idp ldap>`.
+To manage external Identity Provider users, see :mc:`OIDC <mc idp openid>` or :mc:`AD/LDAP <mc idp ldap>`.
 
 .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-user-enable.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-enable.rst
@@ -25,7 +25,7 @@ The :mc:`mc admin user enable` command enables a :ref:`MinIO user <minio-interna
 Clients can only use enabled users to authenticate to the MinIO deployment.
 Users created using :mc-cmd:`mc admin user add` are enabled by default.
 
-To manage external Identity Provider users, see :mc:`OIDC <mc admin idp openid>` or :mc:`AD/LDAP <mc admin idp ldap>`.
+To manage external Identity Provider users, see :mc:`OIDC <mc idp openid>` or :mc:`AD/LDAP <mc idp ldap>`.
 
 .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-user-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-info.rst
@@ -22,7 +22,7 @@ The :mc:`mc admin user info` command returns detailed information of a :ref:`Min
 
 .. end-mc-admin-user-info-desc
 
-To manage external Identity Provider users, see :mc:`OIDC <mc admin idp openid>` or :mc:`AD/LDAP <mc admin idp ldap>`.
+To manage external Identity Provider users, see :mc:`OIDC <mc idp openid>` or :mc:`AD/LDAP <mc idp ldap>`.
 
 .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-user-list.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-list.rst
@@ -28,7 +28,7 @@ The :mc:`mc admin user list` command has equivalent functionality to :mc:`mc adm
 :mc-cmd:`mc admin user ls` does *not* return the access key or secret key associated to a user.
 Use :mc-cmd:`mc admin user info` to retrieve detailed user information, including the user access key.
 
-To manage external Identity Provider users, see :mc:`OIDC <mc admin idp openid>` or :mc:`AD/LDAP <mc admin idp ldap>`.
+To manage external Identity Provider users, see :mc:`OIDC <mc idp openid>` or :mc:`AD/LDAP <mc idp ldap>`.
 
 .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-user-remove.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-remove.rst
@@ -24,7 +24,7 @@ The :mc:`mc admin user rm` command removes a :ref:`MinIO user <minio-internal-id
 
 The :mc:`mc admin user remove` command has equivalent functionality to :mc:`mc admin user rm`.
 
-To manage external Identity Provider users, see :mc:`OIDC <mc admin idp openid>` or :mc:`AD/LDAP <mc admin idp ldap>`.
+To manage external Identity Provider users, see :mc:`OIDC <mc idp openid>` or :mc:`AD/LDAP <mc idp ldap>`.
 
 .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-user.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user.rst
@@ -22,7 +22,7 @@ The :mc:`mc admin user` command and its subcommands manage :ref:`MinIO users <mi
 Clients *must* authenticate to the MinIO deployment with the access key and secret key associated to a user on the deployment.
 MinIO users constitute a key component in MinIO Identity and Access Management.
 
-To manage users who authenticate using a 3rd party IDP, use the :mc:`mc` commands for the appropriate provider:
+To manage users who authenticate using a 3rd party IDP, use the command for the appropriate provider:
 
 - For AD/LDAP, use :mc:`mc idp ldap`
 - For OpenID Connect (OIDC) compatible providers, use :mc:`mc idp openid`

--- a/source/reference/minio-mc-admin/mc-admin-user.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user.rst
@@ -27,13 +27,10 @@ To manage users who authenticate using a 3rd party IDP, use the command for the 
 - For AD/LDAP, use :mc:`mc idp ldap`
 - For OpenID Connect (OIDC) compatible providers, use :mc:`mc idp openid`
 
-.. admonition:: Use ``mc admin`` on MinIO Deployments Only
+.. admonition:: Use ``mc idp`` commands on MinIO Deployments Only
    :class: note
 
-   .. include:: /includes/facts-mc-admin.rst
-      :start-after: start-minio-only
-      :end-before: end-minio-only
-
+   :mc:`mc idp ldap` and :mc:`mc idp openid` and their subcommands are only supported against MinIO deployments.
 
 
 Subcommands

--- a/source/reference/minio-mc-admin/mc-admin-user.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user.rst
@@ -22,10 +22,10 @@ The :mc:`mc admin user` command and its subcommands manage :ref:`MinIO users <mi
 Clients *must* authenticate to the MinIO deployment with the access key and secret key associated to a user on the deployment.
 MinIO users constitute a key component in MinIO Identity and Access Management.
 
-To manage users who authenticate using a 3rd party IDP, use the :mc:`mc admin` commands for the appropriate provider:
+To manage users who authenticate using a 3rd party IDP, use the :mc:`mc` commands for the appropriate provider:
 
-- For AD/LDAP, use :mc:`mc admin idp ldap`
-- For OpenID Connect (OIDC) compatible providers, use :mc:`mc admin idp openid`
+- For AD/LDAP, use :mc:`mc idp ldap`
+- For OpenID Connect (OIDC) compatible providers, use :mc:`mc idp openid`
 
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only
    :class: note

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -116,10 +116,6 @@ Table of Deprecated Admin Commands
      - :mc-cmd:`mc idp openid ls`
      - mc RELEASE.2023-05-26T23-31-54Z
 
-   * - ``mc admin idp openid policy``
-     - :mc-cmd:`mc idp openid policy`
-     - mc RELEASE.2023-05-26T23-31-54Z
-
    * - ``mc admin idp openid rm``
      - :mc-cmd:`mc idp openid rm`
      - mc RELEASE.2023-05-26T23-31-54Z
@@ -200,6 +196,7 @@ Table of Deprecated Admin Commands
    /reference/deprecated/mc-ilm-ls
    /reference/deprecated/mc-ilm-rm
    /reference/deprecated/mc-admin-idp-ldap
+   /reference/deprecated/mc-admin-idp-ldap-policy
    /reference/deprecated/mc-admin-idp-openid
    /reference/deprecated/mc-admin-tier
    /reference/deprecated/mc-admin-bucket-quota

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -64,6 +64,38 @@ Table of Deprecated Admin Commands
      - Replacement Command
      - Version of Change
 
+   * - ``mc admin idp ldap add``
+     - :mc-cmd:`mc idp ldap add`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp ldap disable``
+     - :mc-cmd:`mc idp ldap disable`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp ldap enable``
+     - :mc-cmd:`mc idp ldap enable`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp ldap info``
+     - :mc-cmd:`mc idp ldap info`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp ldap ls``
+     - :mc-cmd:`mc idp ldap ls`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp ldap policy``
+     - :mc-cmd:`mc idp ldap policy`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp ldap rm``
+     - :mc-cmd:`mc idp ldap rm`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp ldap update``
+     - :mc-cmd:`mc idp ldap update`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
    * - ``mc admin policy add``
      - :mc-cmd:`mc admin policy create`
      - mc RELEASE.2023-03-20T17-17-53Z 
@@ -135,6 +167,7 @@ Table of Deprecated Admin Commands
    /reference/deprecated/mc-ilm-import
    /reference/deprecated/mc-ilm-ls
    /reference/deprecated/mc-ilm-rm
+   /reference/deprecated/mc-admin-idp-ldap
    /reference/deprecated/mc-admin-tier
    /reference/deprecated/mc-admin-bucket-quota
    /reference/deprecated/mc-admin-speedtest

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -96,6 +96,38 @@ Table of Deprecated Admin Commands
      - :mc-cmd:`mc idp ldap update`
      - mc RELEASE.2023-05-26T23-31-54Z
 
+   * - ``mc admin idp openid add``
+     - :mc-cmd:`mc idp openid add`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp openid disable``
+     - :mc-cmd:`mc idp openid disable`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp openid enable``
+     - :mc-cmd:`mc idp openid enable`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp openid info``
+     - :mc-cmd:`mc idp openid info`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp openid ls``
+     - :mc-cmd:`mc idp openid ls`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp openid policy``
+     - :mc-cmd:`mc idp openid policy`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp openid rm``
+     - :mc-cmd:`mc idp openid rm`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
+   * - ``mc admin idp openid update``
+     - :mc-cmd:`mc idp openid update`
+     - mc RELEASE.2023-05-26T23-31-54Z
+
    * - ``mc admin policy add``
      - :mc-cmd:`mc admin policy create`
      - mc RELEASE.2023-03-20T17-17-53Z 
@@ -168,6 +200,7 @@ Table of Deprecated Admin Commands
    /reference/deprecated/mc-ilm-ls
    /reference/deprecated/mc-ilm-rm
    /reference/deprecated/mc-admin-idp-ldap
+   /reference/deprecated/mc-admin-idp-openid
    /reference/deprecated/mc-admin-tier
    /reference/deprecated/mc-admin-bucket-quota
    /reference/deprecated/mc-admin-speedtest

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -233,6 +233,18 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-head-desc
           :end-before: end-mc-head-desc
      
+   * - | :mc:`mc idp ldap add`
+       | :mc:`mc idp ldap disable`
+       | :mc:`mc idp ldap enable`
+       | :mc:`mc idp ldap info`
+       | :mc:`mc idp ldap ls`
+       | :mc:`mc idp ldap policy`
+       | :mc:`mc idp ldap rm`
+       | :mc:`mc idp ldap update`
+     - .. include:: /reference/minio-mc/mc-idp-ldap.rst
+          :start-after: start-mc-idp-ldap-desc
+          :end-before: end-mc-idp-ldap-desc
+
    * - | :mc:`mc ilm restore`
        | :mc:`mc ilm rule add`
        | :mc:`mc ilm rule edit`
@@ -529,6 +541,7 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-event
    /reference/minio-mc/mc-find
    /reference/minio-mc/mc-head
+   /reference/minio-mc/mc-idp-ldap
    /reference/minio-mc/mc-ilm
    /reference/minio-mc/mc-legalhold
    /reference/minio-mc/mc-license

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -245,17 +245,16 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-idp-ldap-desc
           :end-before: end-mc-idp-ldap-desc
 
-   * - | :mc:`mc idp ldap add`
-       | :mc:`mc idp ldap disable`
-       | :mc:`mc idp ldap enable`
-       | :mc:`mc idp ldap info`
-       | :mc:`mc idp ldap ls`
-       | :mc:`mc idp ldap policy`
-       | :mc:`mc idp ldap rm`
-       | :mc:`mc idp ldap update`
-     - .. include:: /reference/minio-mc/mc-idp-ldap.rst
-          :start-after: start-mc-idp-ldap-desc
-          :end-before: end-mc-idp-ldap-desc
+   * - | :mc:`mc idp openid add`
+       | :mc:`mc idp openid disable`
+       | :mc:`mc idp openid enable`
+       | :mc:`mc idp openid info`
+       | :mc:`mc idp openid ls`
+       | :mc:`mc idp openid rm`
+       | :mc:`mc idp openid update`
+     - .. include:: /reference/minio-mc/mc-idp-openid.rst
+          :start-after: start-mc-idp-openid-desc
+          :end-before: end-mc-idp-openid-desc
 
    * - | :mc:`mc idp ldap policy attach`
        | :mc:`mc idp ldap policy detach`

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -245,6 +245,18 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-idp-ldap-desc
           :end-before: end-mc-idp-ldap-desc
 
+   * - | :mc:`mc idp openid add`
+       | :mc:`mc idp openid disable`
+       | :mc:`mc idp openid enable`
+       | :mc:`mc idp openid info`
+       | :mc:`mc idp openid ls`
+       | :mc:`mc idp openid policy`
+       | :mc:`mc idp openid rm`
+       | :mc:`mc idp openid update`
+     - .. include:: /reference/minio-mc/mc-idp-openid.rst
+          :start-after: start-mc-idp-openid-desc
+          :end-before: end-mc-idp-openid-desc
+
    * - | :mc:`mc ilm restore`
        | :mc:`mc ilm rule add`
        | :mc:`mc ilm rule edit`
@@ -542,6 +554,7 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-find
    /reference/minio-mc/mc-head
    /reference/minio-mc/mc-idp-ldap
+   /reference/minio-mc/mc-idp-openid
    /reference/minio-mc/mc-ilm
    /reference/minio-mc/mc-legalhold
    /reference/minio-mc/mc-license

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -245,17 +245,24 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-idp-ldap-desc
           :end-before: end-mc-idp-ldap-desc
 
-   * - | :mc:`mc idp openid add`
-       | :mc:`mc idp openid disable`
-       | :mc:`mc idp openid enable`
-       | :mc:`mc idp openid info`
-       | :mc:`mc idp openid ls`
-       | :mc:`mc idp openid policy`
-       | :mc:`mc idp openid rm`
-       | :mc:`mc idp openid update`
-     - .. include:: /reference/minio-mc/mc-idp-openid.rst
-          :start-after: start-mc-idp-openid-desc
-          :end-before: end-mc-idp-openid-desc
+   * - | :mc:`mc idp ldap add`
+       | :mc:`mc idp ldap disable`
+       | :mc:`mc idp ldap enable`
+       | :mc:`mc idp ldap info`
+       | :mc:`mc idp ldap ls`
+       | :mc:`mc idp ldap policy`
+       | :mc:`mc idp ldap rm`
+       | :mc:`mc idp ldap update`
+     - .. include:: /reference/minio-mc/mc-idp-ldap.rst
+          :start-after: start-mc-idp-ldap-desc
+          :end-before: end-mc-idp-ldap-desc
+
+   * - | :mc:`mc idp ldap policy attach`
+       | :mc:`mc idp ldap policy detach`
+       | :mc:`mc idp ldap policy entities`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-policy.rst
+          :start-after: start-mc-idp-ldap-policy-desc
+          :end-before: end-mc-idp-ldap-policy-desc
 
    * - | :mc:`mc ilm restore`
        | :mc:`mc ilm rule add`
@@ -554,6 +561,7 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-find
    /reference/minio-mc/mc-head
    /reference/minio-mc/mc-idp-ldap
+   /reference/minio-mc/mc-idp-ldap-policy
    /reference/minio-mc/mc-idp-openid
    /reference/minio-mc/mc-ilm
    /reference/minio-mc/mc-legalhold

--- a/source/reference/minio-mc/mc-idp-ldap-policy.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-policy.rst
@@ -14,12 +14,14 @@
 
 .. versionadded:: RELEASE.2023-05-26T23-31-54Z
 
+   :mc-cmd:`mc idp ldap policy` and its subcommands replace ``mc admin idp ldap policy``.
+
 Description
 -----------
 
 .. start-mc-idp-ldap-policy-desc
 
-The :mc-cmd:`mc idp ldap policy` command allows you to view the mapping relationships between policies and the associated groups or users.
+The :mc-cmd:`mc idp ldap policy` commands allow you to view the mapping relationships between policies and the associated groups or users.
 
 .. end-mc-idp-ldap-policy-desc
 
@@ -47,7 +49,7 @@ Syntax
 
 .. mc-cmd:: attach
 
-   Attach one or more polices to entity.
+   Attach one or more polices to an entity.
 
    .. tab-set::
 

--- a/source/reference/minio-mc/mc-idp-ldap-policy.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-policy.rst
@@ -1,0 +1,194 @@
+.. _minio-mc-idp-ldap-policy:
+
+======================
+``mc idp ldap policy``
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc idp ldap policy
+
+.. versionadded:: RELEASE.2023-05-26T23-31-54Z
+
+Description
+-----------
+
+.. start-mc-idp-ldap-policy-desc
+
+The :mc-cmd:`mc idp ldap policy` command allows you to view the mapping relationships between policies and the associated groups or users.
+
+.. end-mc-idp-ldap-policy-desc
+
+
+The :mc-cmd:`mc idp ldap policy` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc idp ldap policy attach`
+     - Attach a policy to an entity
+
+   * - :mc-cmd:`mc idp ldap policy detach`
+     - Detach a policy from an entity
+
+   * - :mc-cmd:`mc idp ldap policy entities`
+     - List policy entity mappings
+
+Syntax
+------
+
+.. mc-cmd:: attach
+
+   Attach one or more polices to entity.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLES
+
+         The following example attaches two policies, ``policy1`` and ``policy2``, to the ``projectb`` group on the ``myminio`` deployment. 
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc idp ldap policy attach myminio/                                                \
+                                       policy1                                                 \
+                                       policy2                                                 \
+                                       --group='cn=projectb,ou=groups,ou=swengg,dc=min,dc=io'
+
+
+         The following example attaches the policy, ``userpolicy``, to the user ``bobfisher`` on the ``myminio`` deployment. 
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc idp ldap policy attach myminio/                                                 \
+                                       mypolicy                                                 \
+                                       policy2                                                  \
+                                       --user='uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io'
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+ 
+            mc [GLOBALFLAGS] idp ldap policy attach             \
+                                             POLICYNAME         \
+                                             [POLICY2] ...      \
+                                             ALIAS              \
+                                             [--user=`USER`]    \
+                                             [--group=`GROUP`]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``POLICYNAME`` with the policy to attach to the entity.
+           You may list multiple policies to attach to the entity.
+         - Use must use one of either the ``--user`` or ``--group`` flag.
+           You may only use the flag once in the command.
+           You cannot use both flags in the same command.
+
+
+.. mc-cmd:: detach
+
+   Detach one or more policies from an entity.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLES
+
+         The following example detaches two policies, ``policy1`` and ``policy2``, from the ``projectb`` group on the ``myminio`` deployment. 
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc idp ldap policy detach myminio/                                                \
+                                       policy1                                                 \
+                                       policy2                                                 \
+                                       --group='cn=projectb,ou=groups,ou=swengg,dc=min,dc=io'
+
+
+         The following example detaches the policy, ``userpolicy``, from the user ``bobfisher`` on the ``myminio`` deployment. 
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc idp ldap policy detach myminio/                                                 \
+                                       mypolicy                                                 \
+                                       policy2                                                  \
+                                       --user='uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io'
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+ 
+            mc [GLOBALFLAGS] idp ldap policy detach             \
+                                             POLICYNAME         \
+                                             [POLICY2] ...      \
+                                             ALIAS              \
+                                             [--user=`USER`]    \
+                                             [--group=`GROUP`]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - Replace ``POLICYNAME`` with the policy to detach from the entity.
+           You may list multiple policies to detach from the entity.
+         - Use must use one of either the ``--user`` or ``--group`` flag.
+           You may only use the flag once in the command.
+           You cannot use both flags in the same command.
+
+.. mc-cmd:: entities
+
+   Display a list of mappings for a user, group, and/or policy.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLES
+
+         The following example lists all mappings for a specific policy, a set of groups, and a selection of users on the ``myminio`` deployment.
+
+         Specifically, it lists
+         - Users mapped to the ``finteam-policy`` policy.
+         - Policies assigned to the ``uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io`` user
+         - Policies assigned to the ``cn=projectb,ou=groups,ou=swengg,dc=min,dc=io`` group
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc idp ldap policy entities myminio/                                                 \
+                                         --policy finteam-policy                                  \
+                                         --user 'uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io'  \
+                                         --group 'cn=projectb,ou=groups,ou=swengg,dc=min,dc=io'
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp ldap policy entities                       \
+                                             ALIAS                          \
+                                             [--user `value`, -u `value`]   \
+                                             [--group `value`, -g `value`]  \
+                                             [--policy value]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
+         - You may use each of the ``--user``, ``--group``, and/or ``--policy`` flags as many times as desired in the command.
+         - For each flag, the output lists the entities mapped to the specified policy, user, or group.
+         - Omit all flags to return a list of mappings for all policies.
+
+
+Global Flags
+------------
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc/mc-idp-ldap-policy.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-policy.rst
@@ -21,7 +21,8 @@ Description
 
 .. start-mc-idp-ldap-policy-desc
 
-The :mc-cmd:`mc idp ldap policy` commands allow you to view the mapping relationships between policies and the associated groups or users.
+The :mc-cmd:`mc idp ldap policy` commands allow you to view the mapping relationships between policies and the associated groups or users. The :mc-cmd:`mc idp ldap policy` commands are only supported against MinIO deployments.
+
 
 .. end-mc-idp-ldap-policy-desc
 

--- a/source/reference/minio-mc/mc-idp-ldap.rst
+++ b/source/reference/minio-mc/mc-idp-ldap.rst
@@ -1,0 +1,292 @@
+.. _minio-mc-idp-ldap:
+
+===============
+``mc idp ldap``
+===============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc idp ldap
+
+.. versionadded:: RELEASE.2023-05-26T23-31-54Z
+
+Description
+-----------
+
+.. start-mc-idp-ldap-desc
+
+The :mc-cmd:`mc idp ldap` commands allow you to add, modify, review, list, remove, enable, and disable server configurations to 3rd party :ref:`Active Directory or LDAP Identity and Access Management (IAM) integrations <minio-external-identity-management-ad-ldap>`.
+
+.. end-mc-idp-ldap-desc
+
+Define configuration settings as an alternative to using environment variables when :ref:`setting up an AD/LDAP connection <minio-authenticate-using-ad-ldap-generic>`.
+
+.. note::
+
+   Configuration settings do **not** override settings configured as environment variables.
+
+
+The :mc-cmd:`mc idp ldap` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc idp ldap add`
+     - Create an AD/LDAP IDP server configuration.
+
+   * - :mc-cmd:`mc idp ldap update`
+     - Modify an existing AD/LDAP IDP server configuration.
+
+   * - :mc-cmd:`mc idp ldap ls`
+     - Lists AD/LDAP server configurations.
+
+   * - :mc-cmd:`mc idp ldap rm`
+     - Remove an AD/LDAP IDP server configuration from a deployment.
+
+   * - :mc-cmd:`mc idp ldap info`
+     - Displays details for a specific AD/LDAP server configuration.
+
+   * - :mc-cmd:`mc idp ldap enable`
+     - Enables an AD/LDAP server configuration.
+
+   * - :mc-cmd:`mc idp ldap disable`
+     - Disables an AD/LDAP server configuration.
+
+   * - :mc-cmd:`mc idp ldap policy entities`
+     - List policy association entities
+
+Configuration Parameters
+------------------------
+
+The :mc-cmd:`mc idp ldap` subcommands support configuration parameters.
+The parameters define the server's interaction with the Active Directory or LDAP IAM provider.
+
+For a more detailed explanation of the configuration parameters, refer to the :ref:`config setting documentation <minio-ldap-config-settings>`.
+
+Syntax
+------
+
+.. mc-cmd:: add
+
+   Create a new configuration for an AD/LDAP provider.
+   MinIO supports no more than *one* (1) AD/LDAP provider per deployment.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example sets the AD/LDAP configuration settings for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc idp ldap add                                                            \
+                         myminio                                                        \
+                         server_addr=myldapserver:636                                   \
+                         lookup_bind_dn=cn=admin,dc=min,dc=io                           \
+                         lookup_bind_password=somesecret                                \
+                         user_dn_search_base_dn=dc=min,dc=io                            \
+                         user_dn_search_filter="(uid=%s)"                               \
+                         group_search_base_dn=ou=swengg,dc=min,dc=io                    \
+                         group_search_filter="(&(objectclass=groupofnames)(member=%d))"
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp ldap add               \
+                                      ALIAS             \
+                                      [CFG_PARAM1]      \
+                                      [CFG_PARAM2]...
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to create for AD/LDAP integration.
+         - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-ldap-config-settings>` key-value pairs in the format of ``PARAMETER="value"``.
+
+.. mc-cmd:: update
+
+   Modify an existing set of configurations for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example changes two of the AD/LDAP configuration settings for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp ldap update                                \
+                        myminio                               \
+                        lookup_bind_dn=cn=admin,dc=min,dc=io  \
+                        lookup_bind_password=somesecret
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp ldap update           \
+                                      ALIAS            \
+                                      [CFG_PARAM1]     \
+                                      [CFG_PARAM2]...
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to update for AD/LDAP integration.
+         - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-ldap-config-settings>` key-value pairs to update in the format of ``PARAMETER="value"``.
+
+.. mc-cmd:: ls, list
+
+   Lists the existing set of configurations for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example lists the AD/LDAP configuration settings for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp ldap ls myminio
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp ldap ls ALIAS
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to list the AD/LDAP integration.
+
+.. mc-cmd:: rm, remove
+
+   Remove the existing configuration for an AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example removes the AD/LDAP provider settings for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp ldap rm myminio
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp ldap rm     \
+                                      ALIAS
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to remove the AD/LDAP integration.
+
+
+.. mc-cmd:: info
+
+   Outputs the current configuration for an AD/LDAP provider on a specified MinIO deployment.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example outputs the AD/LDAP configuration settings on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp ldap info myminio
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp ldap info   \
+                                      ALIAS
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to retrieve info on the AD/LDAP integration.
+
+.. mc-cmd:: enable
+
+   Enables the currently configured AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example enables the AD/LDAP configuration on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp ldap enable   \
+                        myminio
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp ldap enable  \
+                                      ALIAS
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to enable the AD/LDAP integration.
+
+.. mc-cmd:: disable
+
+   Disables the currently configured AD/LDAP provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example disables the AD/LDAP configurations on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp ldap disable  \
+                        myminio
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp ldap disable  \
+                                      ALIAS
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to disable the AD/LDAP integration.
+
+Global Flags
+------------
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+

--- a/source/reference/minio-mc/mc-idp-ldap.rst
+++ b/source/reference/minio-mc/mc-idp-ldap.rst
@@ -14,6 +14,8 @@
 
 .. versionadded:: RELEASE.2023-05-26T23-31-54Z
 
+   :mc-cmd:`mc idp ldap` and its subcommands replace ``mc admin idp ldap``.
+
 Description
 -----------
 
@@ -27,8 +29,7 @@ Define configuration settings as an alternative to using environment variables w
 
 .. note::
 
-   Configuration settings do **not** override settings configured as environment variables.
-
+   MinIO :ref:`AD/LDAP environment variables <minio-server-envvar-external-identity-management-ad-ldap>` override their corresponding configuration settings as modified or set by this command.
 
 The :mc-cmd:`mc idp ldap` command has the following subcommands:
 
@@ -60,8 +61,8 @@ The :mc-cmd:`mc idp ldap` command has the following subcommands:
    * - :mc-cmd:`mc idp ldap disable`
      - Disables an AD/LDAP server configuration.
 
-   * - :mc-cmd:`mc idp ldap policy entities`
-     - List policy association entities
+   * - :mc-cmd:`mc idp ldap policy` subcommands
+     - Manage AD/LDAP policies and entity mappings.
 
 Configuration Parameters
 ------------------------

--- a/source/reference/minio-mc/mc-idp-ldap.rst
+++ b/source/reference/minio-mc/mc-idp-ldap.rst
@@ -25,7 +25,7 @@ The :mc-cmd:`mc idp ldap` commands allow you to add, modify, review, list, remov
 
 .. end-mc-idp-ldap-desc
 
-Define configuration settings as an alternative to using environment variables when :ref:`setting up an AD/LDAP connection <minio-authenticate-using-ad-ldap-generic>`.
+Define configuration settings as an alternative to using environment variables when :ref:`setting up an AD/LDAP connection <minio-authenticate-using-ad-ldap-generic>`. The :mc-cmd:`mc idp ldap` commands are only supported against MinIO deployments.
 
 .. note::
 

--- a/source/reference/minio-mc/mc-idp-ldap.rst
+++ b/source/reference/minio-mc/mc-idp-ldap.rst
@@ -21,7 +21,7 @@ Description
 
 .. start-mc-idp-ldap-desc
 
-The :mc-cmd:`mc idp ldap` commands allow you to add, modify, review, list, remove, enable, and disable server configurations to 3rd party :ref:`Active Directory or LDAP Identity and Access Management (IAM) integrations <minio-external-identity-management-ad-ldap>`.
+The :mc-cmd:`mc idp ldap` commands allow you to manage configurations to 3rd party :ref:`Active Directory or LDAP Identity and Access Management (IAM) integrations <minio-external-identity-management-ad-ldap>`.
 
 .. end-mc-idp-ldap-desc
 

--- a/source/reference/minio-mc/mc-idp-openid.rst
+++ b/source/reference/minio-mc/mc-idp-openid.rst
@@ -1,0 +1,309 @@
+.. _minio-mc-idp-openid:
+
+=================
+``mc idp openid``
+=================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc idp openid
+
+.. versionadded:: RELEASE.2023-05-26T23-31-54Z
+
+Description
+-----------
+
+.. start-mc-idp-openid-desc
+
+The :mc-cmd:`mc idp openid` commands allow you to add, modify, review, list, remove, enable, and disable server configurations to 3rd party :ref:`OpenID Identity and Access Management (IAM) integrations <minio-external-identity-management-openid>`.
+
+.. end-mc-idp-openid-desc
+
+Define configuration settings as an alternative to using environment variables when :ref:`setting up an OpenID connection <minio-external-identity-management-openid-configure>`.
+
+
+The :mc-cmd:`mc idp openid` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc idp openid add`
+     - Create an OpenID IDP server configuration.
+
+   * - :mc-cmd:`mc idp openid update`
+     - Modify an existing OpenID IDP server configuration.
+
+   * - :mc-cmd:`mc idp openid rm`
+     - Remove an OpenID IDP server configuration from a deployment.
+
+   * - :mc-cmd:`mc idp openid ls`
+     - Outputs a list of the existing OpenID server configurations for a deployment.
+
+   * - :mc-cmd:`mc idp openid info`
+     - Displays details for a specific OpenID server configuration.
+
+   * - :mc-cmd:`mc idp openid enable`
+     - Enables an OpenID server configuration.
+
+   * - :mc-cmd:`mc idp openid disable`
+     - Disables an OpenID server configuration.
+
+Configuration Parameters
+------------------------
+
+The :mc-cmd:`mc idp openid` subcommands support configuration parameters.
+The parameters define the server's interaction with the IAM provider.
+
+For a more detailed explanation of the configuration parameters, refer to the :ref:`config setting documentation <minio-open-id-config-settings>`.
+
+Syntax
+------
+
+.. mc-cmd:: add
+
+   Create a new set of configurations for an OpenID provider.
+
+   You can run the command multiple times to set up multiple OpenID providers.
+
+   When adding multiple OpenID providers, only one can be a JWT Claim-based provider.
+   All others must be role-based providers.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example creates the configuration settings for the ``myminio`` deployment as defined in a new ``test-config`` setup for Dex integration.
+
+         .. code-block:: shell
+            :class: copyable
+
+             mc idp openid add myminio test-config                                        \
+                client_id=minio-client-app                                                \
+                client_secret=minio-client-app-secret                                     \
+                config_url="http://localhost:5556/dex/.well-known/openid-configuration"   \
+                scopes="openid,groups"                                                    \
+                redirect_uri="http://127.0.0.1:10000/oauth_callback"                      \
+                role_policy="consoleAdmin"
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp openid add               \
+                                        ALIAS             \
+                                        [CFG_NAME]        \
+                                        [CFG_PARAM1]      \
+                                        [CFG_PARAM2]...
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command creates default configuration values.
+         - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-open-id-config-settings>` key-value pairs in the format of ``PARAMETER="value"``.
+
+.. mc-cmd:: update
+
+   Modify an existing set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example changes two of the configuration settings for the ``myminio`` deployment as defined in the ``test-config`` setup for Dex integration.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp openid update                      \
+                          myminio                     \
+                          test_config                 \
+                          scopes="openid,groups"      \
+                          role_policy="consoleAdmin"
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp openid update           \
+                                        ALIAS            \
+                                        [CFG_NAME]       \
+                                        [CFG_PARAM1]     \
+                                        [CFG_PARAM2]...
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command updates the default configuration.
+         - Replace the ``[CFG_PARAM#]`` with each of the :ref:`configuration setting <minio-open-id-config-settings>` key-value pairs to update in the format of ``PARAMETER="value"``.
+
+.. mc-cmd:: rm, remove
+
+   Remove an existing set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example removes the ``test-config`` settings for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp openid rm myminio test_config
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp openid rm          \
+                                        ALIAS       \
+                                        [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command removes the default configurations.
+
+.. mc-cmd:: ls, list
+
+   Outputs a list of existing configuration sets for OpenID providers.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example outputs a list of all OpenID configuration sets defined for the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp openid ls myminio
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp openid ls ALIAS
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to list OpenID integrations for.
+
+
+.. mc-cmd:: info
+
+   Outputs the set of values defined for an existing set of server configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example outputs the configuration settings defined for the ``test_config`` set of OpenID settings on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp openid info myminio test_config
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp openid info        \
+                                        ALIAS       \
+                                        [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the information displays for the default server configuration.
+
+.. mc-cmd:: enable
+
+   Begin using an existing set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example enables the server configurations defined as ``test_config`` on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp openid enable       \
+                          myminio      \
+                          test_config
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp openid enable     \
+                                        ALIAS      \
+                                        [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command enables the default configuration values.
+
+.. mc-cmd:: disable
+
+   Stop using a set of configurations for an OpenID provider.
+
+   .. tab-set::
+
+      .. tab-item:: EXAMPLE
+
+         The following example disables the server configurations defined as ``test_config`` on the ``myminio`` deployment.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc idp openid disable      \
+                          myminio      \
+                          test_config
+
+      .. tab-item:: SYNTAX
+
+         The command has the following syntax:
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc [GLOBALFLAGS] idp openid disable       \
+                                        ALIAS         \
+                                        [CFG_NAME]
+
+         - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for OpenID integration.
+         - Replace ``CFG_NAME`` with a unique string for this configuration.
+           If not specified, the command disables the default configuration values.
+
+
+
+Global Flags
+------------
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc/mc-idp-openid.rst
+++ b/source/reference/minio-mc/mc-idp-openid.rst
@@ -14,6 +14,8 @@
 
 .. versionadded:: RELEASE.2023-05-26T23-31-54Z
 
+   :mc-cmd:`mc idp openid` and its subcommands replace ``mc admin idp openid``.
+
 Description
 -----------
 
@@ -25,6 +27,9 @@ The :mc-cmd:`mc idp openid` commands allow you to add, modify, review, list, rem
 
 Define configuration settings as an alternative to using environment variables when :ref:`setting up an OpenID connection <minio-external-identity-management-openid-configure>`.
 
+.. note::
+
+   MinIO :ref:`OpenID environment variables <minio-server-envvar-external-identity-management-openid>` override their corresponding configuration settings as modified or set by this command.
 
 The :mc-cmd:`mc idp openid` command has the following subcommands:
 

--- a/source/reference/minio-mc/mc-idp-openid.rst
+++ b/source/reference/minio-mc/mc-idp-openid.rst
@@ -25,7 +25,8 @@ The :mc-cmd:`mc idp openid` commands allow you to add, modify, review, list, rem
 
 .. end-mc-idp-openid-desc
 
-Define configuration settings as an alternative to using environment variables when :ref:`setting up an OpenID connection <minio-external-identity-management-openid-configure>`.
+Define configuration settings as an alternative to using environment variables when :ref:`setting up an OpenID connection <minio-external-identity-management-openid-configure>`. The :mc-cmd:`mc idp openid` commands are only supported against MinIO deployments.
+
 
 .. note::
 

--- a/source/reference/minio-mc/mc-idp-openid.rst
+++ b/source/reference/minio-mc/mc-idp-openid.rst
@@ -21,7 +21,7 @@ Description
 
 .. start-mc-idp-openid-desc
 
-The :mc-cmd:`mc idp openid` commands allow you to add, modify, review, list, remove, enable, and disable server configurations to 3rd party :ref:`OpenID Identity and Access Management (IAM) integrations <minio-external-identity-management-openid>`.
+The :mc-cmd:`mc idp openid` commands allow you to manage configurations to 3rd party :ref:`OpenID Identity and Access Management (IAM) integrations <minio-external-identity-management-openid>`.
 
 .. end-mc-idp-openid-desc
 


### PR DESCRIPTION
All the `mc admin idp *` commands have been renamed `mc idp *`. Deprecate everything under `mc admin idp` and create pages for their new names in the MinIO Client section.

Affects the following commands and subcommands;
* `mc admin idp ldap`
* `mc admin idp openid`
*  `mc admin idp ldap policy`

The new pages maintain the existing content and page structure. New pages for each subcommand are out of scope for this PR.

Partly addresses https://github.com/minio/docs/issues/859 and https://github.com/minio/docs/issues/866

Staged:
http://192.241.195.202:9000/staging/DOCS-859-part-2-idp/linux/html/reference/minio-mc.html
http://192.241.195.202:9000/staging/DOCS-859-part-2-idp/linux/html/reference/minio-mc-admin.html
http://192.241.195.202:9000/staging/DOCS-859-part-2-idp/linux/html/reference/minio-mc-deprecated.html

Question for reviewers:
The commands deprecated in RELEASE.2023-05-18T16-59-00Z, https://github.com/minio/docs/issues/859 don't appear to have been in the docs anyway. (Separating several shared commands into specific ones for ldap and openid.) Which would mean RELEASE.2023-05-26T23-31-54Z https://github.com/minio/docs/issues/866 supersedes the previous deprecation. 

Can someone confirm? The affected commands are:
* `mc admin idp info` -> `mc admin idp ldap info` or `mc admin idp openid info`
* `mc admin idp list` -> `mc admin idp ldap list` or `mc admin idp openid list`
* `mc admin idp remove` -> `mc admin idp ldap remove` or `mc admin idp openid remove`
* `mc admin idp set` -> `mc admin idp ldap set` or `mc admin idp openid set`

Additional questions are inline with the diff.
