### PR TITLE
ftp call type for mc admin trace

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -125,6 +125,7 @@ Syntax
    - ``batch-replication``
    - ``bootstrap``
    - ``decommission``
+   - ``ftp``
    - ``healing``
    - ``internal``
    - ``os``


### PR DESCRIPTION
New `ftp` call type for `mc admin trace`.

Fixes https://github.com/minio/docs/issues/879