### PR TITLE
Updates for mc RELEASE.2023-09-20T15-22-31Z

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -95,14 +95,13 @@ Syntax
      
      Removes dangling objects and data directories in the healing process not referenced by the metadata on a per-drive basis.
 
-Colors
-------
+Healing Output Color Key
+------------------------
 
-Originally, the healing mechanism output a table that used colors to attempt to differentiate the status of objects in healing.
-These colors lack much useful detail and have been deprecated in favor of :ref:`healing metrics available at the cluster level <minio-metrics-and-alerts-available-metrics>`.
+Originally, the healing mechanism output a table that used a Green-Yellow-Red-Gray color key to attempt to differentiate the status of objects in healing.
+These colors have been deprecated in favor of more detailed :ref:`healing metrics available at the cluster level <minio-metrics-and-alerts-available-metrics>`.
 
-Originally, the colors conveyed the following intent:
-
+The following table describes the intent of each of the deprecated color keys.
 
 .. list-table::
    :widths: 25 75

--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -42,7 +42,7 @@ Syntax
 
    mc admin heal [FLAGS] TARGET
 
-:mc-cmd:`mc admin heal` supports the following arguments:
+:mc-cmd:`mc admin heal` supports the following argument:
 
 .. mc-cmd:: TARGET
 
@@ -60,37 +60,39 @@ Syntax
    If the ``TARGET`` bucket or bucket prefix has an active healing scan,
    the command returns the status of that scan.
 
-.. mc-cmd:: --scan
-   
+Deprecated Arguments
+++++++++++++++++++++
 
-   The type of scan to perform. Specify one of the following supported scan
-   modes:
+The following command flags have been deprecated and should only be used under guidance from MinIO Engineers in association with a SUBNET ticket.
 
-   - ``normal`` (default)
-   - ``deep``
+.. dropdown::
 
-.. mc-cmd:: --recursive, r
-   
+   :--scan: The type of scan to perform. Specify one of the following supported scan modes:
+     - ``normal`` (default)
+     - ``deep``
 
-   Recursively scans for objects in the specified bucket or bucket prefix.
+   :--recursive, r: Recursively scans for objects in the specified bucket or bucket prefix.
 
-.. mc-cmd:: --dry-run
-   
+   :--dry-run: Inspects the :mc-cmd:`~mc admin heal TARGET` bucket or bucket prefix, but does *not* perform any object healing.
 
-   Inspects the :mc-cmd:`~mc admin heal TARGET` bucket or bucket prefix, 
-   but does *not* perform any object healing.
+   :--force-start, f: Force starts the healing process.
 
-.. mc-cmd:: --force-start, f
-   
+   :--force-stop, s: Force stops the healing sequence.
 
-   Force starts the healing process.
+   :--remove: Removes dangling objects and data directories in the healing process not referenced by the metadata on a per-drive basis.
 
-.. mc-cmd:: --force-stop, s
-   
+Colors
+------
 
-   Force stops the healing sequence.
+Originally, the healing mechanism output a table that used colors to attempt to differentiate the status of objects in healing.
+These colors lack much useful detail and have been deprecated in favor of :ref:`healing metrics available at the cluster level <minio-metrics-and-alerts-available-metrics>`.
 
-.. mc-cmd:: --remove
-   
+Originally, the colors conveyed the following intent:
 
-   Removes dangling objects and data directories in the healing process not referenced by the metadata on a per-drive basis.
+:Green: *Healthy*, the object has all data and parity shards available as required to serve the object
+
+:Yellow: *Healing*, the object is still in the process of healing, and there are sufficient data or parity shards available to complete the healing
+
+:Red: *Unhealthy*, the object has lost one or more shards and requires healing
+
+:Grey: *Unrecoverable*, the object has lost too many data and/or parity shards and cannot be healed or recovered

--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -60,26 +60,40 @@ Syntax
    If the ``TARGET`` bucket or bucket prefix has an active healing scan,
    the command returns the status of that scan.
 
-Deprecated Arguments
+
 ++++++++++++++++++++
 
-The following command flags have been deprecated and should only be used under guidance from MinIO Engineers in association with a SUBNET ticket.
 
-.. dropdown::
+.. dropdown:: Deprecated Arguments
 
-   :--scan: The type of scan to perform. Specify one of the following supported scan modes:
-     - ``normal`` (default)
-     - ``deep``
+   The following command flags have been deprecated and should only be used under guidance from MinIO Engineers in association with a SUBNET ticket.
 
-   :--recursive, r: Recursively scans for objects in the specified bucket or bucket prefix.
+   - ``--scan`` 
+     
+     The type of scan to perform. Specify one of the following supported scan modes:
 
-   :--dry-run: Inspects the :mc-cmd:`~mc admin heal TARGET` bucket or bucket prefix, but does *not* perform any object healing.
+       - ``normal`` (default)
+       - ``deep``
 
-   :--force-start, f: Force starts the healing process.
+   - ``--recursive, r`` 
+     
+     Recursively scans for objects in the specified bucket or bucket prefix.
 
-   :--force-stop, s: Force stops the healing sequence.
+   - ``--dry-run`` 
+     
+     Inspects the :mc-cmd:`~mc admin heal TARGET` bucket or bucket prefix, but does *not* perform any object healing.
 
-   :--remove: Removes dangling objects and data directories in the healing process not referenced by the metadata on a per-drive basis.
+   - ``--force-start, f`` 
+     
+     Force starts the healing process.
+
+   - ``--force-stop, s`` 
+     
+     Force stops the healing sequence.
+
+   - ``--remove`` 
+     
+     Removes dangling objects and data directories in the healing process not referenced by the metadata on a per-drive basis.
 
 Colors
 ------
@@ -89,10 +103,19 @@ These colors lack much useful detail and have been deprecated in favor of :ref:`
 
 Originally, the colors conveyed the following intent:
 
-:Green: *Healthy*, the object has all data and parity shards available as required to serve the object
 
-:Yellow: *Healing*, the object is still in the process of healing, and there are sufficient data or parity shards available to complete the healing
+.. list-table::
+   :widths: 25 75
+   :width: 100%
 
-:Red: *Unhealthy*, the object has lost one or more shards and requires healing
+   * - **Green**
+     - *Healthy*, the object has all data and parity shards available as required to serve the object
+ 
+   * - **Yellow** 
+     - *Healing*, the object is still in the process of healing, and there are sufficient data or parity shards available to complete the healing
 
-:Grey: *Unrecoverable*, the object has lost too many data and/or parity shards and cannot be healed or recovered
+   * - **Red** 
+     - *Unhealthy*, the object has lost one or more shards and requires healing
+
+   * - **Grey** 
+     -  *Unrecoverable*, the object has lost too many data and/or parity shards and cannot be healed or recovered

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -49,24 +49,25 @@ The :mc:`mc mirror` command synchronizes content to MinIO deployment, similar to
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] mirror                           \
-                          [--attr "string"]                \
-                          [--disable-multipart]            \
-                          [--dry-run]                      \
-                          [--encrypt-key "string"]         \
-                          [--exclude "string"]             \
-                          [--limit-download string]        \
-                          [--limit-upload string]          \
-                          [--md5]                          \
-                          [--monitoring-address "string"]  \
-                          [--newer-than "string"]          \
-                          [--older-than "string"]          \
-                          [--preserve]                     \
-                          [--region "string"]              \
-                          [--remove]                       \
-                          [--storage-class "string"]       \
-                          [--watch]                        \
-                          SOURCE                           \ 
+         mc [GLOBALFLAGS] mirror                            \
+                          [--attr "string"]                 \
+                          [--disable-multipart]             \
+                          [--dry-run]                       \
+                          [--encrypt-key "string"]          \
+                          [--exclude "string"]              \
+                          [--exclude-storageclass "string"] \
+                          [--limit-download string]         \
+                          [--limit-upload string]           \
+                          [--md5]                           \
+                          [--monitoring-address "string"]   \
+                          [--newer-than "string"]           \
+                          [--older-than "string"]           \
+                          [--preserve]                      \
+                          [--region "string"]               \
+                          [--remove]                        \
+                          [--storage-class "string"]        \
+                          [--watch]                         \
+                          SOURCE                            \ 
                           TARGET
 
       .. include:: /includes/common-minio-mc.rst
@@ -142,6 +143,14 @@ Parameters
    
 
    Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified object name pattern.
+
+.. mc-cmd:: --exclude
+   
+
+   Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path from the specified storage class.
+   You can use this flag multiple times in a command to exclude objects from more than one storage class.
+
+   Use this when migrating from AWS S3 to MinIO to exclude objects from ``GLACIER`` or ``DEEP_ARCHIVE`` storage.
 
 .. mc-cmd:: --dry-run
    
@@ -303,7 +312,7 @@ Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --watch` to continuously mirror fil
 Continuously Mirror S3 Bucket to an S3-Compatible Host
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --watch` to continuously mirror objects in a bucket on one S3-compatible host to another S3-compatible host where objects added to or deleted from the bucket are added to or deleted from the host.f
+Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --watch` to continuously mirror objects in a bucket on one S3-compatible host to another S3-compatible host where objects added to or deleted from the bucket are added to or deleted from the host.
 
 .. code-block::
    :class: copyable
@@ -315,6 +324,25 @@ Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --watch` to continuously mirror obj
 - Replace :mc-cmd:`SRCPATH <mc mirror SOURCE>` with the bucket to mirror.
 
 - Replace :mc-cmd:`TGTALIAS <mc mirror TARGET>` with the :mc-cmd:`alias <mc alias>` of a configured S3-compatible host.
+
+- Replace :mc-cmd:`TGTPATH <mc mirror TARGET>` with the destination bucket.
+
+Mirror Objects from AWS S3 to MinIO Skipping Objects in GLACIER
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --exclude-storageclass` to mirror objects from AWS S3 to MinIO without mirroring objects in GLACIER or DEEP_ARCHIVE storage.
+
+.. code-block::
+   :class: copyable
+   
+   mc mirror --exclude-storageclass GLACIER  \
+      --exclude-storageclass DEEP_ARCHIVE SRCALIAS/SRCPATH TGALIAS/TGPATH
+
+- Replace :mc-cmd:`SRCALIAS <mc mirror SOURCE>` with the :mc-cmd:`alias <mc alias>` of a configured S3 host.
+
+- Replace :mc-cmd:`SRCPATH <mc mirror SOURCE>` with the bucket to mirror.
+
+- Replace :mc-cmd:`TGTALIAS <mc mirror TARGET>` with the :mc-cmd:`alias <mc alias>` of a configured S3 host.
 
 - Replace :mc-cmd:`TGTPATH <mc mirror TARGET>` with the destination bucket.
 

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -147,10 +147,10 @@ Parameters
 .. mc-cmd:: --exclude-storageclass
    
 
-   Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path from the specified storage class.
+   Exclude object(s) on the :mc-cmd:`~mc mirror SOURCE` that have the specified storage class.
    You can use this flag multiple times in a command to exclude objects from more than one storage class.
 
-   Use this when migrating from AWS S3 to MinIO to exclude objects from ``GLACIER`` or ``DEEP_ARCHIVE`` storage.
+   Use this to exclude objects with storage classes that require rehydration or restoration of objects, such as migrating from an AWS S3 bucket where some objects have the ``GLACIER`` or ``DEEP_ARCHIVE`` storage classes.
 
 .. mc-cmd:: --dry-run
    

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -144,7 +144,7 @@ Parameters
 
    Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified object name pattern.
 
-.. mc-cmd:: --exclude
+.. mc-cmd:: --exclude-storageclass
    
 
    Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path from the specified storage class.


### PR DESCRIPTION
- Deprecates mc admin heal flags
- Adds info about healing colors
- Adds mc mirror --exclude-storageclass flag
    
Closes #1009
Closes #1005

Staged:

- http://192.241.195.202:9000/staging/mc-2023-09-20/linux/reference/minio-mc/mc-mirror.html#mc.mirror.-exclude-storageclass
- http://192.241.195.202:9000/staging/mc-2023-09-20/linux/reference/minio-mc-admin/mc-admin-heal.html