### PR TITLE
Updates for mc RELEASE.2023-08-30T08-02-26Z

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -338,18 +338,18 @@ Syntax
                                minio1         \
                                --user janedoe
 
-         The output of any of hte above examples resembles the following:
+         The output of any of the above examples resembles the following:
 
          .. code-block:: shell
 
             Bucket replication status:
-            ●  30/30 Buckets in sync
+            -  30/30 Buckets in sync
             
             Policy replication status:
-            ●  5/5 Policies in sync
+            -  5/5 Policies in sync
             
             User replication status:
-            ●  3/3 Users in sync
+            -  3/3 Users in sync
             
             Group replication status:
             No Groups present
@@ -358,7 +358,7 @@ Syntax
             Replication status since 1 day 
             Summary:
             Replicated:    0 objects (0 B)
-            Queued:        ● 0 objects, (0 B) (avg: 0 objects, 0 B; max: 0 objects, 0 B)
+            Queued:        - 0 objects, (0 B) (avg: 0 objects, 0 B; max: 0 objects, 0 B)
             Received:      0 objects (0 B)
 
       .. tab-item:: SYNTAX

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -338,6 +338,29 @@ Syntax
                                minio1         \
                                --user janedoe
 
+         The output of any of hte above examples resembles the following:
+
+         .. code-block:: shell
+
+            Bucket replication status:
+            ●  30/30 Buckets in sync
+            
+            Policy replication status:
+            ●  5/5 Policies in sync
+            
+            User replication status:
+            ●  3/3 Users in sync
+            
+            Group replication status:
+            No Groups present
+            
+            Object replication status:
+            Replication status since 1 day 
+            Summary:
+            Replicated:    0 objects (0 B)
+            Queued:        ● 0 objects, (0 B) (avg: 0 objects, 0 B; max: 0 objects, 0 B)
+            Received:      0 objects (0 B)
+
       .. tab-item:: SYNTAX
          
          .. code-block:: shell


### PR DESCRIPTION
Adds example output for `mc admin replicate status` to reflect expanded output.

Closes #988 

Staged: http://192.241.195.202:9000/staging/replicate-status/linux/reference/minio-mc-admin/mc-admin-replicate.html#mc.admin.replicate.status