### PR TITLE
mc admin user info: view inherited policies from groups

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-user-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-info.rst
@@ -12,6 +12,9 @@
 
 .. mc:: mc admin user info
 
+.. versionchanged:: RELEASE.2023-05-26T23-31-54Z
+
+   ``mc admin user info --JSON`` output includes policies inherited from a user's group memberships in ``memberOf``.
 
 Syntax
 ------
@@ -72,8 +75,8 @@ Global Flags
    :end-before: end-minio-mc-globals
 
 
-Example
--------
+Examples
+--------
 
 View User Details
 ~~~~~~~~~~~~~~~~~
@@ -97,6 +100,39 @@ The output resembles the following:
    Status: enabled
    PolicyName: readwrite
    MemberOf:
+
+View Policies from Group Membership
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc-cmd:`mc admin user info` with :std:option:`--JSON <mc.--JSON>` to view the policies inherited from a user's group memberships:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc admin user info ALIAS USERNAME --JSON
+
+- Replace :mc-cmd:`ALIAS <mc admin user info ALIAS>` with the :mc-cmd:`alias <mc alias>` of the MinIO deployment.
+
+- Replace :mc-cmd:`USERNAME <mc admin user info USERNAME>` with the username of the user to display information for.
+
+The ``memberOf`` property in the output contains a list of groups the user is a member of, with the policies attached to each group.
+The output resembles the following:
+
+.. code-block:: shell
+
+   {
+    "status": "success",
+    "accessKey": "myuser",
+    "userStatus": "enabled",
+    "memberOf": [
+     {
+      "name": "testingGroup",
+      "policies": [
+       "testingGroupPolicy"
+      ]
+     }
+    ]
+   }
 
 
 Behavior

--- a/source/reference/minio-mc-admin/mc-admin-user-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-info.rst
@@ -103,7 +103,7 @@ The output resembles the following:
 View Policies from Group Membership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd:`mc admin user info` with :std:option:`--JSON <mc.--JSON>` to view the policies inherited from a user's group memberships:
+Use :mc-cmd:`mc admin user info` with :std:option:`--JSON <mc.--JSON>` to view the policies inherited from a user's :ref:`group memberships <minio-groups>`:
 
 .. code-block:: shell
    :class: copyable

--- a/source/reference/minio-mc-admin/mc-admin-user-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-info.rst
@@ -12,10 +12,6 @@
 
 .. mc:: mc admin user info
 
-.. versionchanged:: RELEASE.2023-05-26T23-31-54Z
-
-   ``mc admin user info --JSON`` output includes policies inherited from a user's group memberships in ``memberOf``.
-
 Syntax
 ------
 
@@ -74,6 +70,9 @@ Global Flags
    :start-after: start-minio-mc-globals
    :end-before: end-minio-mc-globals
 
+.. versionchanged:: RELEASE.2023-05-26T23-31-54Z
+
+   ``mc admin user info --JSON`` output includes policies inherited from a user's group memberships in ``memberOf``.
 
 Examples
 --------


### PR DESCRIPTION
Remaining item from https://github.com/minio/docs/issues/866:

`mc admin user info --JSON` includes the policies the user inherited from their group membership in the `memberOf` property.

Staged:
http://192.241.195.202:9000/staging/DOCS-866-mc-admin-user-info/linux/html/reference/minio-mc-admin/mc-admin-user-info.html

Fixes https://github.com/minio/docs/issues/866