### PR TITLE
Updates for RELEASE.2023-07-18T17-49-40Z

### DIFF
--- a/source/administration/bucket-replication.rst
+++ b/source/administration/bucket-replication.rst
@@ -179,11 +179,7 @@ Replication of Existing Objects
 MinIO by default does not enable existing object replication. Objects
 created before replication was configured *or* while replication is
 disabled are not synchronized to the target deployment.
-Starting with :mc:`mc` :minio-git:`RELEASE.2021-06-13T17-48-22Z
-<mc/releases/tag/RELEASE.2021-06-13T17-48-22Z>` and :mc:`minio`
-:minio-git:`RELEASE.2021-06-07T21-40-51Z
-<minio/releases/tag/RELEASE.2021-06-07T21-40-51Z>`, MinIO supports enabling
-replication of existing objects in a bucket. 
+MinIO supports enabling replication of existing objects in a bucket. 
 
 Enabling existing object replication marks all objects or object prefixes that
 satisfy the replication rules as eligible for synchronization to the source
@@ -244,8 +240,12 @@ workers operating on that queue. MinIO continuously works to replicate and
 remove objects from the queue while scanning for new unreplicated objects to
 add to the queue. 
 
-MinIO queues failed replication operations and retries those operations until replication succeeds.
-This helps keep replication up-to-date without relying on the MinIO scanner to notice unreplicated object versions.
+
+.. versionchanged:: RELEASE.2022-07-18T17-49-40Z
+
+   MinIO queues failed replication operations and retries those operations up to three (3) times.
+   
+   Replication operations that fail more than three times wait for the scanner to identify the object for replication before trying again.
 
 .. versionchanged:: RELEASE.2022-08-11T04-37-28Z
 

--- a/source/administration/bucket-replication.rst
+++ b/source/administration/bucket-replication.rst
@@ -245,8 +245,9 @@ add to the queue.
 
    MinIO queues failed replication operations and retries those operations up to three (3) times.
    
-   Replication operations that fail more than three times wait for the scanner to identify the object for replication before trying again.
-
+   MinIO dequeues replication operations that fail to replicate after three attempts.
+   The scanner can pick up those affected objects at a later time and requeue them for replication.
+  
 .. versionchanged:: RELEASE.2022-08-11T04-37-28Z
 
    Failed or pending replications requeue automatically when performing a list or any ``GET`` or ``HEAD`` API method. 

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -88,6 +88,11 @@ Site Healing
 
 Any MinIO deployment in the site replication configuration can resynchronize damaged :ref:`replica-eligible data <minio-site-replication-what-replicates>` from the peer with the most updated ("latest") version of that data.
 
+.. versionchanged:: RELEASE.2023-07-18T17-49-40Z
+
+   Site replication operations retry up to three (3) times.
+   Failed operations wait for the MinIO Scanner to identify the replication task again before requeueing for another three attempts.
+
 .. versionchanged:: RELEASE.2022-08-11T04-37-28Z
 
    Failed or pending replications requeue automatically when performing any ``GET`` or ``HEAD`` API method. 

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -91,7 +91,9 @@ Any MinIO deployment in the site replication configuration can resynchronize dam
 .. versionchanged:: RELEASE.2023-07-18T17-49-40Z
 
    Site replication operations retry up to three (3) times.
-   Failed operations wait for the MinIO Scanner to identify the replication task again before requeueing for another three attempts.
+   
+   MinIO dequeues replication operations that fail to replicate after three attempts.
+   The scanner can pick up those affected objects at a later time and requeue them for replication.
 
 .. versionchanged:: RELEASE.2022-08-11T04-37-28Z
 

--- a/source/reference/minio-mc-admin/mc-admin-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-info.rst
@@ -21,10 +21,7 @@ for each MinIO server in the deployment.
 
 .. end-mc-admin-info-desc
 
-.. versionchanged:: RELEASE.2023-07-18T17-49-40Z
-
-   MinIO now reports the number of delete markers on the deployment.
-   
+  
 The output of the command resembles the following:
 
 .. code-block::
@@ -53,6 +50,10 @@ Examples
    :class: copyable
 
    mc admin info play
+
+.. versionchanged:: RELEASE.2023-07-18T17-49-40Z
+
+   MinIO reports the number of delete markers on the deployment.
 
 Syntax
 ------

--- a/source/reference/minio-mc-admin/mc-admin-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-info.rst
@@ -51,10 +51,6 @@ Examples
 
    mc admin info play
 
-.. versionchanged:: RELEASE.2023-07-18T17-49-40Z
-
-   MinIO reports the number of delete markers on the deployment.
-
 Syntax
 ------
 

--- a/source/reference/minio-mc-admin/mc-admin-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-info.rst
@@ -21,21 +21,25 @@ for each MinIO server in the deployment.
 
 .. end-mc-admin-info-desc
 
+.. versionchanged:: RELEASE.2023-07-18T17-49-40Z
+
+   MinIO now reports the number of delete markers on the deployment.
+   
 The output of the command resembles the following:
 
 .. code-block::
 
    ●  play.min.io
-      Uptime: 8 hours 
-      Version: 2023-04-15T14:34:02Z
+      Uptime: 14 hours 
+      Version: 2023-08-17T16:37:55Z
       Network: 1/1 OK 
       Drives: 4/4 OK 
       Pool: 1
-   
+
    Pools:
       1st, Erasure sets: 1, Drives per erasure set: 4
-   
-   11 GiB Used, 395 Buckets, 4,131 Objects, 676 Versions
+
+   4.3 GiB Used, 499 Buckets, 3,547 Objects, 554 Versions, 67 Delete Markers
    4 drives online, 0 drives offline
 
 Examples


### PR DESCRIPTION
- Adds information about 3 attempts at site or bucket replication tasks
- Adds note about additional info for delete markers
- Updates mc admin info command example output

Partially addresses #931 .

Not staged, but can do if needed.