### PR TITLE
Discourage replication for SNSD/SNMD

### DIFF
--- a/source/includes/common-replication.rst
+++ b/source/includes/common-replication.rst
@@ -155,8 +155,10 @@ MinIO deployments in a site replication configuration do *not* replicate the cre
 
 .. start-mc-admin-replicate-load-balancing
 
-When replicating to multi-node sites, use the URL or IP address of the site's load balancer, reverse proxy, or similar network control plane component which automatically routes requests to nodes in the deployment.
+Specify the URL or IP address of the site's load balancer, reverse proxy, or similar network control plane component.
+Requests are automatically routed to nodes in the deployment.
 
-Using a single node for configuring site replication creates a single point of failure, where that node being offline results in replication failure.
+MinIO recommends against using a single node hostname for a peer site.
+This creates a single point of failure: if that node goes offline, replication fails.
 
 .. end-mc-admin-replicate-load-balancing

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -181,8 +181,8 @@ You cannot disable versioning in site replication deployments.
 
 MinIO cannot replicate objects in prefixes in the bucket that you excluded from versioning.
 
-Load Balancers Installed on Each Multi-Node Site
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Load Balancers Installed on Each Site
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/common-replication.rst
    :start-after: start-mc-admin-replicate-load-balancing


### PR DESCRIPTION
It's technically possible to replicate with SNSD/SNMD configurations. This is not safe for production environments, docs should discourage it. (See https://github.com/minio/minio/issues/17523)

Staged
http://192.241.195.202:9000/staging/DOCS-919-6-snsd-replication-nope/linux/operations/install-deploy-manage/multi-site-replication.html#load-balancers-installed-on-each-site

Fixes https://github.com/minio/docs/issues/909
(last item to doc for that release)