### PR TITLE
Adds information about role policy and roleARN for OpenID docs.

### DIFF
--- a/source/developers/security-token-service/AssumeRoleWithWebIdentity.rst
+++ b/source/developers/security-token-service/AssumeRoleWithWebIdentity.rst
@@ -123,11 +123,13 @@ This endpoint supports the following query parameters:
      - string
      - *Optional*   
 
-       The role ARN to use for all user authentication requests.
-       If used, there must be a Role Policy defined for the provider by the ``role_policy`` configuration parameter or the ``MINIO_IDENTITY_OPENID_ROLE_POLICY`` environment variable.
-       Likewise, if you configure a Role Policy, you must also specify the ``RoleARN``.
+       The role Amazon Resource Number (ARN) to use for all user authentication requests.
+       If used, there must be a matching OIDC RolePolicy defined for the RoleARN's provider by the ``role_policy`` configuration parameter or the ``MINIO_IDENTITY_OPENID_ROLE_POLICY`` environment variable.
        
-       When used, all valid authorization requests assume the same set of permissions provided by the Role Policy.
+       When used, all valid authorization requests assume the same set of permissions provided by the RolePolicy.
+       You can use  :ref:`OpenID Policy Variables <minio-policy-variables-oidc>` to create policies that programmatically manage what each individual user has access to.
+
+       If you do not supply a RoleARN, MinIO attempts to authorize through a JWT-based claim.
 
 Response Elements
 -----------------

--- a/source/developers/security-token-service/AssumeRoleWithWebIdentity.rst
+++ b/source/developers/security-token-service/AssumeRoleWithWebIdentity.rst
@@ -48,6 +48,8 @@ cluster:
    &DurationSeconds=86000
    &Policy={}
 
+.. _minio-assumerolewithwebidentity-query-parameters:
+
 Request Query Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -116,6 +118,16 @@ This endpoint supports the following query parameters:
 
        See :ref:`minio-access-management` for more information on MinIO
        authentication and authorization.
+
+   * - ``RoleARN``
+     - string
+     - *Optional*   
+
+       The role ARN to use for all user authentication requests.
+       If used, there must be a Role Policy defined for the provider by the ``role_policy`` configuration parameter or the ``MINIO_IDENTITY_OPENID_ROLE_POLICY`` environment variable.
+       Likewise, if you configure a Role Policy, you must also specify the ``RoleARN``.
+       
+       When used, all valid authorization requests assume the same set of permissions provided by the Role Policy.
 
 Response Elements
 -----------------

--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -24,6 +24,17 @@ may be optional depending on the provider.
 
 .. end-minio-openid-client-secret
 
+
+.. start-minio-openid-role-policy
+
+Specify a comma-separated list of :ref:`policy names <minio-policy>` to use for the request's ``RoleARN`` for all authentication requests for the provider.
+The specified policy or policies must already exist on the MinIO Server.
+
+When used, you must also specify the :ref:`RoleARN <minio-assumerolewithwebidentity-query-parameters>` in the authentication request.
+
+.. end-minio-openid-role-policy
+
+
 .. start-minio-openid-jwks-url
 
 Specify the URL for the JSON Web Key Set (JWKS) for MinIO to use when verifying

--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -30,7 +30,7 @@ may be optional depending on the provider.
 Specify a comma-separated list of :ref:`policy names <minio-policy>` to use for the request's ``RoleARN`` for all authentication requests for the provider.
 The specified policy or policies must already exist on the MinIO Server.
 
-When used, you must also specify the :ref:`RoleARN <minio-assumerolewithwebidentity-query-parameters>` in the authentication request.
+To use this OIDC configuration, you must specify the corresponding :ref:`RoleARN <minio-assumerolewithwebidentity-query-parameters>` in the STS request body.
 
 .. end-minio-openid-role-policy
 

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -2476,6 +2476,7 @@ configuration settings.
          :end-before: end-minio-openid-role-policy
 
       This configuration setting corresponds with the :envvar:`MINIO_IDENTITY_OPENID_ROLE_POLICY` environment variable.
+      This setting is mutually exclusive with the :mc-conf:`identity_openid claim_name <identity_openid.claim_name>` configuration setting.
    
    .. mc-conf:: claim_name
       :delimiter: " "
@@ -2487,7 +2488,8 @@ configuration settings.
          :end-before: end-minio-openid-claim-name
 
       This configuration setting corresponds with the :envvar:`MINIO_IDENTITY_OPENID_CLAIM_NAME` environment variable.
-      
+      This setting is mutually exclusive with the :mc-conf:`identity_openid role_policy <identity_openid.role_policy>` configuration setting.
+
    .. mc-conf:: claim_prefix
       :delimiter: " "
 

--- a/source/reference/minio-mc-admin/mc-admin-config.rst
+++ b/source/reference/minio-mc-admin/mc-admin-config.rst
@@ -2466,6 +2466,17 @@ configuration settings.
 
       This configuration setting corresponds with the :envvar:`MINIO_IDENTITY_OPENID_CLIENT_SECRET` environment variable.
       
+   .. mc-conf:: role_policy
+      :delimiter: " "
+
+      *Optional*
+
+      .. include:: /includes/common-minio-external-auth.rst
+         :start-after: start-minio-openid-role-policy
+         :end-before: end-minio-openid-role-policy
+
+      This configuration setting corresponds with the :envvar:`MINIO_IDENTITY_OPENID_ROLE_POLICY` environment variable.
+   
    .. mc-conf:: claim_name
       :delimiter: " "
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -2676,6 +2676,7 @@ identity management using an OpenID Connect (OIDC)-compatible provider. See
       :end-before: end-minio-openid-role-policy
    
    This environment variable corresponds with the :mc-conf:`identity_openid role_policy <identity_openid.role_policy>` configuration setting.
+   This variable is mutually exclusive with the :envvar:`MINIO_IDENTITY_OPENID_CLAIM_NAME` environment variable.
 
 .. envvar:: MINIO_IDENTITY_OPENID_CLAIM_NAME
 
@@ -2686,6 +2687,8 @@ identity management using an OpenID Connect (OIDC)-compatible provider. See
       :end-before: end-minio-openid-claim-name
    
    This environment variable corresponds with the :mc-conf:`identity_openid claim_name <identity_openid.claim_name>` configuration setting.
+   This variable is mutually exclusive with the :envvar:`MINIO_IDENTITY_OPENID_ROLE_POLICY` environment variable.
+
 
 .. envvar:: MINIO_IDENTITY_OPENID_CLAIM_PREFIX
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -2451,7 +2451,7 @@ endpoints as ``PRIMARY`` and ``SECONDARY`` respectively:
 .. _minio-server-envvar-object-lambda-webhook:
 
 Object Lambda
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 The following section documents environment variables for configuring MinIO to publish data to an HTTP webhook endpoint and trigger an Object Lambda function.
 See :ref:`developers-object-lambda` for more complete documentation and tutorials on using these environment variables.
@@ -2666,6 +2666,16 @@ identity management using an OpenID Connect (OIDC)-compatible provider. See
       :end-before: end-minio-openid-client-secret
    
    This environment variable corresponds with the :mc-conf:`identity_openid client_secret <identity_openid.client_secret>` configuration setting.
+
+.. envvar:: MINIO_IDENTITY_OPENID_ROLE_POLICY
+
+   *Optional*
+
+   .. include:: /includes/common-minio-external-auth.rst
+      :start-after: start-minio-openid-role-policy
+      :end-before: end-minio-openid-role-policy
+   
+   This environment variable corresponds with the :mc-conf:`identity_openid role_policy <identity_openid.role_policy>` configuration setting.
 
 .. envvar:: MINIO_IDENTITY_OPENID_CLAIM_NAME
 


### PR DESCRIPTION
Closes #933

- Adds envvar and config param
- Adds Role Policy openID authentication flow

Staged:
- [`AssumeRoleWithWebIdentity`](http://192.241.195.202:9000/staging/rolearn/linux/developers/security-token-service/AssumeRoleWithWebIdentity.html)
- [Environment Variable](http://192.241.195.202:9000/staging/rolearn/linux/reference/minio-server/minio-server.html#envvar.MINIO_IDENTITY_OPENID_ROLE_POLICY)
- [Config Parameter](http://192.241.195.202:9000/staging/rolearn/linux/reference/minio-mc-admin/mc-admin-config.html#mc-conf.identity_openid.role_policy)
- [Role Policy Auth Flow](http://192.241.195.202:9000/staging/rolearn/linux/administration/identity-access-management/oidc-access-management.html#role-policy-and-rolearn)