### PR TITLE
Optional custom init container

### DIFF
--- a/source/includes/k8s/deploy-operator.rst
+++ b/source/includes/k8s/deploy-operator.rst
@@ -50,6 +50,8 @@ Each pod runs three containers:
 - SideCar container that monitors configuration secrets for the tenant and updates them as they change.
   This container also monitors for root credentials and creates an error if it does not find root credentials. 
 
+Starting with v5.0.6, the MinIO Operator supports custom :kube-docs:`init containers <concepts/workloads/pods/init-containers>` for additional pod initialization that may be required for your environment.
+
 The tenant utilizes Persistent Volume Claims to talk to the Persistent Volumes that store the objects.
 
 .. image:: /images/k8s/OperatorsComponent-Diagram.png


### PR DESCRIPTION
Operator 5.0.6+ allows custom init containers, should your pod require additional initialization. Add a brief mention in the Operator install page and link to the k8s docs.

Staged
http://192.241.195.202:9000/staging/DOCS-900-2/k8s/operations/installation.html#minio-operator-components

Partially addresses https://github.com/minio/docs/issues/900