### PR TITLE
mc ping --exit and mc admin user svcacct add/edit --expiry

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-add.rst
@@ -109,6 +109,22 @@ Parameters
    Add a description for the service account.
    For example, you might specify the reason the service account exists.
 
+.. mc-cmd:: --expiry
+   :optional:
+
+   .. versionadded:: RELEASE.2023-05-30T22-41-38Z
+
+   Set an expiration date for the service account.
+   The date must be in the future, you may not set an expiration date that has already passed.
+
+   Allowed date and time formats:
+
+   - ``2023-06-24``
+   - ``2023-06-24T10:00``
+   - ``2023-06-24T10:00:00``
+   - ``2023-06-24T10:00:00Z``
+   - ``2023-06-24T10:00:00-07:00``
+
 .. mc-cmd:: --name
    :optional:
 

--- a/source/reference/minio-mc-admin/mc-admin-user-svcacct-edit.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-svcacct-edit.rst
@@ -75,6 +75,22 @@ Parameters
    Add a description for the service account.
    For example, you might specify the reason the service account exists.
 
+.. mc-cmd:: --expiry
+   :optional:
+
+   .. versionadded:: RELEASE.2023-05-30T22-41-38Z
+
+   Set an expiration date for the service account.
+   The date must be in the future, you may not set an expiration date that has already passed.
+
+   Allowed date and time formats:
+
+   - ``2023-06-24``
+   - ``2023-06-24T10:00``
+   - ``2023-06-24T10:00:00``
+   - ``2023-06-24T10:00:00Z``
+   - ``2023-06-24T10:00:00-07:00``
+
 .. mc-cmd:: --name
    :optional:
 

--- a/source/reference/minio-mc/mc-ping.rst
+++ b/source/reference/minio-mc/mc-ping.rst
@@ -86,6 +86,13 @@ Parameters
 
       mc ping TARGET -e 5
 
+.. mc-cmd:: --exit
+   :optional:
+
+   .. versionadded:: RELEASE.2023-05-30T22-41-38Z
+      
+   Exit after the first successful check.
+
 .. mc-cmd:: --interval
    :optional:
 


### PR DESCRIPTION
Doc updates from [mc RELEASE.2023-05-30T22-41-38Z](https://github.com/minio/docs/issues/870):

[x] New --exit option for mc ping 
[x] Expiration date can be set when adding or editing a service account

Staged:
http://192.241.195.202:9000/staging/DOCS-870/linux/html/reference/minio-mc/mc-ping.html#mc.ping.-exit
http://192.241.195.202:9000/staging/DOCS-870/linux/html/reference/minio-mc-admin/mc-admin-user-svcacct-add.html#mc.admin.user.svcacct.add.-expiry
http://192.241.195.202:9000/staging/DOCS-870/linux/html/reference/minio-mc-admin/mc-admin-user-svcacct-edit.html#mc.admin.user.svcacct.edit.-expiry

Fixes https://github.com/minio/docs/issues/870