### PR TITLE
Fix a bunch of incorrect commands for attaching policies

### DIFF
--- a/source/administration/identity-access-management/ad-ldap-access-management.rst
+++ b/source/administration/identity-access-management/ad-ldap-access-management.rst
@@ -70,8 +70,8 @@ Consider the following policy assignments:
 
 .. code-block:: shell
 
-   mc admin policy set --consoleAdmin user='cn=sisko,cn=users,dc=example,dc=com'
-   mc admin policy set --readwrite,diagnostics user='cn=dax,cn=users,dc=example,dc=com'
+   mc admin policy attach myminio consoleAdmin --user='cn=sisko,cn=users,dc=example,dc=com'
+   mc admin policy attach myminio readwrite,diagnostics --user='cn=dax,cn=users,dc=example,dc=com'
 
 - MinIO would assign an authenticated user with DN matching 
   ``cn=sisko,cn=users,dc=example,dc=com`` the :userpolicy:`consoleAdmin`
@@ -92,8 +92,8 @@ Consider the following policy assignments:
 
 .. code-block:: shell
 
-   mc admin policy set --consoleAdmin group='cn=ops,cn=groups,dc=example,dc=com'
-   mc admin policy set --diagnostics group='cn=engineering,cn=groups,dc=example,dc=com'
+   mc admin policy attach myminio consoleAdmin --group='cn=ops,cn=groups,dc=example,dc=com'
+   mc admin policy attach myminio diagnostics --group='cn=engineering,cn=groups,dc=example,dc=com'
 
 - MinIO would assign any authenticating user with membership in the
   ``cn=ops,cn=groups,dc=example,dc=com`` AD/LDAP group the

--- a/source/administration/identity-access-management/minio-user-management.rst
+++ b/source/administration/identity-access-management/minio-user-management.rst
@@ -149,7 +149,7 @@ The following command assigns the built-in :userpolicy:`readwrite` policy:
 .. code-block:: shell
    :class: copyable
 
-   mc admin policy set ALIAS readwrite user=USERNAME
+   mc admin policy attach ALIAS readwrite --user=USERNAME
 
 Replace ``USERNAME`` with the ``ACCESSKEY`` created in the previous step.
 

--- a/source/includes/common-minio-tiering.rst
+++ b/source/includes/common-minio-tiering.rst
@@ -74,9 +74,9 @@ secret key as per your organizations best practices for password generation.
    :class: copyable
 
    wget -O - https://min.io/docs/minio/linux/examples/LifecycleManagementAdmin.json | \
-   mc admin policy add Alpha LifecycleAdminPolicy /dev/stdin
-   mc admin user add Alpha alphaLifecycleAdmin LongRandomSecretKey
-   mc admin policy set Alpha LifecycleAdminPolicy user=alphaLifecycleAdmin
+   mc admin policy create Alpha LifecycleAdminPolicy /dev/stdin
+   mc admin user create Alpha alphaLifecycleAdmin LongRandomSecretKey
+   mc admin policy attach Alpha LifecycleAdminPolicy --user=alphaLifecycleAdmin
 
 This example assumes that the specified
 aliases have the necessary permissions for creating policies and users

--- a/source/includes/common-replication.rst
+++ b/source/includes/common-replication.rst
@@ -72,9 +72,9 @@ Bucket replication requires specific permissions on the source and destination d
          :class: copyable
 
          wget -O - https://min.io/docs/minio/linux/examples/ReplicationAdminPolicy.json | \
-         mc admin policy add TARGET ReplicationAdminPolicy /dev/stdin
-         mc admin user add TARGET ReplicationAdmin LongRandomSecretKey
-         mc admin policy set TARGET ReplicationAdminPolicy user=ReplicationAdmin
+         mc admin policy create TARGET ReplicationAdminPolicy /dev/stdin
+         mc admin user create TARGET ReplicationAdmin LongRandomSecretKey
+         mc admin policy attach TARGET ReplicationAdminPolicy --user=ReplicationAdmin
 
       MinIO deployments configured for :ref:`Active Directory/LDAP <minio-external-identity-management-ad-ldap>` or :ref:`OpenID Connect <minio-external-identity-management-openid>` user management should instead create a dedicated :ref:`access keys <minio-idp-service-account>` for bucket replication.
 
@@ -99,9 +99,9 @@ Bucket replication requires specific permissions on the source and destination d
          :class: copyable
 
          wget -O - https://min.io/docs/minio/linux/examples/ReplicationRemoteUserPolicy.json | \
-         mc admin policy add TARGET ReplicationRemoteUserPolicy /dev/stdin
-         mc admin user add TARGET ReplicationRemoteUser LongRandomSecretKey
-         mc admin policy set TARGET ReplicationRemoteUserPolicy user=ReplicationRemoteUser
+         mc admin policy create TARGET ReplicationRemoteUserPolicy /dev/stdin
+         mc admin user create TARGET ReplicationRemoteUser LongRandomSecretKey
+         mc admin policy attach TARGET ReplicationRemoteUserPolicy --user=ReplicationRemoteUser
 
       MinIO deployments configured for :ref:`Active Directory/LDAP <minio-external-identity-management-ad-ldap>` or :ref:`OpenID Connect <minio-external-identity-management-openid>` user management should instead create a dedicated :ref:`access keys <minio-idp-service-account>` for bucket replication.
 

--- a/source/includes/k8s/steps-configure-ad-ldap-external-identity-management.rst
+++ b/source/includes/k8s/steps-configure-ad-ldap-external-identity-management.rst
@@ -81,13 +81,13 @@ You must explicitly assign MinIO policies to a given user or group Distinguished
 
 The following example assumes an existing :ref:`alias <alias>` configured for the MinIO Tenant.
 
-Use the :mc:`mc admin policy attach` command to assign a user or group DN to an existing MinIO Policy:
+Use the :mc-cmd:`mc idp ldap policy attach` command to assign a user or group DN to an existing MinIO Policy:
 
 .. code-block:: shell
    :class: copyable
 
-   mc admin policy attach minio-tenant POLICY user='uid=primary,cn=applications,dc=domain,dc=com'
-   mc admin policy attach minio-tenant POLICY group='cn=applications,ou=groups,dc=domain,dc=com'
+   mc idp ldap policy attach minio-tenant POLICY user='uid=primary,cn=applications,dc=domain,dc=com'
+   mc idp ldap policy attach minio-tenant POLICY group='cn=applications,ou=groups,dc=domain,dc=com'
 
 Replace ``POLICY`` with the name of the MinIO policy to assign to the user or group DN.
 

--- a/source/includes/k8s/steps-configure-ad-ldap-external-identity-management.rst
+++ b/source/includes/k8s/steps-configure-ad-ldap-external-identity-management.rst
@@ -86,8 +86,8 @@ Use the :mc-cmd:`mc idp ldap policy attach` command to assign a user or group DN
 .. code-block:: shell
    :class: copyable
 
-   mc idp ldap policy attach minio-tenant POLICY user='uid=primary,cn=applications,dc=domain,dc=com'
-   mc idp ldap policy attach minio-tenant POLICY group='cn=applications,ou=groups,dc=domain,dc=com'
+   mc idp ldap policy attach minio-tenant POLICY --user='uid=primary,cn=applications,dc=domain,dc=com'
+   mc idp ldap policy attach minio-tenant POLICY --group='cn=applications,ou=groups,dc=domain,dc=com'
 
 Replace ``POLICY`` with the name of the MinIO policy to assign to the user or group DN.
 

--- a/source/includes/k8s/steps-configure-openid-external-identity-management.rst
+++ b/source/includes/k8s/steps-configure-openid-external-identity-management.rst
@@ -100,12 +100,12 @@ Consider the following example policy that grants general S3 API access on only 
       ]
    }
 
-Use the :mc:`mc admin policy attach` command to create a policy for use by an OIDC user:
+Use the :mc:`mc admin policy create` command to create a policy for use by an OIDC user:
 
 .. code-block:: shell
    :class: copyable
 
-   mc admin policy add minio-tenant datareadonly /path/to/datareadonly.json
+   mc admin policy create minio-tenant datareadonly /path/to/datareadonly.json
 
 MinIO attaches the ``datareadonly`` policy to any authenticated OIDC user with ``datareadonly`` included in the configured claim.
 

--- a/source/operations/external-iam.rst
+++ b/source/operations/external-iam.rst
@@ -117,7 +117,7 @@ MinIO uses :ref:`Policy Based Access Control (PBAC) <minio-access-management>` t
 When using an Active Directory/LDAP server for identity management (authentication), MinIO maintains control over access (authorization) through PBAC. 
 
 When a user successfully authenticates to MinIO using their AD/LDAP credentials, MinIO searches for all :ref:`policies <minio-policy>` which are explicitly associated to that user's Distinguished Name (DN). 
-Specifically, the policy must be assigned to a user with a matching DN using the :mc:`mc admin policy attach` command. 
+Specifically, the policy must be assigned to a user with a matching DN using the :mc-cmd:`mc idp ldap policy attach` command. 
 
 MinIO also supports querying for the user's AD/LDAP group membership. 
 MinIO attempts to match existing policies to the DN for each of the user's groups. 
@@ -127,7 +127,7 @@ See :ref:`minio-external-identity-management-ad-ldap-access-control-group-lookup
 MinIO uses deny-by-default behavior where a user with no explicitly assigned or group-inherited policies cannot access any resource on the MinIO deployment.
 
 MinIO provides :ref:`built-in policies <minio-policy-built-in>` for basic access control.
-You can create new policies using the :mc:`mc admin policy` command.
+You can create new policies using the :mc:`mc admin policy create` command.
 
 .. _minio-external-identity-management-ad-ldap-access-control-group-lookup:
 


### PR DESCRIPTION
Found many incorrect commands for creating/attaching policies to users and groups. 

Staged:
http://192.241.195.202:9000/staging/DOCS-919-3-admin-policy/k8s/html/index.html

This is additional follow-up from https://github.com/minio/docs/issues/919 and also SUBNET docs feedback. 