### PR TITLE
clarify redirect_uri maybe

### DIFF
--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -82,8 +82,8 @@ Defaults to those scopes advertised in the discovery document.
 
 .. important::
 
-   This parameter is **deprecated** and will be removed in a future release.
-   Use :envvar:`MINIO_BROWSER_REDIRECT_URL` instead.
+   This parameter was removed in :minio-release:`RELEASE.2023-02-27T18-10-45Z`.
+   Use the :envvar:`MINIO_BROWSER_REDIRECT_URL` :ref:`environment variable <minio-server-environment-variables>` instead.
 
 The MinIO Console defaults to using the hostname of the node making the authentication request. 
 For MinIO deployments behind a load balancer or reverse proxy, specify this field to ensure the OIDC provider returns the authentication response to the correct MinIO Console URL.

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -2884,7 +2884,7 @@ identity management using an OpenID Connect (OIDC)-compatible provider. See
       :end-before: end-minio-openid-redirect-uri
 
    This environment variable corresponds with the 
-   :mc-conf:`identity_openid scopes 
+   :mc-conf:`identity_openid redirect_uri 
    <identity_openid.redirect_uri>` setting.
 
 .. envvar:: MINIO_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC


### PR DESCRIPTION
Envvar `MINIO_IDENTITY_OPENID_REDIRECT_URI` is apparently gone, although the corresponding `identity_openid redirect_uri` has been deprecated but not removed. They were both noted as deprecated in the docs 1+ years ago. 

The recommended replacement is the envvar `MINIO_BROWSER_REDIRECT_URL`, which does not appear to have a corresponding `mc admin config` setting.

This PR is an attempt to clarify the situation, feedback appreciated.

Staged
http://192.241.195.202:9000/staging/DOCS-760/linux/html/index.html
http://192.241.195.202:9000/staging/OPERATOR-1720/linux/html/reference/minio-server/minio-server.html#envvar.MINIO_IDENTITY_OPENID_REDIRECT_URI

See https://github.com/minio/operator/pull/1722 and https://github.com/minio/operator/pull/1720 for context.