### PR TITLE
Docs 860 part2: persistant queues

### DIFF
--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -96,7 +96,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the AMQP
-service is offline and replays the directory when connectivity resumes.
+service is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-amqp-queue-dir
 
@@ -205,7 +205,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the MQTT 
-server/broker is offline and replays the directory when connectivity resumes.
+server/broker is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-mqtt-queue-dir
 
@@ -302,7 +302,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the Elasticsearch 
-service is offline and replays the directory when connectivity resumes.
+service is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-elasticsearch-queue-dir
 
@@ -360,7 +360,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the NSQ 
-server/broker is offline and replays the directory when connectivity resumes.
+server/broker is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-nsq-queue-dir
 
@@ -439,7 +439,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the Redis 
-server/broker is offline and replays the directory when connectivity resumes.
+server/broker is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-redis-queue-dir
 
@@ -584,7 +584,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the NATS 
-server/broker is offline and replays the directory when connectivity resumes.
+server/broker is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-nats-queue-dir
 
@@ -672,7 +672,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the PostgreSQL 
-server/broker is offline and replays the directory when connectivity resumes.
+server/broker is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-postgresql-queue-dir
 
@@ -771,7 +771,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the MySQL 
-server/broker is offline and replays the directory when connectivity resumes.
+server/broker is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-mysql-queue-dir
 
@@ -926,7 +926,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the Kafka 
-server/broker is offline and replays the directory when connectivity resumes.
+server/broker is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-kafka-queue-dir
 
@@ -992,7 +992,7 @@ Specify the directory path to enable MinIO's persistent event store for
 undelivered messages, such as ``/home/events``.
 
 MinIO stores undelivered events in the specified store while the webhook
-service is offline and replays the directory when connectivity resumes.
+service is offline and replays the stored events when connectivity resumes.
 
 .. end-minio-notify-webhook-queue-dir
 

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -190,15 +190,30 @@ HTTP Webhook Log Target
       This setting corresponds to the
       :envvar:`MINIO_LOGGER_WEBHOOK_PROXY` environment variable.
 
+   .. mc-conf:: queue_dir
+
+      .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+
+      *Optional*
+
+      Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+
+      MinIO stores undelivered events in the specified store while the webhook service is offline and replays the stored events when connectivity resumes.
+
+      This setting corresponds to the
+      :envvar:`MINIO_LOGGER_WEBHOOK_QUEUE_DIR` environment variable.
+
    .. mc-conf:: queue_size
 
       *Optional*
 
       An integer value to use for the queue size for logger webhook targets.
+      The default is ``100000`` events.
+
+      Requires specifying :mc-conf:`~logger_webhook.queue_dir`.
 
       This setting corresponds to the
       :envvar:`MINIO_LOGGER_WEBHOOK_QUEUE_SIZE` environment variable.
-
 
 .. _minio-server-config-logging-audit:
 
@@ -278,8 +293,44 @@ HTTP Webhook Audit Log Target
 
       Requires specifying :mc-conf:`~audit_webhook.client_cert`.
 
-      This setting corresponds to the
-      :envvar:`MINIO_AUDIT_WEBHOOK_CLIENT_KEY` environment variable.
+      This setting corresponds to the :envvar:`MINIO_AUDIT_WEBHOOK_CLIENT_KEY` environment variable.
+
+   .. mc-conf:: queue_dir
+
+      .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+
+      *Optional*
+
+      Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+
+      MinIO stores undelivered events in the specified store while the webhook service is offline and replays the stored events when connectivity resumes.
+
+      This setting corresponds to the :envvar:`MINIO_AUDIT_WEBHOOK_QUEUE_DIR` environment variable.
+
+   .. mc-conf:: kafka_queue_dir
+
+      .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+
+      *Optional*
+
+      Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+
+      MinIO stores undelivered events in the specified store while the Kafka service is offline and replays the stored events when connectivity resumes.
+
+      This setting corresponds to the :envvar:`MINIO_AUDIT_KAFKA_QUEUE_DIR` environment variable.
+
+   .. mc-conf:: kafka_queue_size
+
+      .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+
+      *Optional*
+
+      An integer value to use for the queue size for Kafka targets.
+      The default is ``100000`` events.
+
+      Requires specifying :mc-conf:`~audit_webhook.kafka_queue_dir`.
+
+      This setting corresponds to the :envvar:`MINIO_AUDIT_KAFKA_QUEUE_SIZE` environment variable.
 
 .. _minio-server-config-bucket-notification-amqp:
 

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -196,7 +196,8 @@ HTTP Webhook Log Target
 
       *Optional*
 
-      Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+      Specify the directory path, such as ``/opt/minio/events``, to enable MinIO's persistent event store for undelivered messages.
+      The MinIO process must have read, write, and list access on the specified directory.
 
       MinIO stores undelivered events in the specified store while the webhook service is offline and replays the stored events when connectivity resumes.
 
@@ -209,8 +210,6 @@ HTTP Webhook Log Target
 
       An integer value to use for the queue size for logger webhook targets.
       The default is ``100000`` events.
-
-      Requires specifying :mc-conf:`~logger_webhook.queue_dir`.
 
       This setting corresponds to the
       :envvar:`MINIO_LOGGER_WEBHOOK_QUEUE_SIZE` environment variable.
@@ -301,36 +300,21 @@ HTTP Webhook Audit Log Target
 
       *Optional*
 
-      Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+      Specify the directory path, such as ``/opt/minio/events``, to enable MinIO's persistent event store for undelivered messages.
+      The MinIO process must have read, write, and list access on the specified directory.
 
       MinIO stores undelivered events in the specified store while the webhook service is offline and replays the stored events when connectivity resumes.
 
       This setting corresponds to the :envvar:`MINIO_AUDIT_WEBHOOK_QUEUE_DIR` environment variable.
 
-   .. mc-conf:: kafka_queue_dir
-
-      .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+   .. mc-conf:: queue_size
 
       *Optional*
 
-      Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
-
-      MinIO stores undelivered events in the specified store while the Kafka service is offline and replays the stored events when connectivity resumes.
-
-      This setting corresponds to the :envvar:`MINIO_AUDIT_KAFKA_QUEUE_DIR` environment variable.
-
-   .. mc-conf:: kafka_queue_size
-
-      .. versionadded:: RELEASE.2023-05-18T00-05-36Z
-
-      *Optional*
-
-      An integer value to use for the queue size for Kafka targets.
+      An integer value to use for the queue size for webhook targets.
       The default is ``100000`` events.
 
-      Requires specifying :mc-conf:`~audit_webhook.kafka_queue_dir`.
-
-      This setting corresponds to the :envvar:`MINIO_AUDIT_KAFKA_QUEUE_SIZE` environment variable.
+      This setting corresponds to the :envvar:`MINIO_AUDIT_WEBHOOK_QUEUE_SIZE` environment variable.
 
 .. _minio-server-config-bucket-notification-amqp:
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -677,6 +677,18 @@ server logs webhook endpoints:
    This variable corresponds to the :mc-conf:`logger_webhook proxy 
    <logger_webhook.proxy>` configuration setting.
 
+.. envvar:: MINIO_LOGGER_WEBHOOK_QUEUE_DIR
+
+   .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+
+   *Optional*
+
+   Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+
+   MinIO stores undelivered events in the specified store while the webhook service is offline and replays the stored events when connectivity resumes.
+
+   This variable corresponds to the :mc-conf:`logger_webhook queue_dir <logger_webhook.queue_dir>` configuration setting.
+
 .. envvar:: MINIO_LOGGER_WEBHOOK_QUEUE_SIZE
 
    *Optional*
@@ -765,6 +777,40 @@ audit log webhook endpoints:
 
    This variable corresponds to the :mc-conf:`audit_webhook client_key
    <audit_webhook.client_key>` configuration setting.
+
+.. envvar:: MINIO_AUDIT_WEBHOOK_QUEUE_DIR
+
+   .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+
+   *Optional*
+
+   Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+
+   MinIO stores undelivered events in the specified store while the webhook service is offline and replays the stored events when connectivity resumes.
+
+   This variable corresponds to the :mc-conf:`audit_webhook queue_dir <audit_webhook.queue_dir>` configuration setting.
+
+.. envvar:: MINIO_AUDIT_KAFKA_QUEUE_DIR
+
+   .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+	    
+   *Optional*
+
+   Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+
+   MinIO stores undelivered events in the specified store while the Kafka service is offline and replays the stored events when connectivity resumes.
+
+   This variable corresponds to the :mc-conf:`audit_webhook kafka_queue_dir <audit_webhook.kafka_queue_dir>` configuration setting.
+
+.. envvar:: MINIO_AUDIT_KAFKA_QUEUE_SIZE
+
+   .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+
+   *Optional*
+
+   An integer value to use for the queue size for audit Kafka targets.
+
+   This variable corresponds to the :mc-conf:`audit_webhook kafka_queue_dir <audit_webhook.kafka_queue_dir>` configuration setting.
 
 Bucket Notifications
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -683,7 +683,8 @@ server logs webhook endpoints:
 
    *Optional*
 
-   Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+   Specify the directory path, such as ``/opt/minio/events``, to enable MinIO's persistent event store for undelivered messages.
+   The MinIO process must have read, write, and list access on the specified directory.
 
    MinIO stores undelivered events in the specified store while the webhook service is offline and replays the stored events when connectivity resumes.
 
@@ -784,33 +785,20 @@ audit log webhook endpoints:
 
    *Optional*
 
-   Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
+   Specify the directory path, such as ``/opt/minio/events``, to enable MinIO's persistent event store for undelivered messages.
+   The MinIO process must have read, write, and list access on the specified directory.
 
    MinIO stores undelivered events in the specified store while the webhook service is offline and replays the stored events when connectivity resumes.
 
    This variable corresponds to the :mc-conf:`audit_webhook queue_dir <audit_webhook.queue_dir>` configuration setting.
 
-.. envvar:: MINIO_AUDIT_KAFKA_QUEUE_DIR
-
-   .. versionadded:: RELEASE.2023-05-18T00-05-36Z
-	    
-   *Optional*
-
-   Specify the directory path to enable MinIO's persistent event store for undelivered messages, such as ``/home/events``.
-
-   MinIO stores undelivered events in the specified store while the Kafka service is offline and replays the stored events when connectivity resumes.
-
-   This variable corresponds to the :mc-conf:`audit_webhook kafka_queue_dir <audit_webhook.kafka_queue_dir>` configuration setting.
-
-.. envvar:: MINIO_AUDIT_KAFKA_QUEUE_SIZE
-
-   .. versionadded:: RELEASE.2023-05-18T00-05-36Z
+.. envvar:: MINIO_AUDIT_WEBHOOK_QUEUE_SIZE
 
    *Optional*
 
-   An integer value to use for the queue size for audit Kafka targets.
+   An integer value to use for the queue size for audit webhook targets.
 
-   This variable corresponds to the :mc-conf:`audit_webhook kafka_queue_dir <audit_webhook.kafka_queue_dir>` configuration setting.
+   This variable corresponds to the :mc-conf:`audit_webhook queue_size <audit_webhook.queue_size>` configuration setting.
 
 Bucket Notifications
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Docs updates for persistent queues added in https://github.com/minio/minio/pull/17121

Kafka bit needs additional attention, see https://github.com/minio/docs/issues/886

Staged:
http://192.241.195.202:9000/staging/DOCS-860-part2/linux/html/reference/minio-server/minio-server.html#logging
http://192.241.195.202:9000/staging/DOCS-860-part2/linux/html/reference/minio-mc-admin/mc-admin-config.html#http-webhook-log-target

Partly addresses https://github.com/minio/docs/issues/860