### PR TITLE
Fixed credentials labels (MINIO_ROOT_USER and MINIO_ROOT_PASSWORD) in env file

### DIFF
--- a/source/includes/common/common-deploy.rst
+++ b/source/includes/common/common-deploy.rst
@@ -9,13 +9,13 @@ The following example provides a starting environment file:
 .. code-block:: shell
    :class: copyable
 
-   # MINIO_ROOT_USER and MINIO_ROOT_PASSWORD sets the root account for the MinIO server.
+   # MINIO_ACCESS_KEY and MINIO_SECRET_KEY sets the root account for the MinIO server.
    # This user has unrestricted permissions to perform S3 and administrative API operations on any resource in the deployment.
    # Omit to use the default values 'minioadmin:minioadmin'.
    # MinIO recommends setting non-default values as a best practice, regardless of environment
 
-   MINIO_ROOT_USER=myminioadmin
-   MINIO_ROOT_PASSWORD=minio-secret-key-change-me
+   MINIO_ACCESS_KEY=myminioadmin
+   MINIO_SECRET_KEY=minio-secret-key-change-me
 
    # MINIO_VOLUMES sets the storage volume or path to use for the MinIO server.
 
@@ -43,13 +43,13 @@ The following example provides a starting environment file:
 .. code-block:: shell
    :class: copyable
 
-   # MINIO_ROOT_USER and MINIO_ROOT_PASSWORD sets the root account for the MinIO server.
+   # MINIO_ACCESS_KEY and MINIO_SECRET_KEY sets the root account for the MinIO server.
    # This user has unrestricted permissions to perform S3 and administrative API operations on any resource in the deployment.
    # Omit to use the default values 'minioadmin:minioadmin'.
    # MinIO recommends setting non-default values as a best practice, regardless of environment.
 
-   MINIO_ROOT_USER=myminioadmin
-   MINIO_ROOT_PASSWORD=minio-secret-key-change-me
+   MINIO_ACCESS_KEY=myminioadmin
+   MINIO_SECRET_KEY=minio-secret-key-change-me
 
    # MINIO_VOLUMES sets the storage volumes or paths to use for the MinIO server.
    # The specified path uses MinIO expansion notation to denote a sequential series of drives between 1 and 4, inclusive.

--- a/source/includes/linux/common-installation.rst
+++ b/source/includes/linux/common-installation.rst
@@ -94,7 +94,7 @@ To update deployments managed using ``systemctl``, see :ref:`minio-upgrade-syste
    
             wget https://dl.min.io/server/minio/release/linux-arm64/minio
             chmod +x minio
-            MINIO_ROOT_USER=admin MINIO_ROOT_PASSWORD=password ./minio server /mnt/data --console-address ":9001"
+            MINIO_ACCESS_KEY=admin MINIO_SECRET_KEY=password ./minio server /mnt/data --console-address ":9001"
 
 .. dropdown:: Other Architectures
 


### PR DESCRIPTION
Hello, 

i tried to install MinIO on a debian 12 VM. Following the doc, I had an error when I started the service. 

`Access key length should be at least 3, and secret key length at least 8 characters
HINT:
> Please provide correct credentials
ERROR Unable to validate credentials inherited from the shell environment: Invalid credentials
`
I found another doc with different labels for USER/PASSWORD.
https://www.howtoforge.com/how-to-install-minio-storage-server-on-debian-11#configure-minio

I replaced the label and it works! 