### PR TITLE
Style Quick Steps section on quickstart pages

### DIFF
--- a/source/_static/scss/includes/_content.scss
+++ b/source/_static/scss/includes/_content.scss
@@ -1,0 +1,54 @@
+.section-next-steps {
+    border: 1px solid var(--table-border-color);
+    border-radius: $border-radius-lg;
+    margin-top: 3rem;
+    padding: 1.5rem;
+   
+    & > h2 {
+        margin-top: 0;
+    }
+
+    & > ul {
+        margin: 0 0 -0.5rem;
+        list-style: none;
+        padding: 0;
+        counter-reset: list-number;
+
+        & > li {
+            display: flex;
+            align-items: start;
+
+            & > p {
+                flex-grow: 1;
+
+                & > a {
+                    display: block;
+                    padding: 0.65rem 0;
+                }
+            }
+            
+            &:not(:last-child) {
+                & > p {
+                    & > a {
+                        border-bottom: 1px dashed var(--table-border-color);
+                    }
+                }
+            }
+
+            &:before {
+                counter-increment: list-number;
+                content: counter(list-number);
+                width: 1.5rem;
+                height: 1.5rem;
+                border-radius: 50%;
+                border: 1px solid var(--table-border-color);
+                margin: 0 1rem 0 -0.2rem;
+                display: grid;
+                place-content: center;
+                font-size: $font-size-sm;
+                flex-shrink: 0;
+                margin-top: 0.6rem;
+            }
+        }
+    }
+}

--- a/source/_static/scss/main.scss
+++ b/source/_static/scss/main.scss
@@ -14,3 +14,4 @@
 @import 'includes/footer';
 @import 'includes/nav';
 @import 'includes/alert';
+@import 'includes/content';

--- a/source/includes/container/quickstart.rst
+++ b/source/includes/container/quickstart.rst
@@ -372,6 +372,8 @@ Procedure
 
       For additional details about this command, see :ref:`alias`.
 
+.. rst-class:: section-next-steps
+
 Next Steps
 ----------
 

--- a/source/includes/k8s/quickstart.rst
+++ b/source/includes/k8s/quickstart.rst
@@ -163,6 +163,8 @@ Procedure
    - The Access Key for a MinIO :ref:`user <minio-users>`
    - The Secret Key for a MinIO :ref:`user <minio-users>`
 
+.. rst-class:: section-next-steps
+   
 Next Steps
 ----------
 

--- a/source/includes/linux/quickstart.rst
+++ b/source/includes/linux/quickstart.rst
@@ -129,6 +129,8 @@ Procedure
 
    The example above uses the :ref:`root user <minio-users-root>`.
 
+.. rst-class:: section-next-steps
+
 Next Steps
 ----------
 

--- a/source/includes/macos/quickstart.rst
+++ b/source/includes/macos/quickstart.rst
@@ -137,6 +137,8 @@ Procedure
 
    For additional details about this command, see :ref:`alias`.
 
+.. rst-class:: section-next-steps
+   
 Next Steps
 ----------
 

--- a/source/includes/windows/quickstart.rst
+++ b/source/includes/windows/quickstart.rst
@@ -143,6 +143,8 @@ Procedure
 
    For additional details about this command, see :ref:`alias`.
 
+.. rst-class:: section-next-steps
+   
 Next Steps
 ----------
 


### PR DESCRIPTION
The section can be styled by adding the container class `.. rst-class:: section-next-steps`


<img width="798" alt="Screenshot 2023-08-30 at 13 52 07" src="https://github.com/minio/docs/assets/13393018/7ff22195-1d2a-454f-9736-ea89a58a7515">
