### PR TITLE
Batch job Permissions

### DIFF
--- a/source/administration/batch-framework.rst
+++ b/source/administration/batch-framework.rst
@@ -79,7 +79,27 @@ The :mc:`mc batch` commands include
 Access to ``mc batch``
 ----------------------
 
-You can use MinIO's :ref:`Policy Based Access Control <minio-policy>` and the :ref:`administrative policy actions <minio-policy-mc-admin-actions>` to restrict who can start a batch job, retrieve a list of running jobs, or describe a running job.
+The batch function itself is a server process not limited by access keys or policies.
+Instead, use MinIO's :ref:`Policy Based Access Control <minio-policy>` and the :ref:`administrative policy actions <minio-policy-mc-admin-actions>` to restrict who can start a batch job, retrieve a list of running jobs, or describe a running job.
+
+MinIO provides the following admin policy actions to control access to Batch Replication functions:
+
+``admin:ListBatchJobs``
+  Grants the user the ability to see batch jobs currently in process.
+
+``admin:DescribeBatchJobs``
+  Grants the user the ability to see the definition details of batch job currently in process.
+
+``admin:StartBatchJob``
+  Grants the user the ability to start a batch job.
+  The job may be further restricted by the credentials the job uses to access either the source or target deployments.
+
+``admin:CancelBatchJob``
+  Allows the user to stop a batch job currently in progress.
+
+You can assign any of these actions to users independently or in any combination.
+
+The built-in ``ConsoleAdmin`` policy includes sufficient access to perform all of these types of batch job actions.
 
 Job Types
 ---------
@@ -88,6 +108,8 @@ Replicate
 ~~~~~~~~~
 
 Use the ``replicate`` job type to create a batch job that replicates objects from one MinIO deployment to another MinIO target.
+
+The access to objects and buckets for the replicate process may be restricted by the credentials you provide in the YAML for either the source or target destinations. 
 
 .. versionadded:: MinIO Server RELEASE.2023-05-04T21-44-30Z
 

--- a/source/administration/batch-framework.rst
+++ b/source/administration/batch-framework.rst
@@ -79,10 +79,13 @@ The :mc:`mc batch` commands include
 Access to ``mc batch``
 ----------------------
 
-The batch function itself is a server process not limited by access keys or policies.
-Instead, use MinIO's :ref:`Policy Based Access Control <minio-policy>` and the :ref:`administrative policy actions <minio-policy-mc-admin-actions>` to restrict who can start a batch job, retrieve a list of running jobs, or describe a running job.
+A user's access keys and policies do not restrict the the buckets, prefixes, or objects the batch function can access or the types of actions the process can perform on any objects.
 
-MinIO provides the following admin policy actions to control access to Batch Replication functions:
+For some job types, the credentials passed to the batch job through the YAML file do restrict the objects that the job can access.
+However, any restrictions to the job are from the credentials in the YAML, not policies attached to the user who starts the job.
+
+Use MinIO's :ref:`Policy Based Access Control <minio-policy>` and the :ref:`administrative policy actions <minio-policy-mc-admin-actions>` to restrict who can perform various batch job functions.
+MinIO provides the following admin policy actions for Batch Jobs:
 
 ``admin:ListBatchJobs``
   Grants the user the ability to see batch jobs currently in process.

--- a/source/administration/batch-framework.rst
+++ b/source/administration/batch-framework.rst
@@ -104,6 +104,10 @@ The built-in ``ConsoleAdmin`` policy includes sufficient access to perform all o
 Job Types
 ---------
 
+.. note:: 
+
+   Depending on the job type, the success or failure of any batch job may be impacted by the credentials given in the batch job's YAML for the source or target deployments.
+
 Replicate
 ~~~~~~~~~
 

--- a/source/administration/identity-access-management/policy-based-access-control.rst
+++ b/source/administration/identity-access-management/policy-based-access-control.rst
@@ -878,6 +878,10 @@ services:
 .. policy-action:: admin:StartBatchJob
 
    Allows user to begin a batch job run.
+
+.. policy-action:: admin:CancelBatchJob
+
+   Allows user to stop a batch job currently in process.
    
 .. policy-action:: admin:Rebalance
 


### PR DESCRIPTION
Adds information to the batch job doc about available permissions.
Updates the batch job policy list to include `cancel`.

Closes #954 

Staged at http://192.241.195.202:9000/staging/permissions/linux/administration/batch-framework.html#access-to-mc-batch