### PR TITLE
Document OpenShift service certificates for Operator deployments

### DIFF
--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -65,7 +65,7 @@ extlinks = {
     'podman-docs'     : ('https://docs.podman.io/en/latest/%s', None),
     'podman-git'      : ('https://github.com/containers/podman/%s', None),
     'docker-docs'     : ('https://docs.docker.com/%s', None),
-    'openshift-docs'  : ('https://docs.openshift.com/container-platform/4.11/%s', None),
+    'openshift-docs'  : ('https://docs.openshift.com/container-platform/4.13/%s', None),
     'influxdb-docs'   : ('https://docs.influxdata.com/influxdb/v2.4/%s', None),
     'eks-docs'        : ('https://docs.aws.amazon.com/eks/latest/userguide/%s', None),
     'minio-web'       : ('https://min.io/%s?ref=docs', None),

--- a/source/includes/k8s/deploy-operator.rst
+++ b/source/includes/k8s/deploy-operator.rst
@@ -95,7 +95,7 @@ Kubernetes TLS Certificate API
    The MinIO Operator manages TLS Certificate Signing Requests (CSR) using the Kubernetes ``certificates.k8s.io`` :kube-docs:`TLS certificate management API <tasks/tls/managing-tls-in-a-cluster/>` to create signed TLS certificates in the following circumstances:
    
    - When ``autoCert`` is enabled.
-   - For the MinIO Console when the :envvar:`OPERATOR_CONSOLE_TLS_ENABLE` environment variable is set to ``on``.
+   - For the MinIO Console when the :envvar:`MINIO_CONSOLE_TLS_ENABLE` environment variable is set to ``on``.
    - For :ref:`STS service <minio-security-token-service>` when :envvar:`OPERATOR_STS_ENABLED` environment variable is set to ``on``.
    - For retrieving the health of the cluster.
    

--- a/source/includes/openshift/deploy-minio-on-openshift.rst
+++ b/source/includes/openshift/deploy-minio-on-openshift.rst
@@ -140,7 +140,7 @@ Once installation completes, click :guilabel:`View Operator` to view the MinIO O
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you have installed the MinIO Operator from Red Hat OperatorHub, the installation process also configures the :openshift-docs:`OpenShift Service CA Operator <security/certificate_types_descriptions/service-ca-certificates.html>`.
-This Operator manages the the TLS certificates required to access the MinIO Operator Console and Tenants.
+This Operator manages the TLS certificates required to access the MinIO Operator Console and Tenants.
 It automatically renews and rotates the certificates 13 months before expiration.
 No additional action is required.
 

--- a/source/includes/openshift/deploy-minio-on-openshift.rst
+++ b/source/includes/openshift/deploy-minio-on-openshift.rst
@@ -151,7 +151,7 @@ See the dropdowns below for details.
 
    To manually enable the ``service-ca`` Operator to manage TLS certificates:
 
-   #. Use the following command to edit the deployment:
+   #. Use the following :openshift-docs:`oc <cli_reference/openshift_cli/getting-started-cli.html>` command to edit the deployment:
 
       .. code-block:: shell
          :class: copyable

--- a/source/includes/openshift/deploy-minio-on-openshift.rst
+++ b/source/includes/openshift/deploy-minio-on-openshift.rst
@@ -1,3 +1,4 @@
+
 .. _deploy-operator-openshift:
 
 =========================================
@@ -16,7 +17,7 @@ Overview
 Red Hat® OpenShift® is an enterprise-ready Kubernetes container platform with full-stack automated operations to manage hybrid cloud, multi-cloud, and edge deployments. 
 OpenShift includes an enterprise-grade Linux operating system, container runtime, networking, monitoring, registry, and authentication and authorization solutions. 
 
-You can deploy the MinIO Kubernetes Operator through the :openshift-docs:`Red Hat® OpenShift® Container Platform 4.7+ <welcome/index.html>`. 
+You can deploy the MinIO Kubernetes Operator through the :openshift-docs:`Red Hat® OpenShift® Container Platform 4.8+ <welcome/index.html>`. 
 You can deploy and manage MinIO Tenants through OpenShift after deploying the MinIO Operator. 
 This procedure includes instructions for the following deployment paths:
 
@@ -26,15 +27,15 @@ This procedure includes instructions for the following deployment paths:
 After deploying the MinIO Operator into your OpenShift cluster, you can create and manage MinIO Tenants through the :openshift-docs:`OperatorHub <operators/understanding/olm-understanding-operatorhub.html>` user interface.
 
 This documentation assumes familiarity with all referenced Kubernetes and OpenShift concepts, utilities, and procedures. 
-While this documentation *may* provide guidance for configuring or deploying Kubernetes-related or OpenShift-related resources on a best-effort basis, it is not a replacement for the official :kube-docs:`Kubernetes Documentation <>` and :openshift-docs:`OpenShift Container Platform 4.7+ Documentation <welcome/index.html>`.
+While this documentation *may* provide guidance for configuring or deploying Kubernetes-related or OpenShift-related resources on a best-effort basis, it is not a replacement for the official :kube-docs:`Kubernetes Documentation <>` and :openshift-docs:`OpenShift Container Platform 4.8+ Documentation <welcome/index.html>`.
 
 Prerequisites
 -------------
 
-RedHat OpenShift 4.7+
+RedHat OpenShift 4.8+
 ~~~~~~~~~~~~~~~~~~~~~
 
-The MinIO Kubernetes Operator is available starting with `OpenShift 4.7+ <https://docs.openshift.com/container-platform/4.7/welcome/index.html>`__.
+The MinIO Kubernetes Operator is available starting with `OpenShift 4.8+ <https://docs.openshift.com/container-platform/4.13/welcome/index.html>`__.
 
 Red Hat Marketplace installation requires registration of the OpenShift cluster with the Marketplace for the necessary namespaces.
 See `Register OpenShift cluster with Red Hat Marketplace <https://marketplace.redhat.com/en-us/documentation/clusters>`__ for complete instructions.
@@ -70,14 +71,30 @@ Select the tab that corresponds to your preferred installation method:
 
 .. tab-set::
 
+   .. tab-item:: Red Hat OperatorHub
+
+      Log into the OpenShift Web Console as a user with ``cluster-admin`` privileges. 
+
+      From the :guilabel:`Administrator` panel, select :guilabel:`Operators`, then :guilabel:`OperatorHub`.
+
+      From the :guilabel:`OperatorHub` page, type "MinIO" into the :guilabel:`Filter` text entry. Select the :guilabel:`MinIO Operator` tile from the search list.
+
+      .. image:: /images/openshift/minio-openshift-select-minio.png
+         :align: center
+         :width: 90%
+         :class: no-scaled-link
+         :alt: From the OperatorHub, search for MinIO, then select the MinIO Tile.
+
+      Select the :guilabel:`MinIO Operator` tile, then click :guilabel:`Install` to begin the installation.
+
    .. tab-item:: Red Hat Marketplace
 
-      Open the `MinIO Red Hat Marketplace listing <https://marketplace.redhat.com/en-us/products/minio-hybrid-cloud-object-storage>`__ in your browser. 
+      Open the `MinIO Red Hat Marketplace listing <https://marketplace.redhat.com/en-us/products/minio-hybrid-cloud-object-storage>`__ in your browser.
       Click :guilabel:`Login` to log in with your Red Hat Marketplace account.
-      
-      After logging in, click :guilabel:`Purchase` to purchase the MinIO Operator for your account. 
 
-      After completing the purchase, click :guilabel:`Workplace` from the top navigation and select :guilabel:`My Software`. 
+      After logging in, click :guilabel:`Purchase` to purchase the MinIO Operator for your account.
+
+      After completing the purchase, click :guilabel:`Workplace` from the top navigation and select :guilabel:`My Software`.
 
       .. image:: /images/openshift/minio-openshift-marketplace-my-software.png
          :align: center
@@ -86,23 +103,6 @@ Select the tab that corresponds to your preferred installation method:
          :alt: From the Red Hat Marketplace, select Workplace, then My Software
 
       Click :guilabel:`MinIO Hybrid Cloud Object Storage` and select :guilabel:`Install Operator` to start the Operator Installation procedure in OpenShift.
-
-   .. tab-item:: Red Hat OperatorHub
-
-      Log into the OpenShift Web Console as a user with ``cluster-admin`` privileges. 
-      
-      From the :guilabel:`Administrator` panel, select :guilabel:`Operators`, then :guilabel:`OperatorHub`.
-      
-      From the :guilabel:`OperatorHub` page, type "MinIO" into the :guilabel:`Filter` text entry. Select the :guilabel:`MinIO Operator` tile from the search list.
-      
-      .. image:: /images/openshift/minio-openshift-select-minio.png
-         :align: center
-         :width: 90%
-         :class: no-scaled-link
-         :alt: From the OperatorHub, search for MinIO, then select the MinIO Tile.
-
-      Select the :guilabel:`MinIO Operator` tile, then click 
-      :guilabel:`Install` to begin the installation.
 
 2) Configure and Deploy the Operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -125,7 +125,7 @@ The :guilabel:`Install Operator` page provides a walkthrough for configuring the
 
 See the :openshift-docs:`Operator Installation Documentation <operators/admin/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster>` :guilabel:`Step 5` for complete descriptions of each displayed option.
 
-Click :guilabel:`Install` to start the installation procedure. 
+Click :guilabel:`Install` to start the installation procedure.
 The web console displays a widget for tracking the installation progress.
 
 .. image:: /images/openshift/minio-openshift-operator-installation-progress.png
@@ -140,41 +140,49 @@ Once installation completes, click :guilabel:`View Operator` to view the MinIO O
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you have installed the MinIO Operator from Red Hat OperatorHub, the installation process also configures the :openshift-docs:`OpenShift Service CA Operator <security/certificate_types_descriptions/service-ca-certificates.html>`.
-This Operator manages the the TLS certificate required to access the MinIO Operator Console and Tenants.
-It automatically renews and rotates the certificate 13 months before expiration.
+This Operator manages the the TLS certificates required to access the MinIO Operator Console and Tenants.
+It automatically renews and rotates the certificates 13 months before expiration.
 No additional action is required.
 
-For Operator installations deployed from Red Hat Marketplace or other methods, configure the :openshift-docs:`Service CA certificates <security/certificate_types_descriptions/service-ca-certificates.html>` manually.
-See the instructions in the dropdown below for details.
+For Operator installations deployed by other methods, configure the :openshift-docs:`Service CA certificates <security/certificate_types_descriptions/service-ca-certificates.html>` manually.
+See the dropdowns below for details.
 
 .. dropdown:: OpenShift Service CA Certificate configuration
 
    To manually enable the ``service-ca`` Operator to manage TLS certificates:
 
-   #. Configure the following MinIO :ref:`environment variables <minio-server-environment-variables>`:
+   #. Use the following command to edit the deployment:
 
-      .. list-table::
-         :header-rows: 1
+      .. code-block:: shell
+         :class: copyable
 
-         * - Environment Variable
-           - Value
+         oc edit deployment minio-operator  -n minio-operator
 
-         * - :envvar:`MINIO_CONSOLE_TLS_ENABLE`
-           - ``on``
+      If needed, replace ``minio-operator`` with the name and namespace of your deployment.
+      ``oc edit`` opens the deployment configuration file in an editor.
 
-         * - :envvar:`OPERATOR_STS_ENABLED`
-           - ``off``
+   #. In the ``spec`` section, add the highlighted MinIO Operator :ref:`environment variables <minio-server-environment-variables>`:
 
-         * - :envvar:`MINIO_OPERATOR_RUNTIME`
-           - ``OpenShift``
+      .. code-block:: shell
+         :class: copyable
+         :emphasize-lines: 5-8
 
-   #. Configure the following ``volumes`` and ``volumeMounts`` in ``something.yaml``:
+         containers:
+         - args:
+           - controller
+           env:
+            - name: MINIO_CONSOLE_TLS_ENABLE
+              value: 'on'
+            - name: MINIO_OPERATOR_RUNTIME
+              value: OpenShift
+
+   #. In the ``volumes`` section, add the following volumes and volume mounts:
 
       - ``sts-tls``
       - ``openshift-service-ca``
       - ``openshift-csr-signer-ca``
 
-      The YAML configuration resembles the following:
+      The added volume configuration resembles the following:
 
       .. code-block:: shell
          :class: copyable
@@ -210,27 +218,80 @@ See the instructions in the dropdown below for details.
                          path: tls.crt
                      optional: true
                defaultMode: 420
+             volumeMounts:
+               - name: openshift-service-ca
+                 mountPath: /tmp/service-ca
+               - name: openshift-csr-signer-ca
+                 mountPath: /tmp/csr-signer-ca
+               - name: sts-tls
+                 mountPath: /tmp/sts
 
-         imagePullPolicy: IfNotPresent
-         volumeMounts:
-           - name: openshift-service-ca
-             mountPath: /tmp/service-ca
-           - name: openshift-csr-signer-ca
-             mountPath: /tmp/csr-signer-ca
-           - name: sts-tls
-             mountPath: /tmp/sts
+.. dropdown:: OpenShift Service CA Certificate for Helm deployments
 
+   For Helm deployments on OpenShift, add the following :ref:`environment variables <minio-server-environment-variables>` and volumes to the ``values.yaml`` in the Operator Helm chart before deploying.
+
+   The added YAML configuration for the ``operator`` pod resembles the following:
+
+   .. code-block::
+      :class: copyable
+
+      operator:
+        env:
+          - name: MINIO_OPERATOR_RUNTIME
+            value: "OpenShift"
+          - name: MINIO_CONSOLE_TLS_ENABLE
+            value: "on"
+
+        volumes:
+          - name: sts-tls
+            projected:
+              sources:
+                - secret:
+                    name: sts-tls
+                    items:
+                      - key: tls.crt
+                        path: public.crt
+                      - key: tls.key
+                        path: private.key
+                    optional: true
+              defaultMode: 420
+          - name: openshift-service-ca
+            configMap:
+              name: openshift-service-ca.crt
+              items:
+                - key: service-ca.crt
+                  path: service-ca.crt
+              defaultMode: 420
+              optional: true
+          - name: openshift-csr-signer-ca
+            projected:
+              sources:
+                - secret:
+                    name: openshift-csr-signer-ca
+                    items:
+                      - key: tls.crt
+                        path: tls.crt
+                    optional: true
+              defaultMode: 420
+        volumeMounts:
+          - name: openshift-service-ca
+            mountPath: /tmp/service-ca
+          - name: openshift-csr-signer-ca
+            mountPath: /tmp/csr-signer-ca
+          - name: sts-tls
+            mountPath: /tmp/sts
+	     
 
 4) Open the MinIO Operator Interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can find the MinIO Operator Interface from the :guilabel:`Operators` left-hand navigation header.
+You can find the MinIO Operator Interface from the :guilabel:`Operators` left-hand navigation header
 
-1. Go to :guilabel:`Operators`, then :guilabel:`Installed Operators`. 
+1. Go to :guilabel:`Operators`, then :guilabel:`Installed Operators`.
 
 2. For the :guilabel:`Project` dropdown, select :guilabel:`openshift-operators`.
 
-3. Select :guilabel:`MinIO Operators` from the list of installed operators. 
+3. Select :guilabel:`MinIO Operators` from the list of installed operators.
    The :guilabel:`Status` column must read :guilabel:`Success` to access the Operator interface.
 
 5) Access the Operator Console
@@ -250,9 +311,9 @@ The following steps provides a summary of actions necessary to create a Route.
 #. Set the :guilabel:`Hostname` as per your organizations networking and hostname topology.
    Omit the hostname to allow OpenShift to generate it automatically
 #. Set the :guilabel:`Service` to :guilabel:`console`
-#. Set the :Guilabel:`Target Port` to  ``9090`` 
+#. Set the :Guilabel:`Target Port` to  ``9090``
 
-You can then access the Operator Console using the configured Route. 
+You can then access the Operator Console using the configured Route.
 The Operator Console still requires using the generated JWT token for access, which you can generate at any time using ``oc minio port-forward``.
 
 6) Next Steps
@@ -260,5 +321,3 @@ The Operator Console still requires using the generated JWT token for access, wh
 
 After deploying the MinIO Operator, you can create a new MinIO Tenant.
 To deploy a MinIO Tenant using OpenShift, see :ref:`deploy-minio-tenant-redhat-openshift`.
-
-

--- a/source/reference/kubectl-minio-plugin.rst
+++ b/source/reference/kubectl-minio-plugin.rst
@@ -165,7 +165,7 @@ Available MinIO Operator Environment Variables
 
    When not specified, the default value is ``operator``.
 
-.. envvar:: OPERATOR_CONSOLE_TLS_ENABLE
+.. envvar:: MINIO_CONSOLE_TLS_ENABLE
 
    Toggle Console TLS service ``on`` or ``off``.
 


### PR DESCRIPTION
MinIO Operator on OpenShift may require manual configuration of TLS cert management via the OpenShift `service-ca` Operator. (For deployments that are _not_ done through Red Hat OperatorHub.)

Document the needed envvars, `volumes`, and `volumeMounts` to enable `service-ca` and avoid the need to manually renew certs.

~Note: This presumes kustomize, additional research/testing required to determine configuration for Helm chart deployments.~

Staged
http://192.241.195.202:9000/staging/DOCS-991/openshift/operations/installation.html#procedure

See also: https://github.com/minio/wiki/wiki/Besides-MINIO_OPERATOR_RUNTIME-what-else-is-needed-in-Operator%3F

Fixes https://github.com/minio/docs/issues/991 (remaining item for v5.0.8)