### PR TITLE
DOCS-898: Synchronous Bucket Notifications, config API secret redaction

### DIFF
--- a/source/administration/monitoring/bucket-notifications.rst
+++ b/source/administration/monitoring/bucket-notifications.rst
@@ -97,6 +97,13 @@ To enable synchronous bucket notifications for *all configured remote targets*, 
 
 - Set the :mc-conf:`api.sync_events` configuration setting to ``on`` and restart the MinIO deployment.
 
+.. important::
+
+   MinIO maintains a user-configurable queue of undelivered bucket notification events for each configured remote (``10000`` events by default).
+
+   Enabling synchronous bucket notification may result in increased queue usage if the remote notification target cannot keep up with the rate of sent events.
+   Once the queue fills, MinIO discards new events.
+
 .. _minio-bucket-notifications-event-types:
 
 Supported S3 Event Types

--- a/source/administration/monitoring/bucket-notifications.rst
+++ b/source/administration/monitoring/bucket-notifications.rst
@@ -79,6 +79,23 @@ MinIO supports publishing event notifications to the following targets:
 
        See :ref:`minio-bucket-notifications-publish-webhook` for a tutorial.
 
+Asynchronous vs Synchronous Bucket Notifications
+------------------------------------------------
+
+MinIO by default performs asynchronous delivery of bucket notification events to configured remote targets.
+
+For each event, MinIO fires the event at the configured remote and does *not* wait for a response before continuing to the next event.
+This can result in lost events if the remote restarts or has a transient failure while the event is in transit or processing.
+
+.. versionadded:: RELEASE.2023-06-23T20-26-00Z
+
+   You can enable synchronous bucket notification behavior for *all* remote targets, where MinIO waits for the configured remote to confirm successful receipt before continuing to the next event.
+
+To enable synchronous bucket notifications for *all configured remote targets*, use either of the following settings:
+
+- Set the :envvar:`MINIO_API_SYNC_EVENTS` environment variable to ``on`` and restart the MinIO deployment.
+
+- Set the :mc-conf:`api.sync_events` configuration setting to ``on`` and restart the MinIO deployment.
 
 .. _minio-bucket-notifications-event-types:
 

--- a/source/administration/monitoring/bucket-notifications.rst
+++ b/source/administration/monitoring/bucket-notifications.rst
@@ -82,14 +82,15 @@ MinIO supports publishing event notifications to the following targets:
 Asynchronous vs Synchronous Bucket Notifications
 ------------------------------------------------
 
-MinIO by default performs asynchronous delivery of bucket notification events to configured remote targets.
-
-For each event, MinIO fires the event at the configured remote and does *not* wait for a response before continuing to the next event.
-This can result in lost events if the remote restarts or has a transient failure while the event is in transit or processing.
-
 .. versionadded:: RELEASE.2023-06-23T20-26-00Z
 
-   You can enable synchronous bucket notification behavior for *all* remote targets, where MinIO waits for the configured remote to confirm successful receipt before continuing to the next event.
+   MinIO supports either asynchronous (default) or synchronous bucket notifications for *all* remote targets.
+
+With asynchronous delivery, MinIO fires the event at the configured remote and does *not* wait for a response before continuing to the next event.
+Asynchronous bucket notification prioritizes sending events with the risk of some events being lost if the remote target has a transient issue during transit or processing.
+
+With synchronous delivery, MinIO fires the event at the configured remote and then waits for the remote to confirm a successful receipt before continuing to the next event.
+Synchronous bucket notification prioritizes delivery of events with the risk of a slower event-send rate and queue fill.
 
 To enable synchronous bucket notifications for *all configured remote targets*, use either of the following settings:
 
@@ -97,12 +98,13 @@ To enable synchronous bucket notifications for *all configured remote targets*, 
 
 - Set the :mc-conf:`api.sync_events` configuration setting to ``on`` and restart the MinIO deployment.
 
-.. important::
+.. note::
 
-   MinIO maintains a user-configurable queue of undelivered bucket notification events for each configured remote (``10000`` events by default).
+   MinIO maintains a per-remote queue of events (``10000`` by default) where it stores unsent and pending events.
 
-   Enabling synchronous bucket notification may result in increased queue usage if the remote notification target cannot keep up with the rate of sent events.
-   Once the queue fills, MinIO discards new events.
+   For asynchronous or synchronous bucket notifications, MinIO discards new events if the queue fills.
+   You can increase the queue size as necessary to better accommodate the rate of event send and processing of the MinIO deployment and remote target.
+
 
 .. _minio-bucket-notifications-event-types:
 

--- a/source/developers/transforms-with-object-lambda.rst
+++ b/source/developers/transforms-with-object-lambda.rst
@@ -108,6 +108,17 @@ To enable MinIO to call the handler, register the handler function as a webhook 
    Register an endpoint for a handler function.
    For multiple handlers, set this environment variable for each function endpoint.
 
+MinIO also supports the following environment variables for authenticated webhook endpoints:
+
+:envvar:`MINIO_LAMBDA_WEBHOOK_AUTH_TOKEN_functionanme <MINIO_LAMBDA_WEBHOOK_AUTH_TOKEN>`
+   Specify the opaque string or JWT authorization token for authenticating to the webhook.
+
+:envvar:`MINIO_LAMBDA_WEBHOOK_CLIENT_CERT_functionname <MINIO_LAMBDA_WEBHOOK_CLIENT_CERT>`
+   Specify the client certificate to use for mTLS authentication to the webhook.
+
+:envvar:`MINIO_LAMBDA_WEBHOOK_CLIENT_KEY_functionname <MINIO_LAMBDA_WEBHOOK_CLIENT_CERT>`
+   Specify the private key to use for mTLS authentication to the webhook.
+
 Restart MinIO to apply the changes.
 
 

--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -161,6 +161,10 @@ server/broker.
 Specify the password for the MQTT username with which MinIO authenticates to the
 MQTT server/broker.
 
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
+
 .. end-minio-notify-mqtt-password
 
 
@@ -287,6 +291,10 @@ enforces authentication.
 
 The password for connecting to an Elasticsearch service endpoint which enforces
 authentication.
+
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
 
 .. end-minio-notify-elasticsearch-password
 
@@ -430,6 +438,10 @@ supports the following values:
 
 Specify the password for the Redis server.
 
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
+
 .. end-minio-notify-redis-password
 
 
@@ -495,11 +507,19 @@ Specify the username for connecting to the NATS service endpoint.
 
 Specify the passport for connecting to the NATS service endpoint.
 
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
+
 .. end-minio-notify-nats-password
 
 .. start-minio-notify-nats-token
 
 Specify the token for connecting to the NATS service endpoint.
+
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
 
 .. end-minio-notify-nats-token
 
@@ -837,6 +857,10 @@ to the Kafka broker(s).
 Specify the password for performing SASL/PLAIN or SASL/SCRAM authentication
 to the Kafka broker(s).
 
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
+
 .. end-minio-notify-kafka-sasl-password
 
 .. start-minio-notify-kafka-sasl-mechanism
@@ -976,6 +1000,10 @@ Specify the URL for the webhook service.
 
 Specify the opaque string or JWT authorization token to use for 
 authenticating to the webhook service.
+
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
 
 .. end-minio-notify-webhook-auth-token
 
@@ -1280,3 +1308,13 @@ Defaults to ``"text/*, application/json, application/xml, binary/octet-stream"``
 +-----------------+--------------------------+
 
 .. end-minio-data-compression-default-desc
+
+.. start-minio-api-sync-events
+
+Enables synchronous :ref:`bucket notifications <minio-bucket-notifications>`.
+
+Specify ``on`` to direct MinIO to wait until the remote target returns success on receipt of an event before processing further events.
+
+Defaults to ``off``, or asynchronous bucket notifications where MinIO does not wait for the remote target to return success on receipt of an event.
+
+.. end-minio-api-sync-events

--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -18,6 +18,10 @@ Specify the client secret MinIO uses when authenticating user credentials
 against the :abbr:`OIDC (OpenID Connect)` compatible provider. This field
 may be optional depending on the provider.
 
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
+
 .. end-minio-openid-client-secret
 
 .. start-minio-openid-jwks-url
@@ -182,6 +186,10 @@ privileges to support querying performing user and group lookups.
 
 Specify the password for the :ref:`Lookup-Bind 
 <minio-external-identity-management-ad-ldap-lookup-bind>` user account.
+
+.. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+   MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
 
 .. end-minio-ad-ldap-lookup-bind-password
 

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -111,6 +111,8 @@ API Configuration
          :start-after: start-minio-api-sync-events
          :end-before: end-minio-api-sync-events
 
+      Corresponds with the :envvar:`MINIO_API_SYNC_EVENTS` environment variable.
+
 .. _minio-server-config-logging-logs:
 
 HTTP Webhook Log Target

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -88,7 +88,7 @@ Configuration Settings
 The following configuration settings define runtime behavior of the 
 MinIO :mc:`server <minio server>` process:
 
-Root User Account
+API Configuration
 ~~~~~~~~~~~~~~~~~
 
 .. mc-conf:: api
@@ -105,6 +105,11 @@ Root User Account
       To reset after an unintentional lock, set :envvar:`MINIO_API_ROOT_ACCESS` ``on`` to override this setting and temporarily re-enable the root account.
       You can then change this setting to ``on`` *or* make the necessary user/policy changes to ensure normal administrative access through other non-root accounts.
 
+   .. mc-conf:: sync_events
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-api-sync-events
+         :end-before: end-minio-api-sync-events
 
 .. _minio-server-config-logging-logs:
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -1005,6 +1005,13 @@ These environment variables configure notification targets for use with
 - :ref:`minio-server-envvar-bucket-notification-kafka`
 - :ref:`minio-server-envvar-bucket-notification-webhook`
 
+.. envvar:: MINIO_API_SYNC_EVENTS
+   :optional:
+
+   .. include:: /includes/common-mc-admin-config.rst
+      :start-after: start-minio-api-sync-events
+      :end-before: end-minio-api-sync-events
+
 .. _minio-server-envvar-bucket-notification-amqp:
 
 AMQP Service for Bucket Notifications
@@ -2629,7 +2636,26 @@ For example, the following command sets two distinct Object Lambda webhook endpo
 
 .. envvar:: MINIO_LAMBDA_WEBHOOK_ENDPOINT
 
-   The HTTP endpoint of the webhook for the handler function.
+   The HTTP endpoint of the lambda webhook for the handler function.
+
+
+.. envvar:: MINIO_LAMBDA_WEBHOOK_AUTH_TOKEN
+
+   Specify the opaque string or JWT authorization token to use for authenticating to the lambda webhook service.
+
+   .. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+      MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
+
+
+.. envvar:: MINIO_LAMBDA_WEBHOOK_CLIENT_CERT
+
+   Specify the path to the client certificate to use for performing mTLS authentication to the lambda webhook service.
+
+.. envvar:: MINIO_LAMBDA_WEBHOOK_CLIENT_KEY
+
+   Specify the path to the private key to use for performing mTLS authentication to the lambda webhook service.
+
 
 .. _minio-server-envvar-external-identity-management-ad-ldap:
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -1012,6 +1012,8 @@ These environment variables configure notification targets for use with
       :start-after: start-minio-api-sync-events
       :end-before: end-minio-api-sync-events
 
+   Corresponds with the :mc-conf:`~api.sync_events` configuration setting.
+
 .. _minio-server-envvar-bucket-notification-amqp:
 
 AMQP Service for Bucket Notifications


### PR DESCRIPTION
Closes #898 

- Adds a short section on synchronous vs asynchronous bucket notifications
- Adds a note on specific configs which now return redacted data on `mc admin config get`
- Found a few new webhook lambda envvars to add

ToDo:

- Add a short section on bucket notification queue behavior and how sync/async affects it

STAGED

- http://192.241.195.202:9000/staging/DOCS-898/linux/administration/monitoring/bucket-notifications.html#asynchronous-vs-synchronous-bucket-notifications
- http://192.241.195.202:9000/staging/DOCS-898/linux/reference/minio-server/minio-server.html#envvar.MINIO_API_SYNC_EVENTS
- http://192.241.195.202:9000/staging/DOCS-898/linux/reference/minio-mc-admin/mc-admin-config.html#mc-conf.api.sync_events
- http://192.241.195.202:9000/staging/DOCS-898/linux/reference/minio-mc-admin/mc-admin-config.html#mc-conf.notify_nats.password