### PR TITLE
Fix syntax in mc version reference page

### DIFF
--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -15,8 +15,7 @@ Description
 
 .. start-mc-version-desc
 
-The :mc:`mc version` command enables, suspends, and retrieves the 
-:ref:`versioning <minio-bucket-versioning>` status for a MinIO bucket.
+The :mc:`mc version` command enables, suspends, and retrieves the :ref:`versioning <minio-bucket-versioning>` status for a MinIO bucket.
 
 .. end-mc-version-desc
 
@@ -24,8 +23,7 @@ The :mc:`mc version` command enables, suspends, and retrieves the
 
    .. tab-item:: EXAMPLE
 
-      The following command enables, suspends, and retrieves versioning
-      status for the ``mydata`` bucket on the ``myminio`` MinIO deployment:
+      The following command enables, suspends, and retrieves versioning status for the ``mydata`` bucket on the ``myminio`` MinIO deployment:
 
       .. code-block:: shell
          :class: copyable
@@ -55,8 +53,7 @@ Parameters
 .. mc-cmd:: ALIAS
    :required:
 
-   The :ref:`alias <alias>` of a MinIO deployment and the full path
-   to the bucket for which to set the versioning configuration. For example:
+   The :ref:`alias <alias>` of a MinIO deployment and the full path to the bucket for which to set the versioning configuration. For example:
 
    .. code-block:: shell
 
@@ -65,11 +62,9 @@ Parameters
 .. mc-cmd:: enable
    :optional:
 
-   Enables versioning on the MinIO bucket specified to
-   :mc-cmd:`ALIAS <mc version ALIAS>`.
+   Enables versioning on the MinIO bucket specified to :mc-cmd:`ALIAS <mc version ALIAS>`.
 
-   Mutually exclusive with :mc-cmd:`~mc version suspend` and
-   :mc-cmd:`~mc version info`
+   Mutually exclusive with :mc-cmd:`~mc version suspend` and :mc-cmd:`~mc version info`
 
 .. mc-cmd:: --exclude-folders
    :optional:
@@ -93,20 +88,16 @@ Parameters
 .. mc-cmd:: info
    :optional:
 
-   Returns the versioning status for the MinIO bucket specified to
-   :mc-cmd:`ALIAS <mc version ALIAS>`.
+   Returns the versioning status for the MinIO bucket specified to :mc-cmd:`ALIAS <mc version ALIAS>`.
 
-   Mutually exclusive with :mc-cmd:`~mc version suspend` and
-   :mc-cmd:`~mc version enable`
+   Mutually exclusive with :mc-cmd:`~mc version suspend` and :mc-cmd:`~mc version enable`
 
 .. mc-cmd:: suspend
    :optional:
 
-   Disables versioning on the MinIO bucket specified to
-   :mc-cmd:`ALIAS <mc version ALIAS>`.
+   Disables versioning on the MinIO bucket specified to :mc-cmd:`ALIAS <mc version ALIAS>`.
 
-   Mutually exclusive with :mc-cmd:`~mc version enable` and
-   :mc-cmd:`~mc version info`
+   Mutually exclusive with :mc-cmd:`~mc version enable` and :mc-cmd:`~mc version info`
 
 Global Flags
 ~~~~~~~~~~~~
@@ -128,11 +119,9 @@ Use :mc:`mc version enable` to enable versioning on a bucket:
 
    mc version enable ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the
-  :mc:`alias <mc alias>` of a configured MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which
-  to enable versioning.
+- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to enable versioning.
 
 Disable Bucket Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -144,11 +133,9 @@ Use :mc:`mc version suspend` to suspend versioning on a bucket:
 
    mc version suspend ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the
-  :mc:`alias <mc alias>` of a configured MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which
-  to suspend versioning.
+- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to suspend versioning.
 
 Get Bucket Versioning Status
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -160,11 +147,9 @@ Use :mc:`mc version info` to retrieve the versioning status for a bucket:
 
    mc version info ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the
-  :mc:`alias <mc alias>` of a configured MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which
-  to retrieve the versioning status.
+- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to retrieve the versioning status.
 
 Behavior
 --------
@@ -172,22 +157,17 @@ Behavior
 Object Locking Enables Bucket Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While bucket versioning is disabled by default, configuring
-object locking on a bucket or an object in that bucket automatically
-enables versioning for the bucket. See 
-:mc:`mc retention` for more information on configuring object locking.
+While bucket versioning is disabled by default, configuring object locking on a bucket or an object in that bucket automatically enables versioning for the bucket.
+See :mc:`mc retention` for more information on configuring object locking.
 
 Bucket Versioning with Existing Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enabling bucket versioning on a bucket with existing data immediately applies
-a versioning ID to any unversioned object.
+Enabling bucket versioning on a bucket with existing data immediately applies a versioning ID to any unversioned object.
 
-Disabling bucket versioning on a bucket with existing versioned data does
-*not* remove any versioned objects. Applications can continue to access
-versioned data after disabling bucket versioning. Use 
-:mc-cmd:`mc rm --versions ALIAS/BUCKET/OBJECT <mc rm --versions>` to delete an 
-object *and* all its versions.
+Disabling bucket versioning on a bucket with existing versioned data does *not* remove any versioned objects.
+Applications can continue to access versioned data after disabling bucket versioning.
+Use :mc-cmd:`mc rm --versions ALIAS/BUCKET/OBJECT <mc rm --versions>` to delete an object *and* all its versions.
 
 S3 Compatibility
 ~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -16,7 +16,7 @@ Description
 .. start-mc-version-desc
 
 The :mc:`mc version` command enables, suspends, and retrieves the 
-:ref:`versioning <minio-bucket-versioning>` configuration for a MinIO bucket.
+:ref:`versioning <minio-bucket-versioning>` status for a MinIO bucket.
 
 .. end-mc-version-desc
 
@@ -25,14 +25,14 @@ The :mc:`mc version` command enables, suspends, and retrieves the
    .. tab-item:: EXAMPLE
 
       The following command enables, suspends, and retrieves versioning
-      for the ``mydata`` bucket on the ``myminio`` MinIO deployment:
+      status for the ``mydata`` bucket on the ``myminio`` MinIO deployment:
 
       .. code-block:: shell
          :class: copyable
 
          mc version enable myminio/mydata
-         mc version info myminio/mydata
          mc version suspend myminio/mydata
+         mc version info myminio/mydata
 
    .. tab-item:: SYNTAX
 
@@ -93,11 +93,11 @@ Parameters
 .. mc-cmd:: info
    :optional:
 
-   Returns the versioning configuration for the MinIO bucket specified to
+   Returns the versioning status for the MinIO bucket specified to
    :mc-cmd:`ALIAS <mc version ALIAS>`.
 
    Mutually exclusive with :mc-cmd:`~mc version suspend` and
-   :mc-cmd:`~mc version info`
+   :mc-cmd:`~mc version enable`
 
 .. mc-cmd:: suspend
    :optional:
@@ -105,7 +105,7 @@ Parameters
    Disables versioning on the MinIO bucket specified to
    :mc-cmd:`ALIAS <mc version ALIAS>`.
 
-   Mutually exclusive with :mc-cmd:`~mc version suspend` and
+   Mutually exclusive with :mc-cmd:`~mc version enable` and
    :mc-cmd:`~mc version info`
 
 Global Flags
@@ -121,12 +121,12 @@ Examples
 Enable Bucket Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc version suspend` to enable versioning on a bucket:
+Use :mc:`mc version enable` to enable versioning on a bucket:
 
 .. code-block:: shell
    :class: copyable
 
-   mc version ALIAS/PATH
+   mc version enable ALIAS/PATH
 
 - Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the
   :mc:`alias <mc alias>` of a configured MinIO deployment.
@@ -142,7 +142,7 @@ Use :mc:`mc version suspend` to suspend versioning on a bucket:
 .. code-block:: shell
    :class: copyable
 
-   mc version ALIAS/PATH
+   mc version suspend ALIAS/PATH
 
 - Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the
   :mc:`alias <mc alias>` of a configured MinIO deployment.
@@ -153,12 +153,12 @@ Use :mc:`mc version suspend` to suspend versioning on a bucket:
 Get Bucket Versioning Status
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc version info` to enable versioning on a bucket:
+Use :mc:`mc version info` to retrieve the versioning status for a bucket:
 
 .. code-block:: shell
    :class: copyable
 
-   mc version ALIAS/PATH
+   mc version info ALIAS/PATH
 
 - Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the
   :mc:`alias <mc alias>` of a configured MinIO deployment.


### PR DESCRIPTION
Fix incorrect commands syntax detail.

Includes a general reformat. For just the items noted in the issue, see the first commit. 

Staged:
http://192.241.195.202:9000/staging/DOCS-916/linux/html/reference/minio-mc/mc-version.html
Fixes  https://github.com/minio/docs/issues/916