### PR TITLE
Partial update for mc RELEASE.2023-05-26T23-31-54Z

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-list.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-list.rst
@@ -36,6 +36,20 @@ The alias :mc:`mc admin user svcacct list` has equivalent functionality to :mc:`
 
          mc admin user svcacct ls myminio admin1
 
+      The output resembles the following:
+   
+      .. code-block:: shell
+
+            Access Key        | Expiry
+         5XF3ZHNZK6FBDWH9JMLX | 2023-06-24 07:00:00 +0000 UTC
+         F4V2BBUZSWY7UG96ED70 | 2023-12-24 18:00:00 +0000 UTC
+         FZVSEZ8NM9JRBEQZ7B8Q | no-expiry
+         HOXGL8ON3RG0IKYCHCUD | no-expiry
+
+      .. versionadded:: RELEASE.2023-05-26T23-31-54Z
+
+        The list of access keys includes the expiry date, or ``no-expiry`` for keys that do not expire.
+	 
    .. tab-item:: SYNTAX
 
       The command has the following syntax: 

--- a/source/reference/minio-mc/mc-ilm-rule-ls.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-ls.rst
@@ -17,6 +17,10 @@
 
    ``mc ilm rule ls`` replaces ``mc ilm ls``.
 
+.. versionchanged:: RELEASE.2023-05-26T23-31-54Z
+
+   ``mc ilm rule ls --JSON`` output includes the policy modification time in ``updateAt``.
+   
 Syntax
 ------
 
@@ -137,10 +141,48 @@ Use :mc:`mc ilm rule ls` to list a bucket's lifecycle management rules:
 
    mc ilm rule ls ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc ilm rule ls ALIAS>` with the 
-  :mc:`alias <mc alias>` of the S3-compatible host.
+- Replace :mc-cmd:`ALIAS <mc ilm rule ls ALIAS>` with the :mc:`alias <mc alias>` of the S3-compatible host.
 
 - Replace ``PATH`` with the path to the bucket on the S3-compatible host.
+
+Show Policy Modification Time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc ilm rule ls` with :std:option:`--JSON <mc.--JSON>` to show the time the policy for a bucket was last updated.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm rule ls ALIAS/PATH --JSON
+
+- Replace :mc-cmd:`ALIAS <mc ilm rule ls ALIAS>` with the :mc:`alias <mc alias>` of the S3-compatible host.
+
+- Replace ``PATH`` with the path to the bucket on the S3-compatible host.
+
+The ``updateAt`` property in the JSON output contains the date and time the policy was updated.
+
+The output resembles the following:
+
+.. code-block:: shell
+
+   {
+    "status": "success",
+    "target": "myminio/mybucket",
+    "config": {
+     "Rules": [
+      {
+       "Expiration": {
+        "Days": 30
+       },
+       "ID": "ci1o2mg0sko6f1r3krv0",
+       "Status": "Enabled"
+      }
+     ]
+    },
+    "updatedAt": "2023-06-09T19:45:30Z"
+   }
+
+
 
 Required Permissions
 --------------------


### PR DESCRIPTION
Update reference docs for recent changes:

* `mc admin user svcacct ls` service account expiration date
* `mc ilm rule ls`  `updateAt` policy mod time

Staged:
http://192.241.195.202:9000/staging/DOCS-866/linux/html/reference/minio-mc-admin/mc-admin-user-svcacct-list.html
file:///Users/andrealongo/repos/docs/build/DOCS-866/linux/html/reference/minio-mc/mc-ilm-rule-ls.html#show-policy-modification-time

Partially addresses https://github.com/minio/docs/issues/866