### PR TITLE
Adds explanation for new scanner events

### DIFF
--- a/source/administration/monitoring/bucket-notifications.rst
+++ b/source/administration/monitoring/bucket-notifications.rst
@@ -189,7 +189,12 @@ Scanner Events
 MinIO supports triggering notifications on the following S3 scanner transition events:
 
 .. data:: s3:Scanner:ManyVersions
+
+   Scanner finds objects with more than 1,000 versions.
+
 .. data:: s3:Scanner:BigPrefix
+
+   Scanner finds prefixes with more than 50,000 sub-folders.
 
 Global Events
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Internal discussion explained when scanner events trigger.
This adds the explanation for those two events.

No issue for this.