### PR TITLE
Updating fstab and minio.service path

### DIFF
--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -189,11 +189,18 @@ For example:
 
    $ nano /etc/fstab
 
-     # <file system>  <mount point>  <type>  <options>                <dump>  <pass>
-     LABEL=DISK1      /mnt/disk1     xfs     defaults,noatime,nofail  0       2
-     LABEL=DISK2      /mnt/disk2     xfs     defaults,noatime,nofail  0       2
-     LABEL=DISK3      /mnt/disk3     xfs     defaults,noatime,nofail  0       2
-     LABEL=DISK4      /mnt/disk4     xfs     defaults,noatime,nofail  0       2
+     # <file system>  <mount point>  <type>  <options>         <dump>  <pass>
+     LABEL=DISK1      /mnt/disk1     xfs     defaults,noatime  0       2
+     LABEL=DISK2      /mnt/disk2     xfs     defaults,noatime  0       2
+     LABEL=DISK3      /mnt/disk3     xfs     defaults,noatime  0       2
+     LABEL=DISK4      /mnt/disk4     xfs     defaults,noatime  0       2
+
+.. note:: 
+
+   For certain cloud environments (Amazon i3, for example), MinIO recommends also setting the ``nofail`` option in ``/etc/fstab``.
+   Cloud instances that do not configure this option may become inaccessible.
+   Setting ``nofail`` in these situations allows continued access to the instance to allow you to rectify the mount points.
+
 
 You can then specify the entire range of drives using the expansion notation ``/mnt/disk{1...4}``. 
 If you want to use a specific subfolder on each drive, specify it as ``/mnt/disk{1...4}/minio``.
@@ -242,11 +249,11 @@ For example:
 
    $ nano /etc/fstab
 
-     # <file system>  <mount point>  <type>  <options>                <dump>  <pass>
-     LABEL=DISK1      /mnt/disk1     xfs     defaults,noatime,nofail  0       2
-     LABEL=DISK2      /mnt/disk2     xfs     defaults,noatime,nofail  0       2
-     LABEL=DISK3      /mnt/disk3     xfs     defaults,noatime,nofail  0       2
-     LABEL=DISK4      /mnt/disk4     xfs     defaults,noatime.nofail  0       2
+     # <file system>  <mount point>  <type>  <options>         <dump>  <pass>
+     LABEL=DISK1      /mnt/disk1     xfs     defaults,noatime  0       2
+     LABEL=DISK2      /mnt/disk2     xfs     defaults,noatime  0       2
+     LABEL=DISK3      /mnt/disk3     xfs     defaults,noatime  0       2
+     LABEL=DISK4      /mnt/disk4     xfs     defaults,noatime  0       2
 
 You can then specify the entire range of drives using the expansion notation
 ``/mnt/disk{1...4}``. If you want to use a specific subfolder on each drive,
@@ -255,6 +262,12 @@ specify it as ``/mnt/disk{1...4}/minio``.
 MinIO **does not** support arbitrary migration of a drive with existing MinIO
 data to a new mount position, whether intentional or as the result of OS-level
 behavior.
+
+.. note:: 
+
+   For certain cloud environments (Amazon i3, for example), MinIO recommends also setting the ``nofail`` option in ``/etc/fstab``.
+   Cloud instances that do not configure this option may become inaccessible.
+   Setting ``nofail`` in these situations allows continued access to the instance to allow you to rectify the mount points.
 
 .. end-local-jbod-desc
 

--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -197,10 +197,12 @@ For example:
 
 .. note:: 
 
-   For certain cloud environments (Amazon i3, for example), MinIO recommends also setting the ``nofail`` option in ``/etc/fstab``.
-   Cloud instances that do not configure this option may become inaccessible.
-   Setting ``nofail`` in these situations allows continued access to the instance to allow you to rectify the mount points.
+   Cloud environment instances which depend on mounted external storage may encounter boot failure if one or more of the remote file mounts return errors or failure.
+   For example, an AWS ECS instances with mounted persistent EBS volumes may fail to boot with the standard ``/etc/fstab`` configuration if one or more EBS volumes fail to mount.
 
+   You can set the ``nofail`` option to silence error reporting at boot and allow the instance to boot with one or more mount issues.
+   
+   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO an the OS from responding to those errors in a normal fashion.
 
 You can then specify the entire range of drives using the expansion notation ``/mnt/disk{1...4}``. 
 If you want to use a specific subfolder on each drive, specify it as ``/mnt/disk{1...4}/minio``.
@@ -265,9 +267,13 @@ behavior.
 
 .. note:: 
 
-   For certain cloud environments (Amazon i3, for example), MinIO recommends also setting the ``nofail`` option in ``/etc/fstab``.
-   Cloud instances that do not configure this option may become inaccessible.
-   Setting ``nofail`` in these situations allows continued access to the instance to allow you to rectify the mount points.
+   Cloud environment instances which depend on mounted external storage may encounter boot failure if one or more of the remote file mounts return errors or failure.
+   For example, an AWS ECS instances with mounted persistent EBS volumes may fail to boot with the standard ``/etc/fstab`` configuration if one or more EBS volumes fail to mount.
+
+   You can set the ``nofail`` option to silence error reporting at boot and allow the instance to boot with one or more mount issues.
+   
+   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO an the OS from responding to those errors in a normal fashion.
+
 
 .. end-local-jbod-desc
 

--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -189,11 +189,11 @@ For example:
 
    $ nano /etc/fstab
 
-     # <file system>  <mount point>  <type>  <options>         <dump>  <pass>
-     LABEL=DISK1      /mnt/disk1     xfs     defaults,noatime  0       2
-     LABEL=DISK2      /mnt/disk2     xfs     defaults,noatime  0       2
-     LABEL=DISK3      /mnt/disk3     xfs     defaults,noatime  0       2
-     LABEL=DISK4      /mnt/disk4     xfs     defaults,noatime  0       2
+     # <file system>  <mount point>  <type>  <options>                <dump>  <pass>
+     LABEL=DISK1      /mnt/disk1     xfs     defaults,noatime,nofail  0       2
+     LABEL=DISK2      /mnt/disk2     xfs     defaults,noatime,nofail  0       2
+     LABEL=DISK3      /mnt/disk3     xfs     defaults,noatime,nofail  0       2
+     LABEL=DISK4      /mnt/disk4     xfs     defaults,noatime,nofail  0       2
 
 You can then specify the entire range of drives using the expansion notation ``/mnt/disk{1...4}``. 
 If you want to use a specific subfolder on each drive, specify it as ``/mnt/disk{1...4}/minio``.

--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -202,7 +202,7 @@ For example:
 
    You can set the ``nofail`` option to silence error reporting at boot and allow the instance to boot with one or more mount issues.
    
-   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO an the OS from responding to those errors in a normal fashion.
+   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO and the OS from responding to those errors in a normal fashion.
 
 You can then specify the entire range of drives using the expansion notation ``/mnt/disk{1...4}``. 
 If you want to use a specific subfolder on each drive, specify it as ``/mnt/disk{1...4}/minio``.
@@ -272,7 +272,7 @@ behavior.
 
    You can set the ``nofail`` option to silence error reporting at boot and allow the instance to boot with one or more mount issues.
    
-   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO an the OS from responding to those errors in a normal fashion.
+   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO and the OS from responding to those errors in a normal fashion.
 
 
 .. end-local-jbod-desc

--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -242,11 +242,11 @@ For example:
 
    $ nano /etc/fstab
 
-     # <file system>  <mount point>  <type>  <options>         <dump>  <pass>
-     LABEL=DISK1      /mnt/disk1     xfs     defaults,noatime  0       2
-     LABEL=DISK2      /mnt/disk2     xfs     defaults,noatime  0       2
-     LABEL=DISK3      /mnt/disk3     xfs     defaults,noatime  0       2
-     LABEL=DISK4      /mnt/disk4     xfs     defaults,noatime  0       2
+     # <file system>  <mount point>  <type>  <options>                <dump>  <pass>
+     LABEL=DISK1      /mnt/disk1     xfs     defaults,noatime,nofail  0       2
+     LABEL=DISK2      /mnt/disk2     xfs     defaults,noatime,nofail  0       2
+     LABEL=DISK3      /mnt/disk3     xfs     defaults,noatime,nofail  0       2
+     LABEL=DISK4      /mnt/disk4     xfs     defaults,noatime.nofail  0       2
 
 You can then specify the entire range of drives using the expansion notation
 ``/mnt/disk{1...4}``. If you want to use a specific subfolder on each drive,

--- a/source/includes/linux/common-installation.rst
+++ b/source/includes/linux/common-installation.rst
@@ -212,8 +212,10 @@ For binary installations, create this file manually on all MinIO hosts.
 
 .. note::
    
-   ``systemd`` checks the ``/etc/systemd/...`` path before checking the ``/usr/lib/systemd/...`` path.
-   Make sure the file only exists at ``/usr/lib/systemd/system/minio.service`` path.
+   ``systemd`` checks the ``/etc/systemd/...`` path before checking the ``/usr/lib/systemd/...`` path and uses the first file it finds.
+   To avoid conflicting or unexpected configuration options, check that the file only exists at the ``/usr/lib/systemd/system/minio.service`` path.
+
+   Refer to the `man page for systemd.unit <https://www.man7.org/linux/man-pages/man5/systemd.unit.5.html>`__ for details on the file path search order.
     
 .. code-block:: shell
    :class: copyable

--- a/source/includes/linux/common-installation.rst
+++ b/source/includes/linux/common-installation.rst
@@ -209,7 +209,7 @@ operating systems using RPM, DEB, or binary:
 
 The ``.deb`` or ``.rpm`` packages install the following 
 `systemd <https://www.freedesktop.org/wiki/Software/systemd/>`__ service file to 
-``/etc/systemd/system/minio.service``. For binary installations, create this
+``/lib/systemd/system/minio.service``. For binary installations, create this
 file manually on all MinIO hosts:
 
 .. code-block:: shell

--- a/source/includes/linux/common-installation.rst
+++ b/source/includes/linux/common-installation.rst
@@ -207,11 +207,14 @@ operating systems using RPM, DEB, or binary:
 
 .. start-install-minio-systemd-desc
 
-The ``.deb`` or ``.rpm`` packages install the following 
-`systemd <https://www.freedesktop.org/wiki/Software/systemd/>`__ service file to 
-``/lib/systemd/system/minio.service``. For binary installations, create this
-file manually on all MinIO hosts:
+The ``.deb`` or ``.rpm`` packages install the following `systemd <https://www.freedesktop.org/wiki/Software/systemd/>`__ service file to ``/usr/lib/systemd/system/minio.service``. 
+For binary installations, create this file manually on all MinIO hosts.
 
+.. note::
+   
+   ``systemd`` checks the ``/etc/systemd/...`` path before checking the ``/usr/lib/systemd/...`` path.
+   Make sure the file only exists at ``/usr/lib/systemd/system/minio.service`` path.
+    
 .. code-block:: shell
    :class: copyable
 

--- a/source/includes/linux/common-minio-kes.rst
+++ b/source/includes/linux/common-minio-kes.rst
@@ -25,7 +25,7 @@ For more granular controls, deploy a dedicated load balancer to manage connectio
 
 .. start-kes-service-file-desc
 
-Create the ``/etc/systemd/system/kes.service`` file on all KES hosts:
+Create the ``/lib/systemd/system/kes.service`` file on all KES hosts:
 
 .. literalinclude:: /extra/kes.service
    :language: shell

--- a/source/operations/data-recovery/recover-after-drive-failure.rst
+++ b/source/operations/data-recovery/recover-after-drive-failure.rst
@@ -85,9 +85,12 @@ For example, consider
 
 .. note:: 
 
-   For certain cloud environments (Amazon i3, for example), MinIO recommends also setting the ``nofail`` option in ``/etc/fstab``.
-   Cloud instances that do not configure this option may become inaccessible.
-   Setting ``nofail`` in these situations allows continued access to the instance to allow you to rectify the mount points.
+   Cloud environment instances which depend on mounted external storage may encounter boot failure if one or more of the remote file mounts return errors or failure.
+   For example, an AWS ECS instances with mounted persistent EBS volumes may fail to boot with the standard ``/etc/fstab`` configuration if one or more EBS volumes fail to mount.
+
+   You can set the ``nofail`` option to silence error reporting at boot and allow the instance to boot with one or more mount issues.
+   
+   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO an the OS from responding to those errors in a normal fashion.
 
 Given the previous example command, no changes are required to 
 ``fstab`` since the replacement drive at ``/mnt/drive1`` uses the same

--- a/source/operations/data-recovery/recover-after-drive-failure.rst
+++ b/source/operations/data-recovery/recover-after-drive-failure.rst
@@ -77,17 +77,23 @@ For example, consider
 
    $ cat /etc/fstab
 
-     # <file system>  <mount point>  <type>  <options>                <dump>  <pass>
-     LABEL=DRIVE1     /mnt/drive1    xfs     defaults,noatime,nofail  0       2
-     LABEL=DRIVE2     /mnt/drive2    xfs     defaults,noatime,nofail  0       2
-     LABEL=DRIVE3     /mnt/drive3    xfs     defaults,noatime,nofail  0       2
-     LABEL=DRIVE4     /mnt/drive4    xfs     defaults,noatime,nofail  0       2
+     # <file system>  <mount point>  <type>  <options>         <dump>  <pass>
+     LABEL=DRIVE1     /mnt/drive1    xfs     defaults,noatime  0       2
+     LABEL=DRIVE2     /mnt/drive2    xfs     defaults,noatime  0       2
+     LABEL=DRIVE3     /mnt/drive3    xfs     defaults,noatime  0       2
+     LABEL=DRIVE4     /mnt/drive4    xfs     defaults,noatime  0       2
+
+.. note:: 
+
+   For certain cloud environments (Amazon i3, for example), MinIO recommends also setting the ``nofail`` option in ``/etc/fstab``.
+   Cloud instances that do not configure this option may become inaccessible.
+   Setting ``nofail`` in these situations allows continued access to the instance to allow you to rectify the mount points.
 
 Given the previous example command, no changes are required to 
 ``fstab`` since the replacement drive at ``/mnt/drive1`` uses the same
 label ``DRIVE1`` as the failed drive.
 
-4) Remount the Replaced Drive(s)
+1) Remount the Replaced Drive(s)
 --------------------------------
 
 Use ``mount -a`` to remount the drives unmounted at the beginning of this

--- a/source/operations/data-recovery/recover-after-drive-failure.rst
+++ b/source/operations/data-recovery/recover-after-drive-failure.rst
@@ -77,11 +77,11 @@ For example, consider
 
    $ cat /etc/fstab
 
-     # <file system>  <mount point>  <type>  <options>         <dump>  <pass>
-     LABEL=DRIVE1     /mnt/drive1    xfs     defaults,noatime  0       2
-     LABEL=DRIVE2     /mnt/drive2    xfs     defaults,noatime  0       2
-     LABEL=DRIVE3     /mnt/drive3    xfs     defaults,noatime  0       2
-     LABEL=DRIVE4     /mnt/drive4    xfs     defaults,noatime  0       2
+     # <file system>  <mount point>  <type>  <options>                <dump>  <pass>
+     LABEL=DRIVE1     /mnt/drive1    xfs     defaults,noatime,nofail  0       2
+     LABEL=DRIVE2     /mnt/drive2    xfs     defaults,noatime,nofail  0       2
+     LABEL=DRIVE3     /mnt/drive3    xfs     defaults,noatime,nofail  0       2
+     LABEL=DRIVE4     /mnt/drive4    xfs     defaults,noatime,nofail  0       2
 
 Given the previous example command, no changes are required to 
 ``fstab`` since the replacement drive at ``/mnt/drive1`` uses the same

--- a/source/operations/data-recovery/recover-after-drive-failure.rst
+++ b/source/operations/data-recovery/recover-after-drive-failure.rst
@@ -90,7 +90,7 @@ For example, consider
 
    You can set the ``nofail`` option to silence error reporting at boot and allow the instance to boot with one or more mount issues.
    
-   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO an the OS from responding to those errors in a normal fashion.
+   You should not use this option on systems which have locally attached disks, as silencing drive errors prevents both MinIO and the OS from responding to those errors in a normal fashion.
 
 Given the previous example command, no changes are required to 
 ``fstab`` since the replacement drive at ``/mnt/drive1`` uses the same

--- a/source/operations/install-deploy-manage/decommission-server-pool.rst
+++ b/source/operations/install-deploy-manage/decommission-server-pool.rst
@@ -331,7 +331,7 @@ server in the deployment and remove the decommissioned pool.
 
 The ``.deb`` or ``.rpm`` packages install a 
 `systemd <https://www.freedesktop.org/wiki/Software/systemd/>`__ service file to 
-``/etc/systemd/system/minio.service``. For binary installations, this
+``/lib/systemd/system/minio.service``. For binary installations, this
 procedure assumes the file was created manually as per the 
 :ref:`deploy-minio-distributed` procedure.
 
@@ -521,7 +521,7 @@ For persistent failures, use :mc:`mc admin console` or review the ``systemd`` lo
 Once decommissioning completes, you can safely remove the pools from the deployment configuration. 
 Modify the startup command for each remaining MinIO server in the deployment and remove the decommissioned pool.
 
-The ``.deb`` or ``.rpm`` packages install a `systemd <https://www.freedesktop.org/wiki/Software/systemd/>`__ service file to ``/etc/systemd/system/minio.service``. 
+The ``.deb`` or ``.rpm`` packages install a `systemd <https://www.freedesktop.org/wiki/Software/systemd/>`__ service file to ``/lib/systemd/system/minio.service``. 
 For binary installations, this procedure assumes the file was created manually as per the :ref:`deploy-minio-distributed` procedure.
 
 The ``minio.service`` file uses an environment file located at ``/etc/default/minio`` for sourcing configuration settings, including the startup. 


### PR DESCRIPTION
Updates fstab to add `nofail`.
Modifies path for `minio.service` to be in `/lib/` instead of `/etc/`.

Closes #874 .

Staged [here]( http://192.241.195.202:9000/staging/fstab874/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#local-jbod-storage-with-sequential-mounts).