### PR TITLE
Docs 860 part1: max policy document size, webhook metrics

### DIFF
--- a/source/administration/identity-access-management/policy-based-access-control.rst
+++ b/source/administration/identity-access-management/policy-based-access-control.rst
@@ -159,7 +159,8 @@ MinIO policy documents use the same schema as
 The following sample document provides a template for creating custom
 policies for use with a MinIO deployment. For more complete documentation on IAM
 policy elements, see the :aws-docs:`IAM JSON Policy Elements Reference
-<IAM/latest/UserGuide/reference_policies_elements.html>`. 
+<IAM/latest/UserGuide/reference_policies_elements.html>`.
+The maximum size for a policy document is 2048 characters.
 
 .. code-block:: javascript
    :class: copyable

--- a/source/administration/monitoring/publish-events-to-webhook.rst
+++ b/source/administration/monitoring/publish-events-to-webhook.rst
@@ -1,4 +1,4 @@
-.. _minio-bucket-notifications-publish-webhook:
+-1;95;0c.. _minio-bucket-notifications-publish-webhook:
 
 =========================
 Publish Events to Webhook
@@ -311,3 +311,9 @@ a notification.
    :class: copyable
 
    mc cp ~/data/new-object.txt ALIAS/BUCKET
+
+Webhook Metrics
+---------------
+
+MinIO publishes several :ref:`metrics <minio-metrics-and-alerts>` for monitoring webhook endpoints.
+See :ref:`minio-metrics-and-alerts-webhook` for a list of available metrics.

--- a/source/administration/monitoring/publish-events-to-webhook.rst
+++ b/source/administration/monitoring/publish-events-to-webhook.rst
@@ -1,4 +1,4 @@
--1;95;0c.. _minio-bucket-notifications-publish-webhook:
+.. _minio-bucket-notifications-publish-webhook:
 
 =========================
 Publish Events to Webhook

--- a/source/operations/monitoring/metrics-and-alerts.rst
+++ b/source/operations/monitoring/metrics-and-alerts.rst
@@ -613,6 +613,7 @@ Lock Metrics
 
    Number of current READ locks on the peer.
 
+.. _minio-metrics-and-alerts-webhook:
 
 Webhook Metrics
 ~~~~~~~~~~~~~~~
@@ -623,7 +624,7 @@ Webhook Metrics
 
 .. metric:: minio_cluster_webhook_online
 
-   State of the webhook endpoint: ``1`` if online, or ``0`` if not online.
+   Reports whether the webhook endpoint is online (1) or offline (0). 
 
 .. metric:: minio_cluster_webhook_queue_length
 

--- a/source/operations/monitoring/metrics-and-alerts.rst
+++ b/source/operations/monitoring/metrics-and-alerts.rst
@@ -623,7 +623,7 @@ Webhook Metrics
 
 .. metric:: minio_cluster_webhook_online
 
-   State of the webhook endpoint: `1` if online, or `0` if not online.
+   State of the webhook endpoint: ``1`` if online, or ``0`` if not online.
 
 .. metric:: minio_cluster_webhook_queue_length
 

--- a/source/operations/monitoring/metrics-and-alerts.rst
+++ b/source/operations/monitoring/metrics-and-alerts.rst
@@ -613,6 +613,26 @@ Lock Metrics
 
    Number of current READ locks on the peer.
 
+
+Webhook Metrics
+~~~~~~~~~~~~~~~
+
+.. metric:: minio_cluster_webhook_failed_messages
+
+   Number of messages that failed to send.
+
+.. metric:: minio_cluster_webhook_online
+
+   State of the webhook endpoint: `1` if online, or `0` if not online.
+
+.. metric:: minio_cluster_webhook_queue_length
+
+   Number of messages in the webhook queue.
+
+.. metric:: minio_cluster_webhook_total_messages
+
+   Number of messages sent to this webhook endpoint.
+
 .. toctree::
    :titlesonly:
    :hidden:

--- a/source/reference/minio-mc-admin/mc-admin-policy-create.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-create.rst
@@ -94,7 +94,7 @@ The :mc-cmd:`mc admin policy create` command accepts the following arguments:
 .. mc-cmd:: POLICYPATH
 
    The file path of the policy to add. 
-   The file *must* be a JSON-formatted file with :iam-docs:`IAM-compatible syntax <reference_policies.html>` and a maximum size of 2048 characters.
+   The file *must* be a JSON-formatted file with :iam-docs:`IAM-compatible syntax <reference_policies.html>` and no more than 2048 characters.
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc-admin/mc-admin-policy-create.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-create.rst
@@ -94,7 +94,7 @@ The :mc-cmd:`mc admin policy create` command accepts the following arguments:
 .. mc-cmd:: POLICYPATH
 
    The file path of the policy to add. 
-   The file *must* be a JSON-formatted file with :iam-docs:`IAM-compatible syntax <reference_policies.html>`. 
+   The file *must* be a JSON-formatted file with :iam-docs:`IAM-compatible syntax <reference_policies.html>` and a maximum size of 2048 characters.
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
@@ -119,8 +119,9 @@ Parameters
 .. mc-cmd:: --policy
    :optional:
 
-   The path to a :ref:`policy document <minio-policy>` to attach to the new access key.
+   The path to a :ref:`policy document <minio-policy>` to attach to the new access key, with a maximum size of 2048 characters.
    The attached policy cannot grant access to any action or resource not explicitly allowed by the parent user's policies.
+   
 
 .. mc-cmd:: --secret-key
    :optional:

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-edit.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-edit.rst
@@ -85,7 +85,7 @@ Parameters
 .. mc-cmd:: --policy
    :optional:
 
-   The path to a :ref:`policy document <minio-policy>` to attach to the new access key.
+   The path to a :ref:`policy document <minio-policy>` to attach to the new access key, with a maximum size of 2048 characters.
    The attached policy cannot grant access to any action or resource not explicitly allowed by the parent user's policies.
 
    The new policy overwrites any previously attached policy.


### PR DESCRIPTION
Docs updates for two items from [MinIO RELEASE.2023-05-18T00-05-36Z](https://github.com/minio/docs/issues/860):

* Max policy size of 2KiB for service accounts
  I _think_ this change now means json policy documents have the same max size in all cases. The limit wasn't documented previously. This change adds max size info throughout, not only for service accounts.
* Webhook usage metrics

Staged:
http://192.241.195.202:9000/staging/DOCS-860-part1/linux/html/reference/minio-mc-admin/mc-admin-user-svcacct-add.html
http://192.241.195.202:9000/staging/DOCS-860-part1/linux/html/reference/minio-mc-admin/mc-admin-user-svcacct-edit.html
http://192.241.195.202:9000/staging/DOCS-860-part1/linux/html/reference/minio-mc-admin/mc-admin-policy-create.html
http://192.241.195.202:9000/staging/DOCS-860-part1/linux/html/administration/identity-access-management/policy-based-access-control.html#policy-document-structure


Partly addresses https://github.com/minio/docs/issues/860