### PR TITLE
Updates NATS notification docs to point to JetStream service

### DIFF
--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -533,9 +533,16 @@ MinIO supports the following time units:
 
 .. start-minio-notify-nats-streaming
 
-Specify ``on`` to enable streaming events to the NATS service endpoint.
+Specify ``on`` to enable JetStream support for streaming events to a NATS JetStream service endpoint.
 
 .. end-minio-notify-nats-streaming
+
+.. start-minio-notify-nats-jetstream
+
+Specify ``on`` to enable asynchronous publishing of events to the NATS service endpoint.
+
+.. end-minio-notify-nats-jetstream
+
 
 .. start-minio-notify-nats-streaming-async
 

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -1342,6 +1342,14 @@ service as a target for :ref:`Bucket Nofitications <minio-bucket-notifications>`
 :ref:`minio-bucket-notifications-publish-nats` for a tutorial on 
 using these environment variables.
 
+.. admonition:: NATS Streaming Deprecated
+   :class: important
+
+   NATS Streaming is deprecated.
+   Migrate to `JetStream <https://docs.nats.io/nats-concepts/jetstream>`__ instead. 
+
+   The related MinIO configuration options and environment variables are deprecated. 
+
 .. mc-conf:: notify_nats
 
    The top-level configuration key for defining an NATS service endpoint for use
@@ -1480,8 +1488,21 @@ using these environment variables.
       This configuration setting corresponds with the environment variable
       :envvar:`MINIO_NOTIFY_NATS_PING_INTERVAL`.
 
+   .. mc-conf:: jetstream
+      :delimiter: " "
+
+      *Optional*
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-notify-nats-jetstream
+         :end-before: end-minio-notify-nats-jetstream
+
+      This configuration setting corresponds with the environment variable :envvar:`MINIO_NOTIFY_NATS_JETSTREAM`.
+
    .. mc-conf:: streaming
       :delimiter: " "
+
+      *Deprecated*
 
       *Optional*
 
@@ -1495,6 +1516,8 @@ using these environment variables.
    .. mc-conf:: streaming_async
       :delimiter: " "
 
+      *Deprecated*
+ 
       *Optional*
 
       .. include:: /includes/common-mc-admin-config.rst
@@ -1507,6 +1530,8 @@ using these environment variables.
    .. mc-conf:: streaming_max_pub_acks_in_flight
       :delimiter: " "
 
+      *Deprecated*
+ 
       *Optional*
 
       .. include:: /includes/common-mc-admin-config.rst
@@ -1519,6 +1544,8 @@ using these environment variables.
    .. mc-conf:: streaming_cluster_id
       :delimiter: " "
 
+      *Deprecated*
+ 
       *Optional*
 
       .. include:: /includes/common-mc-admin-config.rst

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -1713,30 +1713,30 @@ endpoints as ``PRIMARY`` and ``SECONDARY`` respectively:
 NATS Service for Bucket Notifications
 +++++++++++++++++++++++++++++++++++++
 
-The following section documents environment variables for configuring an NATS
-service as a target for :ref:`Bucket Nofitications <minio-bucket-notifications>`. See
-:ref:`minio-bucket-notifications-publish-nats` for a tutorial on
-using these environment variables.
+.. admonition:: NATS Streaming Deprecated
+   :class: important
 
-You can specify multiple NATS service endpoints by appending a unique identifier
-``_ID`` for each set of related NATS environment variables:
-the top level key. For example, the following commands set two distinct NATS
-service endpoints as ``PRIMARY`` and ``SECONDARY`` respectively:
+   NATS Streaming is deprecated.
+   Migrate to `JetStream <https://docs.nats.io/nats-concepts/jetstream>`__ instead. 
+
+   The related MinIO configuration options and environment variables are deprecated. 
+
+The following section documents environment variables for configuring an NATS service as a target for :ref:`Bucket Nofitications <minio-bucket-notifications>`. 
+See :ref:`minio-bucket-notifications-publish-nats` for a tutorial on using these environment variables.
+
+You can specify multiple NATS service endpoints by appending a unique identifier ``_ID`` for each set of related NATS environment variables no to the top level key. 
+For example, the following commands set two distinct NATS service endpoints as ``PRIMARY`` and ``SECONDARY`` respectively:
 
 .. code-block:: shell
    :class: copyable
 
    set MINIO_NOTIFY_NATS_ENABLE_PRIMARY="on"
    set MINIO_NOTIFY_NATS_ADDRESS_PRIMARY="https://nats-endpoint.example.net:4222"
-   set MINIO_NOTIFY_NATS_SUBJECT="minioevents"
 
    set MINIO_NOTIFY_NATS_ENABLE_SECONDARY="on"
    set MINIO_NOTIFY_NATS_ADDRESS_SECONDARY="https://nats-endpoint.example.net:4222"
-   set MINIO_NOTIFY_NATS_SUBJECT="minioevents"
 
-For example, :envvar:`MINIO_NOTIFY_NATS_ENABLE_PRIMARY
-<MINIO_NOTIFY_NATS_ENABLE>` indicates the environment variable is associated to
-an NATS service endpoint with ID of ``PRIMARY``.
+For example, :envvar:`MINIO_NOTIFY_NATS_ENABLE_PRIMARY <MINIO_NOTIFY_NATS_ENABLE>` indicates the environment variable is associated to an NATS service endpoint with ID of ``PRIMARY``.
 
 .. envvar:: MINIO_NOTIFY_NATS_ENABLE
 
@@ -1843,7 +1843,19 @@ an NATS service endpoint with ID of ``PRIMARY``.
    :mc-conf:`notify_nats ping_interval <notify_nats.ping_interval>`
    configuration setting.
 
+.. envvar:: MINIO_NOTIFY_NATS_JETSTREAM
+
+   *Optional*
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-notify-nats-jetstream
+      :end-before: end-minio-notify-nats-jetstream
+
+   This environment variable corresponds with the :mc-conf:`notify_nats jetstream <notify_nats.jetstream>` configuration setting.
+
 .. envvar:: MINIO_NOTIFY_NATS_STREAMING
+
+   *Deprecated*
 
    *Optional*
 
@@ -1857,6 +1869,8 @@ an NATS service endpoint with ID of ``PRIMARY``.
 
 .. envvar:: MINIO_NOTIFY_NATS_STREAMING_ASYNC
 
+   *Deprecated*
+
    *Optional*
 
    .. include:: /includes/common-mc-admin-config.rst
@@ -1869,6 +1883,8 @@ an NATS service endpoint with ID of ``PRIMARY``.
 
 .. envvar:: MINIO_NOTIFY_NATS_STREAMING_MAX_PUB_ACKS_IN_FLIGHT
 
+   *Deprecated*
+
    *Optional*
 
    .. include:: /includes/common-mc-admin-config.rst
@@ -1880,6 +1896,8 @@ an NATS service endpoint with ID of ``PRIMARY``.
    <notify_nats.streaming_max_pub_acks_in_flight>` configuration setting.
 
 .. envvar:: MINIO_NOTIFY_NATS_STREAMING_CLUSTER_ID
+
+   *Deprecated*
 
    *Optional*
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -998,6 +998,7 @@ These environment variables configure notification targets for use with
 - :ref:`minio-server-envvar-bucket-notification-elasticsearch`
 - :ref:`minio-server-envvar-bucket-notification-nsq`
 - :ref:`minio-server-envvar-bucket-notification-redis`
+- :ref:`minio-server-envvar-bucket-notification-nats`
 - :ref:`minio-server-envvar-bucket-notification-postgresql`
 - :ref:`minio-server-envvar-bucket-notification-mysql`
 - :ref:`minio-server-envvar-bucket-notification-kafka`


### PR DESCRIPTION
Streaming configs and envvars are deprecated.

Closes #903

Staged:
- http://192.241.195.202:9000/staging/nats-903/administration/monitoring/publish-events-to-nats.html
- http://192.241.195.202:9000/staging/nats-903/reference/minio-mc-admin/mc-admin-config.html#nats-service-for-bucket-notifications
- http://192.241.195.202:9000/staging/nats-903/reference/minio-server/minio-server.html#envvar.MINIO_NOTIFY_NATS_JETSTREAM