### PR TITLE
Batch replication requires realtime tier

### DIFF
--- a/source/administration/batch-framework.rst
+++ b/source/administration/batch-framework.rst
@@ -124,7 +124,9 @@ Replicate
 
 Use the ``replicate`` job type to create a batch job that replicates objects from one MinIO deployment (the ``source`` deployment) to another MinIO deployment (the ``target`` deployment).
 Either the ``source`` or the ``target`` **must** be the :ref:`local <minio-batch-local>` deployment.
-Starting with the MinIO Server ``RELEASE.2023-05-04T21-44-30Z``, the other deployment can be either another MinIO deployment or any S3-compatible location.
+
+Starting with the MinIO Server ``RELEASE.2023-05-04T21-44-30Z``, the other deployment can be either another MinIO deployment or any S3-compatible location using a realtime storage class.
+For example, when replicating objects from S3 to MinIO, MinIO skips any objects tiered to the ``GLACIER`` storage class.
 
 The batch job definition file can limit the replication by bucket, prefix, and/or filters to only replicate certain objects.
 The access to objects and buckets for the replication process may be restricted by the credentials you provide in the YAML for either the source or target destinations. 

--- a/source/administration/batch-framework.rst
+++ b/source/administration/batch-framework.rst
@@ -126,7 +126,7 @@ Use the ``replicate`` job type to create a batch job that replicates objects fro
 Either the ``source`` or the ``target`` **must** be the :ref:`local <minio-batch-local>` deployment.
 
 Starting with the MinIO Server ``RELEASE.2023-05-04T21-44-30Z``, the other deployment can be either another MinIO deployment or any S3-compatible location using a realtime storage class.
-For example, when replicating objects from S3 to MinIO, MinIO skips any objects tiered to the ``GLACIER`` storage class.
+Use filtering options in the replication ``YAML`` file to exclude objects stored in locations that require rehydration or other restoration methods before serving the requested object.
 
 The batch job definition file can limit the replication by bucket, prefix, and/or filters to only replicate certain objects.
 The access to objects and buckets for the replication process may be restricted by the credentials you provide in the YAML for either the source or target destinations. 

--- a/source/reference/minio-mc/mc-batch-generate.rst
+++ b/source/reference/minio-mc/mc-batch-generate.rst
@@ -325,7 +325,7 @@ For **flag based filters**
        Keys rotate only for objects created prior to the date.
    * - ``tags:``
      - Rotate keys only for objects with tags that match the specified ``key:`` and ``value:``.  
-   * - ``metadtaa:``
+   * - ``metadata:``
      - Rotate keys only for objects with metadata that match the specified ``key:`` and ``value:``.  
    * - ``kmskey:``
      - Rotate keys only for objects with a KMS key-id that match the specified value.  


### PR DESCRIPTION
Based on discussion of https://github.com/minio/minio/pull/18044, adding info to the batch replication doc about requiring a realtime tier for replication.

Not staged.