### PR TITLE
Update configure-minio-kes-hashicorp.rst

### DIFF
--- a/source/operations/server-side-encryption/configure-minio-kes-hashicorp.rst
+++ b/source/operations/server-side-encryption/configure-minio-kes-hashicorp.rst
@@ -309,7 +309,7 @@ The following section describes each of the |KES-git| configuration settings for
              - /v1/key/generate/*
              - /v1/key/decrypt/*
              - /v1/key/bulk/decrypt
-             - /v1/key/list
+             - /v1/key/list/*
              - /v1/status
              - /v1/metrics
              - /v1/log/audit


### PR DESCRIPTION
Adding /v1/key/list/* in the doc instead of  /v1/key/list which gives Authentication issue .

policy:
minio:
allow:
- /v1/key/create/* # You can replace these wildcard '' with a string prefix to restrict key names
- /v1/key/generate/ # e.g. '/minio-'
- /v1/key/decrypt/*
- /v1/key/bulk/decrypt
- /v1/key/list
- /v1/status