### PR TITLE
Adding C++ SDK into the list

### DIFF
--- a/source/developers/minio-drivers.rst
+++ b/source/developers/minio-drivers.rst
@@ -25,8 +25,6 @@ MinIO publishes the following Software Development Kits (SDK):
 C++ (``minio-cpp``)
 -------------------
 
-Latest Version
-  |cpp-sdk-version|
 
 Reference
   `MinIO C++ SDK Reference <https://minio-cpp.min.io/>`__

--- a/source/developers/minio-drivers.rst
+++ b/source/developers/minio-drivers.rst
@@ -18,43 +18,40 @@ MinIO publishes the following Software Development Kits (SDK):
 4. :ref:`Java <java-sdk>`
 5. :ref:`JavaScript <javascript-sdk>`
 6. :ref:`Python <python-sdk>`
+7. :ref: `C++ <cpp-sdk>`
 
+.. _cpp-sdk:
 
-..
-  C++ repo does not have any releases yet. Once released, unblock this section and add to toctree and numbered list.
-  
-  .. _cpp-sdk:
+C++ (``minio-cpp``)
+-------------------
 
-  C++ (``minio-cpp``)
-  -------------------
+Latest Version
+  |cpp-sdk-version|
 
-  Latest Version
-    |cpp-sdk-version|
+Reference
+  `MinIO C++ SDK Reference <https://minio-cpp.min.io/>`__
 
-  Reference
-    :doc:`MinIO C++ SDK Reference </developers/cpp/minio-cpp>`
+Install
+  - ``vcpkg``
 
-  Install
-    - ``vcpkg``
+    .. code-block:: shell
+       :class: copyable
+
+       vcpkg install minio-cpp
+
+  - Source
              
-      .. code-block:: shell
-         :class: copyable
+    .. code-block:: shell
+       :class: copyable
 
-         vcpkg install minio-cpp
-
-    - Source
-             
-      .. code-block:: shell
-         :class: copyable
-
-         git clone https://github.com/minio/minio-cpp
-         cd minio-cpp
-         wget --quiet -O vcpkg-master.zip https://github.com/microsoft/vcpkg/archive/refs/heads/master.zip
-         unzip -qq vcpkg-master.zip
-         ./vcpkg-master/bootstrap-vcpkg.sh
-         ./vcpkg-master/vcpkg integrate install
-         cmake -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=./vcpkg-master/scripts/buildsystems/vcpkg.cmake
-         cmake --build ./build --config Debug  
+       git clone https://github.com/minio/minio-cpp
+       cd minio-cpp
+       wget --quiet -O vcpkg-master.zip https://github.com/microsoft/vcpkg/archive/refs/heads/master.zip
+       unzip -qq vcpkg-master.zip
+       ./vcpkg-master/bootstrap-vcpkg.sh
+       ./vcpkg-master/vcpkg integrate install
+       cmake -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=./vcpkg-master/scripts/buildsystems/vcpkg.cmake
+       cmake --build ./build --config Debug
 
 .. _dotnet-sdk:
 

--- a/source/developers/minio-drivers.rst
+++ b/source/developers/minio-drivers.rst
@@ -18,7 +18,7 @@ MinIO publishes the following Software Development Kits (SDK):
 4. :ref:`Java <java-sdk>`
 5. :ref:`JavaScript <javascript-sdk>`
 6. :ref:`Python <python-sdk>`
-7. :ref: `C++ <cpp-sdk>`
+7. :ref:`C++ <cpp-sdk>`
 
 .. _cpp-sdk:
 


### PR DESCRIPTION
### Objective:

To add C++ SDK in the page: https://min.io/docs/minio/linux/developers/minio-drivers.html

![Screenshot 2023-08-10 at 12 39 28 PM](https://github.com/minio/docs/assets/6667358/ed9931e0-a3ce-4de7-954a-3960a76a6f4c)
