### PR TITLE
split mc version into subcommand pages

### DIFF
--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -65,7 +65,7 @@ Clients therefore drive the overall hierarchy of data within a given bucket or p
 .. cond:: windows
 
    Unlike filenames on a Windows system, object names in MinIO cannot have a ``\`` character.
-   Use ``/`` as a delimiter in object names to have MinIO automatically create a folder structure using :term:`prefixes`.
+   Use ``/`` as a delimiter in object names to have MinIO automatically create a folder structure using :term:`prefixes <prefix>`.
 
 MinIO has no hard :ref:`thresholds <minio-server-limits>` on the number of buckets, objects, or prefixes on a given deployment.
 The relative performance of the hardware and networking underlying the MinIO deployment may create a practical limit to the number of objects in a given prefix or bucket.

--- a/source/administration/object-management/object-retention.rst
+++ b/source/administration/object-management/object-retention.rst
@@ -234,7 +234,7 @@ the MinIO :mc:`mc` CLI, or using an S3-compatible SDK.
         MinIO deployment.
 
       - Replace ``BUCKET`` with the 
-        :mc-cmd:`name <mc version ALIAS>` of the bucket to create.
+        :mc-cmd:`name <mc mb ALIAS>` of the bucket to create.
 
 Configure Bucket-Default Object Retention
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -258,7 +258,7 @@ using an S3-compatible SDK.
 
    .. tab-item:: MinIO CLI
 
-      Use the :mc-cmd:`mc version enable` command to enable versioning on an 
+      Use the :mc:`mc version enable` command to enable versioning on an 
       existing bucket:
 
       .. code-block:: shell
@@ -270,7 +270,7 @@ using an S3-compatible SDK.
         MinIO deployment.
 
       - Replace ``BUCKET`` with the 
-        :mc-cmd:`target bucket <mc version ALIAS>` on which to enable
+        :mc-cmd:`target bucket <mc mb ALIAS>` on which to enable
         versioning.
 
 Objects created prior to enabling versioning have a 
@@ -291,7 +291,7 @@ This is useful for Spark/Hadoop workloads or others that initially create object
 
    MinIO does not support excluding prefixes from versioning on buckets with :ref:`object locking enabled <minio-object-locking>`.
 
-- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version --excluded-prefixes` option:
+- Use :mc:`mc version enable` with the :mc-cmd:`~mc version enable --excluded-prefixes` option:
 
   .. code-block:: shell
      :class: copyable
@@ -302,7 +302,7 @@ This is useful for Spark/Hadoop workloads or others that initially create object
 
   - Replace ``BUCKET`` with the name of the :s3-docs:`bucket <UsingBucket.html>` you want to exclude :ref:`prefixes <minio-admin-concepts-organize-objects>` for.
 
-The list of :mc-cmd:`~mc version --excluded-prefixes` prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``prefix*``.
+The list of :mc-cmd:`~mc version enable --excluded-prefixes` prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``prefix*``.
 To match objects by prefix only, use ``prefix/*``.
 
 For example, the following command excludes any objects containing ``_test`` or ``_temp`` in their prefix or name from versioning:
@@ -313,10 +313,10 @@ For example, the following command excludes any objects containing ``_test`` or 
      mc version enable --excluded-prefixes "_test, _temp" local/my-bucket
 
 You can exclude up to 10 prefixes for each bucket.
-To add or remove prefixes, repeat the :mc-cmd:`mc version enable` command with an updated list.
+To add or remove prefixes, repeat the :mc:`mc version enable` command with an updated list.
 The new list of prefixes replaces the previous one.
 
-To view the currently excluded prefixes, use :mc-cmd:`mc version info` with the ``--JSON`` option:
+To view the currently excluded prefixes, use :mc:`mc version info` with the ``--JSON`` option:
 
   .. code-block:: shell
      :class: copyable
@@ -341,7 +341,7 @@ The command output resembles the following, with the list of excluded prefixes i
       }
      }
 
-To disable prefix exclusion and resume versioning all prefixes, repeat the :mc-cmd:`mc version enable` command without :mc-cmd:`~mc version --excluded-prefixes`:
+To disable prefix exclusion and resume versioning all prefixes, repeat the :mc:`mc version enable` command without :mc-cmd:`~mc version enable --excluded-prefixes`:
 
   .. code-block:: shell
      :class: copyable
@@ -367,7 +367,7 @@ You can exclude folders from versioning using the :ref:`MinIO Client <minio-clie
 
    Buckets with :ref:`object locking enabled <minio-object-locking>` require versioning and do not support excluding folders.
 
-- Use :mc-cmd:`mc version enable` with the :mc-cmd:`~mc version --exclude-folders` option to exclude objects with names ending in ``/`` from versioning:
+- Use :mc:`mc version enable` with the :mc-cmd:`~mc version enable --exclude-folders` option to exclude objects with names ending in ``/`` from versioning:
 
   .. code-block:: shell
      :class: copyable
@@ -378,7 +378,7 @@ You can exclude folders from versioning using the :ref:`MinIO Client <minio-clie
 
   - Replace ``BUCKET`` with the :s3-docs:`bucket <UsingBucket.html>` you want to exclude :ref:`folders <minio-admin-concepts-organize-objects>` for.
 
-To check whether folders are versioned for a bucket, use the :mc-cmd:`mc version enable` command with the ``--json`` option.
+To check whether folders are versioned for a bucket, use the :mc:`mc version enable` command with the ``--json`` option.
 If the ``ExcludeFolders`` property is ``true``, folders in that bucket are not versioned.
 
   .. code-block:: shell
@@ -402,7 +402,7 @@ The command output resembles the following:
       }
      }
 
-To disable folder exclusion and resume versioning all folders, repeat the :mc-cmd:`mc version enable` command without :mc-cmd:`~mc version --exclude-folders`:
+To disable folder exclusion and resume versioning all folders, repeat the :mc:`mc version enable` command without :mc-cmd:`~mc version enable --exclude-folders`:
 
   .. code-block:: shell
      :class: copyable
@@ -441,7 +441,7 @@ MinIO :mc:`mc` CLI, or using an S3-compatible SDK.
 
    .. tab-item:: MinIO CLI
 
-      Use the :mc-cmd:`mc version suspend` command to enable versioning on an 
+      Use the :mc:`mc version suspend` command to enable versioning on an 
       existing bucket:
 
       .. code-block:: shell
@@ -453,7 +453,7 @@ MinIO :mc:`mc` CLI, or using an S3-compatible SDK.
         MinIO deployment.
 
       - Replace ``BUCKET`` with the 
-        :mc-cmd:`target bucket <mc version ALIAS>` on which to disable
+        :mc-cmd:`target bucket <mc mb ALIAS>` on which to disable
         versioning.
 
 Objects created while versioning is suspended are assigned a ``null`` :ref:`version ID <minio-bucket-versioning-id>`. 

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -270,7 +270,7 @@ using an S3-compatible SDK.
         MinIO deployment.
 
       - Replace ``BUCKET`` with the 
-        :mc-cmd:`target bucket <mc mb ALIAS>` on which to enable
+        :mc-cmd:`target bucket <mc version enable ALIAS>` on which to enable
         versioning.
 
 Objects created prior to enabling versioning have a 

--- a/source/includes/common-replication.rst
+++ b/source/includes/common-replication.rst
@@ -27,8 +27,8 @@ To configure replication between arbitrary S3-compatible services, use :mc:`mc m
 
 MinIO relies on the immutability protections provided by :ref:`versioning <minio-bucket-versioning>` to support replication and resynchronization.
 
-Use :mc-cmd:`mc version info` to validate the versioning status of both the source and remote buckets. 
-Use the :mc-cmd:`mc version enable` command to enable versioning as necessary.
+Use :mc:`mc version info` to validate the versioning status of both the source and remote buckets. 
+Use the :mc:`mc version enable` command to enable versioning as necessary.
 
 If you exclude a prefix or folder from versioning within the source bucket, MinIO cannot replicate objects within that folder or prefix.
 

--- a/source/includes/container/installation.rst
+++ b/source/includes/container/installation.rst
@@ -56,7 +56,7 @@ MinIO provides container images at the following repositories:
 .. versionchanged:: RELEASE.2022-12-02T19-19-22Z
 
    These images include the :ref:`MinIO Client <minio-client>` command line tool built in for container-level debugging.
-   However, to regularly interact with a container MinIO install, :ref:`install the MinIO Client <mc-install>` on your computer and define an :mc-cmd:`mc alias set <alias>` to the container instead.
+   However, to regularly interact with a container MinIO install, :ref:`install the MinIO Client <mc-install>` on your computer and define an :mc:`alias <mc alias set>` to the container instead.
 
 Use of MinIO images from any other repository, host, or organization is at your own risk.
 

--- a/source/operations/install-deploy-manage/migrate-fs-gateway.rst
+++ b/source/operations/install-deploy-manage/migrate-fs-gateway.rst
@@ -89,9 +89,9 @@ Procedure
      - Duplicate the existing ``/etc/default/minio`` environment file with a unique name.
      - In the new deployment's service file, update ``EnvironmentFile`` to reference the new environment file.
 
-   The steps below use the :mc-cmd:`mc` command line tool from both deployments.
-   *Existing MinIO Client* is :mc-cmd:`mc` from the old deployment.
-   *New MinIO Client* is :mc-cmd:`mc` from the new deployment.
+   The steps below use the :mc:`mc` command line tool from both deployments.
+   *Existing MinIO Client* is :mc:`mc` from the old deployment.
+   *New MinIO Client* is :mc:`mc` from the new deployment.
 
 #. Add an alias for the deployment created in the previous step using :mc:`mc alias set` and the new MinIO Client.
 
@@ -151,8 +151,8 @@ Procedure
             - Use the new MinIO Client.
             - Replace ``ALIAS`` with the alias for the new deployment.
 
-	    If :mc:`~mc admin config import` reports an error for a configuration key, comment it out with ``#`` at the beginning of the relevant line and try again.
-            When you are finished migrating the deployment, verify the current syntax for the target MinIO Server version and set any needed keys manually using :mc:`mc admin config set`.
+	    If :mc-cmd:`~mc admin config import` reports an error for a configuration key, comment it out with ``#`` at the beginning of the relevant line and try again.
+            When you are finished migrating the deployment, verify the current syntax for the target MinIO Server version and set any needed keys manually using :mc-cmd:`mc admin config set`.
 
          c. Restart the server for the new deployment with the new MinIO Client.
 

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -417,7 +417,9 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-update-desc
           :end-before: end-mc-update-desc
      
-   * - :mc:`mc version`
+   * - | :mc:`mc version enable`
+       | :mc:`mc version info`
+       | :mc:`mc version suspend`
      - .. include:: /reference/minio-mc/mc-version.rst
           :start-after: start-mc-version-desc
           :end-before: end-mc-version-desc

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -351,9 +351,9 @@ Use the :mc:`mc version enable` command to enable versioning on *both* the sourc
 
    mc version enable ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of the MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc version enable ALIAS>` with the :mc:`alias <mc alias>` of the MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to enable versioning.
+- Replace :mc-cmd:`PATH <mc version enable ALIAS>` with the bucket on which to enable versioning.
 
 Required Permissions
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-version-enable.rst
+++ b/source/reference/minio-mc/mc-version-enable.rst
@@ -1,0 +1,126 @@
+.. _minio-mc-version-enable:
+
+=====================
+``mc version enable``
+=====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc version enable
+
+
+Syntax
+------
+
+.. start-mc-version-enable-desc
+
+The :mc:`mc version enable` command enables versioning on the specified bucket.
+
+.. end-mc-version-enable-desc
+
+Mutually exclusive with :mc-cmd:`~mc version suspend` and :mc-cmd:`~mc version info`.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command enables versioning for the ``mybucket`` bucket on the ``myminio`` MinIO deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+          mc version enable myminio/mybucket
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] version enable ALIAS                \
+	                                 --exclude-folders    \
+					 --excluded-prefixes
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of a MinIO deployment and the full path to the bucket for which to enable versioning. For example:
+
+   .. code-block:: shell
+
+      mc version enable myminio/mybucket
+
+.. mc-cmd:: --exclude-folders
+   :optional:
+
+   Disable versioning on all folders (objects whose name ends with ``/``) in the specified bucket.
+
+.. mc-cmd:: --excluded-prefixes
+   :optional:
+
+   Disable versioning on objects matching a list of prefixes, up to 10.
+   The list of prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``prefix*``.
+   To match objects by prefix only, use ``prefix/*``.
+
+   For example, the following command excludes any objects containing ``_test`` or ``_temp`` in their prefix or name from versioning:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc version enable --excluded-prefixes "_test, _temp" myminio/mybucket
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Example
+-------
+
+Enable Bucket Versioning
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc version enable` to enable versioning for a bucket:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc version enable ALIAS/PATH
+
+- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
+
+- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to enable versioning.
+
+
+Behavior
+--------
+
+Bucket Versioning with Existing Data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enabling bucket versioning on a bucket with existing data immediately applies a versioning ID to any unversioned object.
+
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-version-enable.rst
+++ b/source/reference/minio-mc/mc-version-enable.rst
@@ -22,8 +22,6 @@ The :mc:`mc version enable` command enables versioning on the specified bucket.
 
 .. end-mc-version-enable-desc
 
-Mutually exclusive with :mc-cmd:`~mc version suspend` and :mc-cmd:`~mc version info`.
-
 .. tab-set::
 
    .. tab-item:: EXAMPLE

--- a/source/reference/minio-mc/mc-version-enable.rst
+++ b/source/reference/minio-mc/mc-version-enable.rst
@@ -104,9 +104,9 @@ Use :mc:`mc version enable` to enable versioning for a bucket:
 
    mc version enable ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc version enable ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to enable versioning.
+- Replace :mc-cmd:`PATH <mc version enable ALIAS>` with the bucket on which to enable versioning.
 
 
 Behavior

--- a/source/reference/minio-mc/mc-version-info.rst
+++ b/source/reference/minio-mc/mc-version-info.rst
@@ -22,8 +22,6 @@ The :mc:`mc version info` command returns the versioning status for the specifie
 
 .. end-mc-version-info-desc
 
-Mutually exclusive with :mc-cmd:`~mc version suspend` and :mc-cmd:`~mc version enable`.
-
 .. tab-set::
 
    .. tab-item:: EXAMPLE

--- a/source/reference/minio-mc/mc-version-info.rst
+++ b/source/reference/minio-mc/mc-version-info.rst
@@ -1,0 +1,99 @@
+.. _minio-mc-version-info:
+
+===================
+``mc version info``
+===================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc version info
+
+
+Syntax
+------
+
+.. start-mc-version-info-desc
+
+The :mc:`mc version info` command returns the versioning status for the specified bucket.
+
+.. end-mc-version-info-desc
+
+Mutually exclusive with :mc-cmd:`~mc version suspend` and :mc-cmd:`~mc version enable`.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command returns the versioning status for the ``mybucket`` bucket on the ``myminio`` MinIO deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc version info myminio/mybucket
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] version info ALIAS
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+
+   The full path to the bucket on which to retrieve the versioning status.
+   For example:
+
+   .. code-block:: shell
+
+      mc version info myminio/mybucket
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Example
+-------
+
+Get Bucket Versioning Status
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc version info` to retrieve the versioning status for a bucket:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc version info ALIAS/PATH
+
+- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
+
+- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to retrieve the versioning status.
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-version-info.rst
+++ b/source/reference/minio-mc/mc-version-info.rst
@@ -83,9 +83,9 @@ Use :mc:`mc version info` to retrieve the versioning status for a bucket:
 
    mc version info ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc version info ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to retrieve the versioning status.
+- Replace :mc-cmd:`PATH <mc version info ALIAS>` with the bucket on which to retrieve the versioning status.
 
 
 Behavior

--- a/source/reference/minio-mc/mc-version-suspend.rst
+++ b/source/reference/minio-mc/mc-version-suspend.rst
@@ -1,0 +1,107 @@
+.. _minio-mc-version-suspend:
+
+======================
+``mc version suspend``
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc version suspend
+
+
+Syntax
+------
+
+.. start-mc-version-suspend-desc
+
+The :mc:`mc version suspend` command disables versioning on the specified bucket.
+
+.. end-mc-version-suspend-desc
+
+Mutually exclusive with :mc-cmd:`~mc version info` and :mc-cmd:`~mc version enable`.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command disables versioning for the ``mybucket`` bucket on the ``myminio`` MinIO deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc version suspend myminio/mybucket
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] version suspend ALIAS
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+
+   The full path to the bucket on which to disable versioning.
+   For example:
+
+   .. code-block:: shell
+
+      mc version suspend myminio/mybucket
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Example
+-------
+
+Disable Bucket Versioning
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc version suspend` to disable versioning for a bucket:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc version suspend ALIAS/PATH
+
+- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
+
+- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to disable versioning.
+
+
+Behavior
+--------
+
+Bucket Versioning with Existing Data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Disabling bucket versioning on a bucket with existing versioned data does *not* remove any versioned objects.
+Applications can continue to access versioned data after disabling bucket versioning.
+Use :mc-cmd:`mc rm --versions ALIAS/BUCKET/OBJECT <mc rm --versions>` to delete an object *and* all its versions.
+
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-version-suspend.rst
+++ b/source/reference/minio-mc/mc-version-suspend.rst
@@ -22,8 +22,6 @@ The :mc:`mc version suspend` command disables versioning on the specified bucket
 
 .. end-mc-version-suspend-desc
 
-Mutually exclusive with :mc-cmd:`~mc version info` and :mc-cmd:`~mc version enable`.
-
 .. tab-set::
 
    .. tab-item:: EXAMPLE

--- a/source/reference/minio-mc/mc-version-suspend.rst
+++ b/source/reference/minio-mc/mc-version-suspend.rst
@@ -83,9 +83,9 @@ Use :mc:`mc version suspend` to disable versioning for a bucket:
 
    mc version suspend ALIAS/PATH
 
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
+- Replace :mc-cmd:`ALIAS <mc version suspend ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
 
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to disable versioning.
+- Replace :mc-cmd:`PATH <mc version suspend ALIAS>` with the bucket on which to disable versioning.
 
 
 Behavior

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -19,6 +19,8 @@ The :mc:`mc version` commands enable, disable, and retrieve the :ref:`versioning
 
 .. end-mc-version-desc
 
+For more information about object versioning in MinIO, see :ref:`minio-bucket-versioning`.
+
 :mc:`mc version` includes the following subcommands:
 
 .. list-table::

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -15,141 +15,35 @@ Description
 
 .. start-mc-version-desc
 
-The :mc:`mc version` command enables, suspends, and retrieves the :ref:`versioning <minio-bucket-versioning>` status for a MinIO bucket.
+The :mc:`mc version` commands enable, disable, and retrieve the :ref:`versioning <minio-bucket-versioning>` status for a MinIO bucket.
 
 .. end-mc-version-desc
 
-.. tab-set::
+:mc:`mc version` includes the following subcommands:
 
-   .. tab-item:: EXAMPLE
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
 
-      The following command enables, suspends, and retrieves versioning status for the ``mydata`` bucket on the ``myminio`` MinIO deployment:
+   * - Subcommand
+     - Description
 
-      .. code-block:: shell
-         :class: copyable
+   * - :mc:`~mc version enable`
+     - .. include:: /reference/minio-mc/mc-version-enable.rst
+          :start-after: start-mc-version-enable-desc
+          :end-before: end-mc-version-enable-desc
 
-         mc version enable myminio/mydata
-         mc version suspend myminio/mydata
-         mc version info myminio/mydata
+   * - :mc:`~mc version info`
+     - .. include:: /reference/minio-mc/mc-version-info.rst
+          :start-after: start-mc-version-info-desc
+          :end-before: end-mc-version-info-desc
 
-   .. tab-item:: SYNTAX
+   * - :mc:`~mc version suspend`
+     - .. include:: /reference/minio-mc/mc-version-suspend.rst
+          :start-after: start-mc-version-suspend-desc
+          :end-before: end-mc-version-suspend-desc
 
-      The command has the following syntax:
-
-      .. code-block:: shell
-         :class: copyable
-
-         mc [GLOBALFLAGS] version                    \
-                          [enable | suspend | info]  \
-                          ALIAS
-
-      .. include:: /includes/common-minio-mc.rst
-         :start-after: start-minio-syntax
-         :end-before: end-minio-syntax
-
-Parameters
-~~~~~~~~~~
-
-.. mc-cmd:: ALIAS
-   :required:
-
-   The :ref:`alias <alias>` of a MinIO deployment and the full path to the bucket for which to set the versioning configuration. For example:
-
-   .. code-block:: shell
-
-      mc version enable myminio/mybucket
-
-.. mc-cmd:: enable
-   :optional:
-
-   Enables versioning on the MinIO bucket specified to :mc-cmd:`ALIAS <mc version ALIAS>`.
-
-   Mutually exclusive with :mc-cmd:`~mc version suspend` and :mc-cmd:`~mc version info`
-
-.. mc-cmd:: --exclude-folders
-   :optional:
-
-   Use with :mc-cmd:`mc version enable` to disable versioning on all folders (objects whose name ends with ``/``) in the specified bucket.
-
-.. mc-cmd:: --excluded-prefixes
-   :optional:
-
-   Use with :mc-cmd:`mc version enable` to disable versioning on objects matching a list of prefixes, up to 10.
-   The list of prefixes match all objects containing the specified strings in their prefix or name, similar to a regular expression of the form ``prefix*``.
-   To match objects by prefix only, use ``prefix/*``.
-
-   For example, the following command excludes any objects containing ``_test`` or ``_temp`` in their prefix or name from versioning:
-
-   .. code-block:: shell
-      :class: copyable
-
-      mc version enable --excluded-prefixes "_test, _temp" local/my-bucket
-
-.. mc-cmd:: info
-   :optional:
-
-   Returns the versioning status for the MinIO bucket specified to :mc-cmd:`ALIAS <mc version ALIAS>`.
-
-   Mutually exclusive with :mc-cmd:`~mc version suspend` and :mc-cmd:`~mc version enable`
-
-.. mc-cmd:: suspend
-   :optional:
-
-   Disables versioning on the MinIO bucket specified to :mc-cmd:`ALIAS <mc version ALIAS>`.
-
-   Mutually exclusive with :mc-cmd:`~mc version enable` and :mc-cmd:`~mc version info`
-
-Global Flags
-~~~~~~~~~~~~
-
-.. include:: /includes/common-minio-mc.rst
-   :start-after: start-minio-mc-json-globals
-   :end-before: end-minio-mc-json-globals
-
-Examples
---------
-
-Enable Bucket Versioning
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use :mc:`mc version enable` to enable versioning on a bucket:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc version enable ALIAS/PATH
-
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
-
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to enable versioning.
-
-Disable Bucket Versioning
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use :mc:`mc version suspend` to suspend versioning on a bucket:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc version suspend ALIAS/PATH
-
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
-
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to suspend versioning.
-
-Get Bucket Versioning Status
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use :mc:`mc version info` to retrieve the versioning status for a bucket:
-
-.. code-block:: shell
-   :class: copyable
-
-   mc version info ALIAS/PATH
-
-- Replace :mc-cmd:`ALIAS <mc version ALIAS>` with the :mc:`alias <mc alias>` of a configured MinIO deployment.
-
-- Replace :mc-cmd:`PATH <mc version ALIAS>` with the bucket on which to retrieve the versioning status.
 
 Behavior
 --------
@@ -175,3 +69,11 @@ S3 Compatibility
 .. include:: /includes/common-minio-mc.rst
    :start-after: start-minio-mc-s3-compatibility
    :end-before: end-minio-mc-s3-compatibility
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   /reference/minio-mc/mc-version-enable
+   /reference/minio-mc/mc-version-info
+   /reference/minio-mc/mc-version-suspend


### PR DESCRIPTION
Addresses potential confusion about required/optional and the several mutually exclusive options.

Staged:
http://192.241.195.202:9000/staging/DOCS-918/linux/html/reference/minio-mc/mc-version.html
http://192.241.195.202:9000/staging/DOCS-918/linux/html/reference/minio-mc/mc-version-enable.html
http://192.241.195.202:9000/staging/DOCS-918/linux/html/reference/minio-mc/mc-version-info.html
http://192.241.195.202:9000/staging/DOCS-918/linux/html/reference/minio-mc/mc-version-suspend.html

Fixes https://github.com/minio/docs/issues/918