### PR TITLE
Document audit kafka queue config/envvars

### DIFF
--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -1124,6 +1124,22 @@ A comment to associate with the configuration.
 
 .. end-minio-kafka-audit-logging-comment-desc
 
+.. start-minio-kafka-audit-logging-queue-dir-desc
+
+Specify the directory path to enable MinIO's persistent event store for
+undelivered messages, such as ``/opt/minio/events``.
+
+MinIO stores undelivered events in the specified store while the Kafka
+service is offline and replays the stored events when connectivity resumes.
+
+.. end-minio-kafka-audit-logging-queue-dir-desc
+
+.. start-minio-kafka-audit-logging-queue-size-desc
+
+Specify the maximum limit for undelivered messages. Defaults to ``100000``.
+
+.. end-minio-kafka-audit-logging-queue-size-desc
+
 .. start-minio-data-compression-allow_encryption-desc
 
 Set to ``on`` to encrypt objects after compressing them.

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -477,6 +477,26 @@ Kafka Audit Log Target
 
       This setting corresponds to the :envvar:`MINIO_AUDIT_KAFKA_COMMENT` environment variable.
 
+   .. mc-conf:: queue_dir
+      :optional:
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-kafka-audit-logging-queue-dir-desc
+         :end-before: end-minio-kafka-audit-logging-queue-dir-desc
+
+      This setting corresponds to the :envvar:`MINIO_AUDIT_KAFKA_QUEUE_DIR` environment variable.
+
+   .. mc-conf::	queue_size
+      :optional:
+      :delimiter: " "
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-kafka-audit-logging-queue-size-desc
+         :end-before: end-minio-kafka-audit-logging-queue-size-desc
+
+      This setting corresponds to the :envvar:`MINIO_AUDIT_KAFKA_QUEUE_SIZE` environment variable.
+
 .. _minio-server-config-bucket-notification-amqp:
 
 AMQP Service for Bucket Notifications

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -941,6 +941,25 @@ The following section documents environment variables for configuring MinIO to p
 
    This environment variable corresponds to the :mc-conf:`audit_kafka.comment` configuration setting.
 
+.. envvar:: MINIO_AUDIT_KAFKA_QUEUE_DIR
+   :optional:
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-kafka-audit-logging-queue-dir-desc
+      :end-before: end-minio-kafka-audit-logging-queue-dir-desc
+
+   This environment variable corresponds to the :mc-conf:`audit_kafka.queue_dir` configuration setting.
+
+.. envvar:: MINIO_AUDIT_KAFKA_QUEUE_SIZE
+   :optional:
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-kafka-audit-logging-queue-size-desc
+      :end-before: end-minio-kafka-audit-logging-queue-size-desc
+
+   This environment variable corresponds to the :mc-conf:`audit_kafka.queue_size` configuration setting.
+
+
 Bucket Notifications
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add audit_kafka `queue_dir`, `queue_size`, and their corresponding envvars.

See https://github.com/minio/docs/issues/886 and https://github.com/minio/docs/pull/906 for related updates.

Staged:
http://192.241.195.202:9000/staging/DOCS-860-part-n/linux/html/reference/minio-server/minio-server.html#envvar.MINIO_AUDIT_KAFKA_QUEUE_DIR
http://192.241.195.202:9000/staging/DOCS-860-part-n/linux/html/reference/minio-mc-admin/mc-admin-config.html#mc-conf.audit_kafka.queue_dir

Fixes https://github.com/minio/docs/issues/860 (final item)