### PR TITLE
Can remove a decommissioned pool as soon as it completes

### DIFF
--- a/source/operations/install-deploy-manage/decommission-server-pool.rst
+++ b/source/operations/install-deploy-manage/decommission-server-pool.rst
@@ -258,7 +258,7 @@ The example command begins decommissioning the matching server pool on the
 ``myminio`` deployment.
 
 During the decommissioning process, MinIO continues routing read operations
-(``GET``, ``LIST``, ``HEAD``) operations to the pool for those objects not
+(``GET``, ``LIST``, ``HEAD``) to the pool for those objects not
 yet migrated. MinIO routes all new write operations (``PUT``) to the
 remaining pools in the deployment.
 
@@ -316,7 +316,7 @@ errors.
 4) Remove the Decommissioned Pool from the Deployment Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once decommissioning completes, you can safely remove the pool from the
+As each pool completes decommissioning, you can safely remove it from the
 deployment configuration. Modify the startup command for each remaining MinIO
 server in the deployment and remove the decommissioned pool.
 


### PR DESCRIPTION
Docs update for a change in the server pool decommissioning process: you no longer have to wait for all pools to complete before removing the ones that are done. [Original PR](https://github.com/minio/minio/pull/17221)

Partly addresses https://github.com/minio/docs/issues/860