### PR TITLE
Correct ChaCha20Poly-1305 to ChaCha20-Poly1305

### DIFF
--- a/source/administration/server-side-encryption.rst
+++ b/source/administration/server-side-encryption.rst
@@ -182,7 +182,7 @@ The MinIO server uses the following cryptographic primitive implementations:
      - HMAC-SHA-256 
 
    * - :ref:`AEAD <minio-encryption-sse-content-encryption>` 
-     - ``ChaCha20Poly-1305`` by default. 
+     - ``ChaCha20-Poly1305`` by default. 
      
        ``AES-256-GCM`` for x86-64 CPUs with the AES-NI extension.
 


### PR DESCRIPTION
It's [ChaCha20-Poly1305](https://en.wikipedia.org/wiki/ChaCha20-Poly1305), not ChaCha20Poly-1305. Sorry a little bit OCD.