### PR TITLE
Operator supports PSA restricted namespaces

### DIFF
--- a/source/includes/k8s/deploy-operator.rst
+++ b/source/includes/k8s/deploy-operator.rst
@@ -75,7 +75,7 @@ Starting with v5.0.0, MinIO *recommends* Kubernetes 1.21.0 or later for both the
 
 .. versionadded:: Operator 5.0.6
 
-For Kubernetes v1.25.0 and later, MinIO supports deploying in environments with the :kube-docs:`Pod Security admission (PSA) <concepts/security/pod-security-admission>` ``restricted`` policy enabled.
+For Kubernetes 1.25.0 and later, MinIO supports deploying in environments with the :kube-docs:`Pod Security admission (PSA) <concepts/security/pod-security-admission>` ``restricted`` policy enabled.
 
 
 ``kubectl`` Configuration

--- a/source/includes/k8s/deploy-operator.rst
+++ b/source/includes/k8s/deploy-operator.rst
@@ -73,6 +73,11 @@ You *must* upgrade your Kubernetes infrastructure to 1.19.0 or later to use the 
 
 Starting with v5.0.0, MinIO *recommends* Kubernetes 1.21.0 or later for both the infrastructure and the ``kubectl`` CLI tool.
 
+.. versionadded:: Operator 5.0.6
+
+For Kubernetes 1.25 and later, MinIO supports deploying in environments with the :kube-docs:`Pod Security admission (PSA) <concepts/security/pod-security-admission>` ``restricted`` policy enabled.
+
+
 ``kubectl`` Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/k8s/deploy-operator.rst
+++ b/source/includes/k8s/deploy-operator.rst
@@ -75,7 +75,7 @@ Starting with v5.0.0, MinIO *recommends* Kubernetes 1.21.0 or later for both the
 
 .. versionadded:: Operator 5.0.6
 
-For Kubernetes 1.25 and later, MinIO supports deploying in environments with the :kube-docs:`Pod Security admission (PSA) <concepts/security/pod-security-admission>` ``restricted`` policy enabled.
+For Kubernetes v1.25.0 and later, MinIO supports deploying in environments with the :kube-docs:`Pod Security admission (PSA) <concepts/security/pod-security-admission>` ``restricted`` policy enabled.
 
 
 ``kubectl`` Configuration


### PR DESCRIPTION
Add a mention in the Operator docs that MinIO supports the `restricted` policy for [Pod Security admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)

Staged:
http://192.241.195.202:9000/staging/DOCS-900-1/k8s/operations/installation.html#kubernetes-version-1-19-0

Partly addresses https://github.com/minio/docs/issues/900