### PR TITLE
Updates for mc RELEASE.2023-08-29T22-55-06Z

### DIFF
--- a/source/administration/monitoring/bucket-notifications.rst
+++ b/source/administration/monitoring/bucket-notifications.rst
@@ -183,6 +183,14 @@ Specify the wildcard ``*`` character to select all events related to a prefix:
 
    Selects all ``s3:ObjectRestore``\ -prefixed events.
 
+Scanner Events
+~~~~~~~~~~~~~~
+
+MinIO supports triggering notifications on the following S3 scanner transition events:
+
+.. data:: s3:Scanner:ManyVersions
+.. data:: s3:Scanner:BigPrefix
+
 Global Events
 ~~~~~~~~~~~~~
 

--- a/source/reference/minio-mc-admin/mc-admin-kms-key.rst
+++ b/source/reference/minio-mc-admin/mc-admin-kms-key.rst
@@ -88,3 +88,23 @@ Syntax
 
       Omit this argument to return the default master key on the
       :mc-cmd:`~mc admin kms key status TARGET` deployment.
+
+.. mc-cmd:: list
+   :fullpath:
+
+   List all Key Management System (KMS) keys for a MinIO instance.
+
+   The command has the following syntax:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc admin kms key list TARGET
+
+   The command accepts the following argument:
+
+   .. mc-cmd:: TARGET
+
+      Specify the :mc-cmd:`alias <mc alias>` of a configured MinIO deployment.
+
+      The ``TARGET`` deployment **must** include a configured MinIO Key Encryption Service (KES) server.

--- a/source/reference/minio-mc/mc-event-add.rst
+++ b/source/reference/minio-mc/mc-event-add.rst
@@ -227,9 +227,11 @@ corresponding :ref:`S3 events <minio-bucket-notifications-event-types>`:
        | :data:`s3:ObjectRestore:Post`
        | :data:`s3:ObjectRestore:Completed`
 
-For more complete documentation on the listed S3 events, see 
-:s3-docs:`S3 Supported Event Types
-<NotificationHowTo.html#notification-how-to-event-types-and-destinations>`.
+   * - ``scanner``
+     - | :data:`s3:Scanner:ManyVersions`
+       | :data:`s3:Scanner:BigPrefix`
+
+For more complete documentation on the listed S3 events, see :s3-docs:`S3 Supported Event Types <NotificationHowTo.html#notification-how-to-event-types-and-destinations>`.
 
 S3 Compatibility
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
mc [RELEASE.2023-08-29T22-55-06Z](https://github.com/minio/mc/releases/tag/RELEASE.2023-08-29T22-55-06Z) has changes that impact the docs:

- Adds `list` command to `mc admin kms key`
- Adds new group of `scanner` event types

There is no issue to track this release.

Staged at 
- [Scanner events](http://192.241.195.202:9000/staging/kmskey/linux/administration/monitoring/bucket-notifications.html#scanner-events)
- [`mc event add` supported events](http://192.241.195.202:9000/staging/kmskey/linux/reference/minio-mc/mc-event-add.html#mc-event-supported-events)
- [`mc admin kms key list`](http://192.241.195.202:9000/staging/kmskey/linux/reference/minio-mc-admin/mc-admin-kms-key.html#mc.admin.kms.key.list)