### PR TITLE
Documents the scanner.speed config and minio_scanner_speed envvar

### DIFF
--- a/source/administration/bucket-replication.rst
+++ b/source/administration/bucket-replication.rst
@@ -203,6 +203,10 @@ feature. The time required to fully synchronize a bucket depends on a number of
 factors, including but not limited to the current cluster replication load,
 overall cluster load, and the size of the namespace (all objects in the bucket).
 
+.. include:: /includes/common/scanner.rst
+   :start-after: start-scanner-speed-config
+   :end-before: end-scanner-speed-config
+
 If versioning was not previously enabled when configuring bucket replication, 
 existing objects have a ``versionid = null``. These objects do replicate.
 

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -123,6 +123,10 @@ Scanner performance typically depends on the available node resources, the size 
 For example, a cluster that starts with 100TB of data that then grows to 200TB of data may require more time to scan the entire namespace of buckets and objects given the same hardware and workload.
 As the cluster or workload increases, scanner performance decreases as it yields more frequently to ensure priority of normal S3 operations.
 
+.. include:: /includes/common/scanner.rst
+   :start-after: start-scanner-speed-config
+   :end-before: end-scanner-speed-config
+
 Consider regularly checking cluster metrics, capacity, and resource usage to ensure the cluster hardware is scaling alongside cluster and workload growth:
 
 - :ref:`minio-metrics-and-alerts`

--- a/source/includes/common/scanner.rst
+++ b/source/includes/common/scanner.rst
@@ -1,0 +1,35 @@
+.. start-scanner-speed-config
+
+You can adjust how MinIO balances the scanner performance with read/write operations using either the :envvar:`MINIO_SCANNER_SPEED` environment variable or the :mc-conf:`scanner speed <scanner.speed>` configuration setting.
+
+.. end-scanner-speed-config
+
+
+.. start-scanner-speed-values
+
+MinIO utilizes the scanner for :ref:`bucket replication <minio-bucket-replication>`, :ref:`site replication <minio-site-replication-overview>`, and :ref:`lifecycle management <minio-lifecycle-management>` tasks.
+
+Valid values include:
+
+.. list-table::
+   :stub-columns: 1
+   :widths: 30 70
+   :width: 100%
+   
+   * - ``fastest``
+     - Removes wait time for scanner activity, maximizing scanner performance at the possible cost of some read or write performance.
+   
+   * - ``fast``
+     - Adds a small wait time for scanner activity if MinIO notices a latency in read or write processes slight risk of some loss of read or write performance.
+   
+   * - ``default``
+     - Adds a moderate wait time for scanner activity if MinIO notices a latency in any read or write processes.
+       Provides a standard balance of maintaining read/write performance with ongoing scanner activity. 
+   
+   * - ``slow``
+     - Adds an additional delay to scanner processes if MinIO notices a latency in any read or write operation in order to prioritize read/write performance at a slight cost of scanner performance.
+
+   * - ``slowest``
+     - Adds the greatest delay to scanner processes if MinIO notices a latency of any read or write operation in order to prioritize read/write performance at a greater cost of scanner performance.
+
+.. end-scanner-speed-values

--- a/source/includes/common/scanner.rst
+++ b/source/includes/common/scanner.rst
@@ -18,7 +18,7 @@ Valid values include:
    
    * - ``fastest``
      - Removes scanner wait on read/write latency, allowing the scanner to operate at full-speed and IOPS consumption.
-       This setting may result in reduced read/write performance for IOPS-limited systems.
+       This setting may result in reduced read and write performance.
    
    * - ``fast``
      - Sets a short scanner wait time on read/write latency, allowing the scanner to operate at a higher speed and IOPS consumption.
@@ -26,17 +26,17 @@ Valid values include:
    
    * - ``default``
      - Sets a moderate scanner wait time on read/write latency, allowing the scanner to operate at a balanced speed and IOPS consumption.
-       This setting seeks to maintain read/write performance while allowing ongoing scanner activity. 
+       This setting seeks to maintain read and write performance while allowing ongoing scanner activity. 
    
    * - ``slow``
      - Sets a medium scanner wait time on read/write latency, where the scanner operates at a reduced speed and IOPS consumption.
-       This setting allows better read/write performance while reducing scanner performance.
+       This setting allows better read and write performance while reducing scanner performance.
 
        May impact scanner-dependent features, such as lifecycle management and replication.
 
    * - ``slowest``
      - Sets a large scanner wait time on read/write latency, where the scanner operates at a substantially lower speed and IOPS consumption.
-       This setting prioritizes read/write operations at the potential cost of scanner operations.
+       This setting prioritizes read and write operations at the potential cost of scanner operations.
 
        May impact scanner-dependent features, such as lifecycle management and replication.
 

--- a/source/includes/common/scanner.rst
+++ b/source/includes/common/scanner.rst
@@ -17,19 +17,27 @@ Valid values include:
    :width: 100%
    
    * - ``fastest``
-     - Removes wait time for scanner activity, maximizing scanner performance at the possible cost of some read or write performance.
+     - Removes scanner wait on read/write latency, allowing the scanner to operate at full-speed and IOPS consumption.
+       This setting may result in reduced read/write performance for IOPS-limited systems.
    
    * - ``fast``
-     - Adds a small wait time for scanner activity if MinIO notices a latency in read or write processes slight risk of some loss of read or write performance.
+     - Sets a short scanner wait time on read/write latency, allowing the scanner to operate at a higher speed and IOPS consumption.
+       This setting may result in reduced read and write performance.
    
    * - ``default``
-     - Adds a moderate wait time for scanner activity if MinIO notices a latency in any read or write processes.
-       Provides a standard balance of maintaining read/write performance with ongoing scanner activity. 
+     - Sets a moderate scanner wait time on read/write latency, allowing the scanner to operate at a balanced speed and IOPS consumption.
+       This setting seeks to maintain read/write performance while allowing ongoing scanner activity. 
    
    * - ``slow``
-     - Adds an additional delay to scanner processes if MinIO notices a latency in any read or write operation in order to prioritize read/write performance at a slight cost of scanner performance.
+     - Sets a medium scanner wait time on read/write latency, where the scanner operates at a reduced speed and IOPS consumption.
+       This setting allows better read/write performance while reducing scanner performance.
+
+       May impact scanner-dependent features, such as lifecycle management and replication.
 
    * - ``slowest``
-     - Adds the greatest delay to scanner processes if MinIO notices a latency of any read or write operation in order to prioritize read/write performance at a greater cost of scanner performance.
+     - Sets a large scanner wait time on read/write latency, where the scanner operates at a substantially lower speed and IOPS consumption.
+       This setting prioritizes read/write operations at the potential cost of scanner operations.
+
+       May impact scanner-dependent features, such as lifecycle management and replication.
 
 .. end-scanner-speed-values

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -105,6 +105,10 @@ Any MinIO deployment in the site replication configuration can resynchronize dam
    If one site loses data for any reason, resynchronize the data from another healthy site with :mc-cmd:`mc admin replicate resync`.
    This launches an active process that resynchronizes the data without waiting for the passive MinIO scanner to recognize the missing data.
 
+.. include:: /includes/common/scanner.rst
+   :start-after: start-scanner-speed-config
+   :end-before: end-scanner-speed-config
+
 Synchronous vs Asynchronous Replication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -115,6 +115,22 @@ API Configuration
 
 .. _minio-server-config-logging-logs:
 
+Scanner
+~~~~~~~
+
+.. mc-conf:: scanner
+
+   Configuration settings that affect the scanner process.
+   MinIO utilizes the scanner for :ref:`bucket replication <minio-bucket-replication>`, :ref:`site replication <minio-site-replication-overview>`, and :ref:`lifecycle management <minio-lifecycle-management>` tasks.
+
+   .. mc-conf:: speed
+
+      This configuration setting corresponds with the :envvar:`MINIO_SCANNER_SPEED` environment variable.
+
+      .. include:: /includes/common/scanner.rst
+         :start-after: start-scanner-speed-values
+         :end-before: end-scanner-speed-values
+   
 HTTP Webhook Log Target
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -294,6 +294,16 @@ Core Configuration
 
    If this setting is omitted, the default is to only accept path-style requests. For example, ``minio.example.net/data``.
 
+.. _minio-scanner-speed-options:
+
+.. envvar:: MINIO_SCANNER_SPEED
+
+   Manage the maximum wait period for the scanner when balancing MinIO read/write performance to scanner processes.
+   
+   .. include:: /includes/common/scanner.rst
+      :start-after: start-scanner-speed-values
+      :end-before: end-scanner-speed-values
+   
 Root Credentials
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Closes #796

Staged:

- http://192.241.195.202:9000/staging/speed/linux/reference/minio-mc-admin/mc-admin-config.html#scanner
- http://192.241.195.202:9000/staging/speed/linux/reference/minio-server/minio-server.html#envvar.MINIO_SCANNER_SPEED

And a few other paragraphs here there and yon.