### PR TITLE
Partial updates for Operator v5.0.7 docs

### DIFF
--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -176,6 +176,7 @@ Persistent Volumes
 
    MinIO can use any Kubernetes :kube-docs:`Persistent Volume (PV) <concepts/storage/persistent-volumes>` that supports the :kube-docs:`ReadWriteOnce <concepts/storage/persistent-volumes/#access-modes>` access mode.
    MinIO's consistency guarantees require the exclusive storage access that ``ReadWriteOnce`` provides.
+   Additionally, MinIO recommends setting a reclaim policy of ``Retain`` for the PVC :kube-docs:`StorageClass <concepts/storage/storage-classes>`.
 
    For Kubernetes clusters where nodes have Direct Attached Storage, MinIO strongly recommends using the `DirectPV CSI driver <https://min.io/directpv?ref=docs>`__. 
    DirectPV provides a distributed persistent volume manager that can discover, format, mount, schedule, and monitor drives across Kubernetes nodes.

--- a/source/reference/kubectl-minio-plugin/kubectl-minio-delete.rst
+++ b/source/reference/kubectl-minio-plugin/kubectl-minio-delete.rst
@@ -52,8 +52,9 @@ Syntax
 
       .. code-block:: shell
 
-         kubectl minio delete       \
-                        --namespace  
+         kubectl minio delete                 \
+                        --namespace           \
+			[--force --dangerous]
 
 Flags
 -----
@@ -67,3 +68,15 @@ The command supports the following flags:
 
    Defaults to ``minio-operator``. 
 
+.. mc-cmd:: --dangerous
+   :optional:
+
+   Safety flag to confirm deletion of the MinIO Operator and all tenants with :mc-cmd:`~kubectl minio delete --force`.
+
+.. mc-cmd:: --force
+   :optional:
+
+   Deletes the MinIO Operator and all tenants without confirmation.
+   Requires the :mc-cmd:`~kubectl minio delete --dangerous` flag.
+
+   This operation is irreversible.

--- a/source/reference/kubectl-minio-plugin/kubectl-minio-delete.rst
+++ b/source/reference/kubectl-minio-plugin/kubectl-minio-delete.rst
@@ -73,6 +73,8 @@ The command supports the following flags:
 
    Safety flag to confirm deletion of the MinIO Operator and all tenants with :mc-cmd:`~kubectl minio delete --force`.
 
+   This operation is irreversible.
+
 .. mc-cmd:: --force
    :optional:
 

--- a/source/reference/kubectl-minio-plugin/kubectl-minio-tenant-info.rst
+++ b/source/reference/kubectl-minio-plugin/kubectl-minio-tenant-info.rst
@@ -27,6 +27,7 @@ Displays information on a MinIO Tenant, including but not limited to:
 - The total capacity of the Tenant
 - The version of MinIO server and MinIO Console running on the Tenant
 - The configuration of each Pool in the Tenant.
+- The root user credentials for the Tenant.
 
 .. end-kubectl-minio-tenant-info-desc
 

--- a/source/reference/kubectl-minio-plugin/kubectl-minio-tenant-info.rst
+++ b/source/reference/kubectl-minio-plugin/kubectl-minio-tenant-info.rst
@@ -35,7 +35,7 @@ Syntax
 ------
 
 .. tab-set::
-                                    
+
    .. tab-item:: EXAMPLE
 
       The following example retrieves the information of the MinIO Tenant ``minio-tenant-1`` in the namespace ``minio-namespace-1``.
@@ -45,7 +45,7 @@ Syntax
 
          kubectl minio tenant info                          \
                               minio-tenant-1                \
-                              --namespace minio-namespace-1 
+                              --namespace minio-namespace-1
 
    .. tab-item:: SYNTAX
 
@@ -69,3 +69,37 @@ The command supports the following flag:
    The namespace in which to look for the MinIO Tenant.
 
    Defaults to ``minio``.
+
+
+Example
+-------
+
+Display Tenant Details
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following command outputs information for the Tenant ``minio-tenant`` in the namespace ``minio-ns``:
+
+.. code-block:: shell
+   :class: copyable
+
+   kubectl minio tenant info               \
+                     minio-tenant          \
+                     --namespace minio-ns
+
+The output resembles the following:
+
+.. code-block:: shell
+
+   Tenant 'minio-tenant', Namespace 'minio-ns', Total capacity 16 GiB
+
+   Current status: Initialized
+   MinIO version: minio/minio:RELEASE.2023-06-23T20-26-00Z
+   MinIO service: minio/ClusterIP (port 443)
+   Console service: minio-tenant-console/ClusterIP (port 9443)
+
+   POOL    SERVERS    VOLUMES(SERVER)    CAPACITY(VOLUME)
+   0       4          1                  4.0 GiB
+
+   MinIO Root User Credentials:
+   MINIO_ROOT_USER="root_user"
+   MINIO_ROOT_PASSWORD="root_password"


### PR DESCRIPTION
The easy bits from https://github.com/minio/docs/issues/943: 

- [x] `kubectl minio tenant info` now includes tenant secret info ([PR #1704](https://github.com/minio/operator/pull/1704))
- [x] `kubectl minio delete` now has a `--force` flag ([PR #1687](https://github.com/minio/operator/pull/1687))

Staged:
http://192.241.195.202:9000/staging/DOCS-943-1/k8s/reference/kubectl-minio-plugin/kubectl-minio-delete.html
http://192.241.195.202:9000/staging/DOCS-943-1/k8s/reference/kubectl-minio-plugin/kubectl-minio-tenant-info.html
http://192.241.195.202:9000/staging/DOCS-943-1/k8s/operations/install-deploy-manage/deploy-minio-tenant.html#persistent-volumes