### PR TITLE
Fix docs for gateway/filesystem deployment migration

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -278,7 +278,7 @@ Glossary
 
    standalone deployment
      A :term:`single-node single-drive` (SNSD) MinIO deployment.
-     This term previously referred to the deprecated :ref:`Gateway and Filesystem Mode <minio-gateway-migration>` deployment types.
+     This term previously referred to the deprecated :ref:`Gateway or Filesystem Mode <minio-gateway-migration>` deployment types.
 
    SUBNET
      `MinIO's Subscription Network <https://min.io/pricing?jmp=docs>`__ tracks support tickets and provides 24 hour direct-to-engineer access for subscribed accounts.

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -275,7 +275,11 @@ Glossary
      A deployment uses a single external key to decrypt any object throughout the deployment.
 
      See also: :term:`SSE-KMS`, :term:`SSE-C`, :term:`encryption at rest`, :term:`network encryption`.
-   
+
+   standalone deployment
+     A :term:`single-node single-drive` (SNSD) MinIO deployment.
+     This term previously referred to the deprecated :ref:`Gateway and Filesystem Mode <minio-gateway-migration>` deployment types.
+
    SUBNET
      `MinIO's Subscription Network <https://min.io/pricing?jmp=docs>`__ tracks support tickets and provides 24 hour direct-to-engineer access for subscribed accounts.
 

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -95,11 +95,10 @@ Procedure
 
          Migrate configuration settings:
 
-	 If your deployment uses :ref:`environment variables <minio-server-environment-variables>` for configuration settings, copy the environment variables from the existing deployment's ``/etc/default/minio` file to the same file in the new deployment.
+	 If your deployment uses :ref:`environment variables <minio-server-environment-variables>` for configuration settings, copy the environment variables from the existing deployment's ``/etc/default/minio`` file to the same file in the new deployment.
          You may omit any ``MINIO_CACHE_*`` and ``MINIO_GATEWAY_SSE`` environment variables, as these are no longer used.                                                               
 
-	 If you use :mc-cmd:`mc admin config set <mc admin config set>` for configuration settings, duplicate the existing settings for the new deployment.
-         You can examine runtime settings using ``env | grep MINIO_`` or, for deployments using MinIO's systemd service, check the contents of ``/etc/default/minio``.
+	 If you use :mc-cmd:`mc admin config set <mc admin config set>` for configuration settings, duplicate the existing settings for the new deployment using the new MinIO Client.
 
       .. tab-item:: Filesystem mode
 

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -192,20 +192,6 @@ Procedure
             - Replace ``ALIAS`` with the alias for the new deployment.
             - Replace the name of the zip file with the name for the existing deployment's file.
 
-#. *(Optional)* Duplicate **tiers** from existing standalone deployment to new deployment with the existing MinIO Client.
-
-   Use :mc:`mc ilm tier ls` with the ``--json`` flag to retrieve a list of the tiers that exist on the standalone deployment.
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc ilm tier ls ALIAS --json
-
-   - Use the existing MinIO Client.
-   - Replace ``ALIAS`` with the alias for the existing standalone deployment.
-
-   Use the list to recreate the tiers on the new deployment.
-
 #. Migrate bucket contents with :mc:`mc mirror`.
 
    Use :mc:`mc mirror` with the :mc-cmd:`~mc mirror --preserve` and :mc-cmd:`~mc mirror --watch` flags on the standalone deployment to move objects to the new |SNSD| deployment with the existing MinIO Client

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -38,6 +38,9 @@ This document outlines the steps required to successfully launch and migrate to 
    Standalone/file system mode continues to work on any release up to and including MinIO Server `RELEASE.2022-10-24T18-35-07Z <https://github.com/minio/minio/releases/tag/RELEASE.2022-10-24T18-35-07Z>`__.
    To continue using a standalone deployment, install that MinIO Server release with MinIO Client `RELEASE.2022-10-29T10-09-23Z <https://github.com/minio/mc/releases/tag/RELEASE.2022-10-29T10-09-23Z>`__ or any `earlier release <https://github.com/minio/minio/releases>`__ with its corresponding MinIO Client. Note that the version of the MinIO Client should be newer and as close as possible to the version of the MinIO server.
 
+   Filesystem mode deployments must be on at least `RELEASE.2022-06-25T15-50-16Z <https://github.com/minio/minio/releases/tag/RELEASE.2022-06-25T15-50-16Z>`__  to use the MinIO Client import and export commands.
+   Filesystem mode deployments up to and including `RELEASE.2022-06-20T23-13-45Z <https://github.com/minio/minio/releases/tag/RELEASE.2022-06-20T23-13-45Z>`__ can be migrated by manually recreating users, policies, buckets, and other resources on the new deployment.
+
 
 Procedure
 ---------
@@ -48,6 +51,20 @@ Procedure
    Depending on your current deployment setup, you may need to retrieve the values for both.
 
    You can examine any runtime settings using ``env | grep MINIO_`` or, for deployments using MinIO's systemd service, check the contents of ``/etc/default/minio``.
+
+#. For filesystem mode deployments:
+
+   If needed, upgrade the existing deployment.
+
+   The oldest acceptable versions are:
+
+   - MinIO `RELEASE.2022-06-25T15-50-16Z <https://github.com/minio/minio/releases/tag/RELEASE.2022-06-25T15-50-16Z>`__
+   - MinIO Client `RELEASE.2022-06-26T18-51-48Z <https://github.com/minio/mc/releases/tag/RELEASE.2022-06-26T18-51-48Z>`__
+
+   The newest acceptable versions are:
+
+   - MinIO `RELEASE.2022-10-24T18-35-07Z <https://github.com/minio/minio/releases/tag/RELEASE.2022-10-24T18-35-07Z>`__
+   - MinIO Client `RELEASE.2022-10-29T10-09-23Z <https://github.com/minio/mc/releases/tag/RELEASE.2022-10-29T10-09-23Z>`__
 
 #. Create a new Single-Node Single-Drive MinIO deployment.
 

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -72,10 +72,14 @@ Procedure
    - Replace ``PATH`` with the IP address or hostname and port for the new deployment.
    - Replace ``ACCESSKEY`` and ``SECRETKEY`` with the credentials you used when creating the new deployment.
 
-   If you are migrating a `filesystem` deployment, continue to the next step.
-   For `standalone` deployments, skip to :ref:`migrate bucket contents <minio-gateway-migrate-bucket-contents>`.
+#. Standalone deployments: migrate environment variables
 
-#. Filestem Mode Deployments: Export the existing deployment's **configurations**.
+   Copy the :ref:`environment variables <minio-server-environment-variables>` from the existing deployment's ``/etc/default/minio`` file to the same file in the new deployment.
+   You may omit any ``MINIO_CACHE_*`` and ``MINIO_GATEWAY_SSE`` environment variables, as these are no longer used.
+
+   To continue migrating a `standalone` deployment, skip to :ref:`migrate bucket contents <minio-gateway-migrate-bucket-contents>`.
+
+#. Filesystem Mode Deployments: Export the existing deployment's **configurations**.
 
    Use the :mc-cmd:`mc admin config export <mc admin config export>` export command with the existing MinIO Client to retrieve the configurations defined for the existing standalone MinIO deployment.
 

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -58,7 +58,8 @@ Procedure
    If the existing standalone system points to the root of the drive, you must use a separate drive for the new deployment.
 
    If both old and new deployments are on the same host:
-
+   
+   - Install the new deployment to a different path from the existing deployment.
    - Set the new deployment's Console and API ports to different ports than the existing deployment.
 
      The following commandline options set the ports at startup:
@@ -71,7 +72,11 @@ Procedure
      - Duplicate the existing ``/etc/default/minio`` environment file with a unique name.
      - In the new deployment's service file, update ``EnvironmentFile`` to reference the new environment file.
 
-#. Add an alias for the deployment created in the previous step using :mc:`mc alias set` and the updated MinIO Client.
+   The steps below use the :mc-cmd:`mc` command line tool from both deployments.
+   *Existing MinIO Client* is :mc-cmd:`mc` from the old deployment.
+   *New MinIO Client* is :mc-cmd:`mc` from the new deployment.
+
+#. Add an alias for the deployment created in the previous step using :mc:`mc alias set` and the new MinIO Client.
 
    .. code-block:: shell
       :class: copyable
@@ -101,7 +106,7 @@ Procedure
 	 If you use :mc-cmd:`mc admin config set <mc admin config set>` for configuration settings, duplicate the existing settings for the new deployment using the new MinIO Client.
 
       .. tab-item:: Filesystem mode
-
+	 
          a. Export the existing deployment's **configurations**.
 
             Use the :mc-cmd:`mc admin config export <mc admin config export>` export command with the existing MinIO Client to retrieve the configurations defined for the existing standalone MinIO deployment.
@@ -137,7 +142,7 @@ Procedure
             - Use the new MinIO Client.
             - Replace ``ALIAS`` with the alias for the new deployment.
 
-         d. Export **bucket metadata** from existing standalone deployment with the existing MinIO Client.
+         d. Export **bucket metadata** from the existing standalone deployment with the existing MinIO Client.
 
             The following command exports bucket metadata from the existing deployment to a ``.zip`` file.
 
@@ -151,7 +156,7 @@ Procedure
             - versioning
 
             The export includes the bucket metadata only.
-            No objects export from the existing deployment with this command.
+            This command does not export objects from the existing deployment.
 
             .. code-block:: shell
                :class: copyable
@@ -232,7 +237,6 @@ Procedure
 #. Stop the server for both deployments.
 
 #. Restart the new MinIO deployment with the ports used for the previous standalone deployment.
-
-   Refer to step four in the deploy |SNSD| :ref:`documentation <deploy-minio-standalone>`.
+   For more about starting the MinIO service, refer to step four in the deploy |SNSD| :ref:`documentation <deploy-minio-standalone>`.
    
-   Ensure you apply all environment variables and runtime configuration settings, and validate the behavior.
+   Ensure you apply all environment variables and runtime configuration settings and validate the behavior of the new deployment.

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -29,7 +29,7 @@ Deployments still using the `standalone` or `filesystem` MinIO modes that upgrad
 Overview
 --------
 
-To upgrade to a :minio-release:`RELEASE.2022-10-29T06-21-33Z` or later, those who were using the `standalone` or `filesystem` deployment modes must create a new :ref:`Single-Node Single-Drive <minio-snsd>` deployment and migrate settings and content to the new deployment.
+To upgrade to the :minio-release:`RELEASE.2022-10-29T06-21-33Z` or later release, those who were using the `standalone` or `filesystem` deployment modes must create a new :ref:`Single-Node Single-Drive <minio-snsd>` deployment and migrate settings and content to the new deployment.
 
 This document outlines the steps required to successfully launch and migrate to a new deployment.
 
@@ -60,7 +60,7 @@ Procedure
 
    Set the port to a custom point different than the existing standalone deployment.
 
-#. Add an alias for the new deployment with :mc:`mc alias set` with the new MinIO Client from the previous step.
+#. Add an alias for the deployment created in the previous step using :mc:`mc alias set` and the updated MinIO Client.
 
    .. code-block:: shell
       :class: copyable
@@ -74,11 +74,15 @@ Procedure
 
 #. Migrate settings according to the type of deployment:
 
+   - The MinIO Gateway is a stateless proxy service that provides S3 API compatibility for an array of backend storage systems.
+
+   - Filesystem mode deployments provide an S3 access layer for a single MinIO server process and single storage volume.
+
    .. tab-set::
 
       .. tab-item:: Gateway
 
-         a. Migrate environment variables
+         Migrate environment variables:
 
             Copy the :ref:`environment variables <minio-server-environment-variables>` from the existing deployment's ``/etc/default/minio`` file to the same file in the new deployment.
             You may omit any ``MINIO_CACHE_*`` and ``MINIO_GATEWAY_SSE`` environment variables, as these are no longer used.

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -39,7 +39,6 @@ This document outlines the steps required to successfully launch and migrate to 
    To continue using a standalone deployment, install that MinIO Server release with MinIO Client `RELEASE.2022-10-29T10-09-23Z <https://github.com/minio/mc/releases/tag/RELEASE.2022-10-29T10-09-23Z>`__ or any `earlier release <https://github.com/minio/minio/releases>`__ with its corresponding MinIO Client. Note that the version of the MinIO Client should be newer and as close as possible to the version of the MinIO server.
 
 
-
 Procedure
 ---------
 
@@ -51,7 +50,7 @@ Procedure
    This procedure does not cover migrating environment variables due to the variety of configuration methods.
    You can examine any runtime settings using ``env | grep MINIO_`` or, for deployments using MinIO's systemd service, check the contents of ``/etc/default/minio``.
 
-#. Create a new Single-Node Single-Drive MinIO deployment
+#. Create a new Single-Node Single-Drive MinIO deployment.
 
    Refer to the :ref:`documentation for step-by-step instructions <deploy-minio-standalone>` for launching a new |SNSD| deployment.
 
@@ -61,7 +60,7 @@ Procedure
 
    Set the port to a custom point different than the existing standalone deployment.
 
-#. Add an alias for the new deployment with :mc:`mc alias set` with the new MinIO Client from the previous step
+#. Add an alias for the new deployment with :mc:`mc alias set` with the new MinIO Client from the previous step.
 
    .. code-block:: shell
       :class: copyable
@@ -73,7 +72,10 @@ Procedure
    - Replace ``PATH`` with the IP address or hostname and port for the new deployment.
    - Replace ``ACCESSKEY`` and ``SECRETKEY`` with the credentials you used when creating the new deployment.
 
-#. Export the existing deployment's **configurations**
+   If you are migrating a `filesystem` deployment, continue to the next step.
+   For `standalone` deployments, skip to :ref:`migrate bucket contents <minio-gateway-migrate-bucket-contents>`.
+
+#. Filestem Mode Deployments: Export the existing deployment's **configurations**.
 
    Use the :mc-cmd:`mc admin config export <mc admin config export>` export command with the existing MinIO Client to retrieve the configurations defined for the existing standalone MinIO deployment.
 
@@ -85,7 +87,7 @@ Procedure
    - Use the existing MinIO Client.
    - Replace ``ALIAS`` with the alias used for the existing standalone deployment you are retrieving values from. 
 
-#. Import **configurations** from existing standalone deployment to new deployment with the new MinIO Client
+#. Import **configurations** from existing standalone deployment to new deployment with the new MinIO Client.
 
    .. code-block:: shell
       :class: copyable
@@ -95,7 +97,7 @@ Procedure
    - Use the new MinIO Client.
    - Replace ``ALIAS`` with the alias for the new deployment.
 
-#. Restart the server for the new deployment with the new MinIO Client
+#. Restart the server for the new deployment with the new MinIO Client.
 
    .. code-block:: shell
       :class: copyable
@@ -105,7 +107,7 @@ Procedure
    - Use the new MinIO Client.
    - Replace ``ALIAS`` with the alias for the new deployment.
    
-#. Export **bucket metadata** from existing standalone deployment with the existing MinIO Client
+#. Export **bucket metadata** from existing standalone deployment with the existing MinIO Client.
 
    The following command exports bucket metadata from the existing deployment to a ``.zip`` file.
 
@@ -131,7 +133,7 @@ Procedure
 
    This command creates a ``cluster-metadata.zip`` file with metadata for each bucket.
 
-#. Import **bucket metadata** to the new deployment with the new MinIO Client
+#. Import **bucket metadata** to the new deployment with the new MinIO Client.
 
    The following command reads the contents of the exported bucket ``.zip`` file and creates buckets on the new deployment with the same configurations.
 
@@ -145,7 +147,7 @@ Procedure
 
    The command creates buckets on the new deployment with the same configurations as provided by the metadata in the .zip file from the existing deployment.
 
-#. *(Optional)* Duplicate **tiers** from existing standalone deployment to new deployment with the existing MinIO Client
+#. *(Optional)* Duplicate **tiers** from existing standalone deployment to new deployment with the existing MinIO Client.
 
    Use :mc:`mc ilm tier ls` with the ``--json`` flag to retrieve a list of the tiers that exist on the standalone deployment.
 
@@ -159,7 +161,7 @@ Procedure
    
    Use the list to recreate the tiers on the new deployment.
 
-#. Export **IAM settings** from the existing standalone deployment to new deployment with the existing MinIO Client
+#. Export **IAM settings** from the existing standalone deployment to new deployment with the existing MinIO Client.
 
    If you are using an external identity and access management provider, recreate those settings in the new deployment along with all associated policies.
 
@@ -181,7 +183,7 @@ Procedure
 
    This command creates a ``ALIAS-iam-info.zip`` file with IAM data.
 
-#. Import the **IAM settings** to the new deployment with the new MinIO Client:
+#. Import the **IAM settings** to the new deployment with the new MinIO Client.
 
    Use the exported file to create the IAM setting on the new deployment.
 
@@ -194,7 +196,11 @@ Procedure
    - Replace ``ALIAS`` with the alias for the new deployment.
    - Replace the name of the zip file with the name for the existing deployment's file.
 
-#. Use :mc:`mc mirror` with the :mc-cmd:`~mc mirror --preserve` and :mc-cmd:`~mc mirror --watch` flags on the standalone deployment to move objects to the new |SNSD| deployment with the existing MinIO Client
+   .. _minio-gateway-migrate-bucket-contents:
+
+#. Standalone deployments: migrate bucket contents with :mc:`mc mirror`.
+
+   Use :mc:`mc mirror` with the :mc-cmd:`~mc mirror --preserve` and :mc-cmd:`~mc mirror --watch` flags on the standalone deployment to move objects to the new |SNSD| deployment with the existing MinIO Client
 
    .. code-block:: shell
       :class: copyable
@@ -205,13 +211,13 @@ Procedure
    - Replace ``SOURCE/BUCKET`` with the alias and a bucket for the existing standalone deployment.
    - Replace ``TARGET/BUCKET`` with the alias and corresponding bucket for the new deployment.
 
-#. Stop writes to the standalone deployment from any S3 or POSIX client
+#. Stop writes to the standalone deployment from any S3 or POSIX client.
 
-#. Wait for ``mc mirror`` to complete for all buckets for any remaining operations
+#. Wait for ``mc mirror`` to complete for all buckets for any remaining operations.
 
-#. Stop the server for both deployments
+#. Stop the server for both deployments.
 
-#. Restart the new MinIO deployment with the ports used for the previous standalone deployment
+#. Restart the new MinIO deployment with the ports used for the previous standalone deployment.
 
    Refer to step four in the deploy |SNSD| :ref:`documentation <deploy-minio-standalone>`.
    

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -106,10 +106,15 @@ Procedure
 	 If you use :mc-cmd:`mc admin config set <mc admin config set>` for configuration settings, duplicate the existing settings for the new deployment using the new MinIO Client.
 
       .. tab-item:: Filesystem mode
-	 
+
+         .. note::
+
+            The following Filesystem mode steps presume the existing MinIO Client supports the needed export commands.
+	    If it does not, recreate users, policies, lifecycle rules, and buckets manually on the new deployment using the new MinIO Client.
+
          a. Export the existing deployment's **configurations**.
 
-            Use the :mc-cmd:`mc admin config export <mc admin config export>` export command with the existing MinIO Client to retrieve the configurations defined for the existing standalone MinIO deployment.
+            Use the :mc-cmd:`mc admin config export <mc admin config export>` command with the existing MinIO Client to retrieve the configurations defined for the existing standalone MinIO deployment.
 
             .. code-block:: shell
                :class: copyable

--- a/source/reference/minio-mc-admin/mc-admin-top.rst
+++ b/source/reference/minio-mc-admin/mc-admin-top.rst
@@ -24,9 +24,6 @@ Description
 The :mc-cmd:`mc admin top` command returns statistics for distributed
 MinIO deployments, similar to the output of the ``top`` command. 
 
-:mc-cmd:`mc admin top` is not supported on standalone MinIO deployments
-or MinIO Gateway deployments.
-
 .. end-mc-admin-top-desc
 
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only
@@ -59,7 +56,6 @@ Syntax
       the command retrieves statistics.
 
       The alias *must* correspond to a distributed (multi-node) MinIO deployment.
-      The command returns an error for standalone MinIO deployments or MinIO
-      Gateway deployments.
-
+      The command returns an error for :term:`single-node single-drive` deployments.
+      
 


### PR DESCRIPTION
The instructions to migrate a MinIO Gateway or filesystem mode deployment are incorrect. Separate out the steps that differ for each into tabs and clean up where needed. Several migration steps for filesystem mode don't apply to gateway, and tiers don't apply to either.

Staged:
http://192.241.195.202:9000/staging/DOCS-818/linux/html/operations/install-deploy-manage/migrate-fs-gateway.html

Fixes https://github.com/minio/docs/issues/818