### PR TITLE
Improve mc deprecated reference: cleanup, move mc admin top

### DIFF
--- a/source/reference/deprecated/mc-admin-bucket-quota.rst
+++ b/source/reference/deprecated/mc-admin-bucket-quota.rst
@@ -12,7 +12,11 @@
 
 .. versionchanged:: RELEASE.2022-12-13T00-23-28Z
 
-   ``mc admin bucket quota`` replaced by :mc-cmd:`mc quota set`, :mc-cmd:`mc quota info`, and :mc-cmd:`mc quota clear`.
+   ``mc admin bucket quota`` replaced by:
+
+   - :mc-cmd:`mc quota set`
+   - :mc-cmd:`mc quota info`
+   - :mc-cmd:`mc quota clear`
 
 Description
 -----------

--- a/source/reference/deprecated/mc-admin-idp-ldap-policy.rst
+++ b/source/reference/deprecated/mc-admin-idp-ldap-policy.rst
@@ -14,7 +14,7 @@
 
 .. versionchanged:: RELEASE.2023-05-26T23-31-54Z
 
-   ``mc admin idp ldap policy`` has moved to  :mc-cmd:`mc idp ldap policy`.
+   ``mc admin idp ldap policy`` and its subcommands replaced by :mc-cmd:`mc idp ldap policy`.
 
 Description
 -----------

--- a/source/reference/deprecated/mc-admin-idp-ldap.rst
+++ b/source/reference/deprecated/mc-admin-idp-ldap.rst
@@ -14,7 +14,7 @@
 
 .. versionchanged:: RELEASE.2023-05-26T23-31-54Z
 
-   ``mc admin idp ldap`` and its subcommands have moved to  :mc-cmd:`mc idp ldap`.
+   ``mc admin idp ldap`` and its subcommands replaced by :mc-cmd:`mc idp ldap`.
 
 Description
 -----------

--- a/source/reference/deprecated/mc-admin-idp-openid.rst
+++ b/source/reference/deprecated/mc-admin-idp-openid.rst
@@ -14,7 +14,7 @@
 
 .. versionchanged:: RELEASE.2023-05-26T23-31-54Z
 
-   ``mc admin idp openid`` and its subcommands have moved to  :mc-cmd:`mc idp openid`.
+   ``mc admin idp openid`` and its subcommands replaced by :mc-cmd:`mc idp openid`.
 
 Description
 -----------

--- a/source/reference/deprecated/mc-admin-speedtest.rst
+++ b/source/reference/deprecated/mc-admin-speedtest.rst
@@ -12,9 +12,7 @@
 
 .. versionchanged:: RELEASE.2022-07-24T02-25-13Z
 
-.. important:: 
-
-   The ``mc admin speedtest`` function has moved to the :mc:`mc support perf` command.
+   ``mc admin speedtest`` replaced by :mc:`mc support perf`.
 
 Description
 -----------

--- a/source/reference/deprecated/mc-admin-top.rst
+++ b/source/reference/deprecated/mc-admin-top.rst
@@ -10,11 +10,9 @@
 
 .. mc:: mc admin top
 
-.. note::
+.. versionchanged:: RELEASE.2022-08-11T00-30-48Z
 
-   .. versionchanged:: RELEASE.2022-08-11T00-30-48Z
-
-   :mc-cmd:`mc support top` replaces the ``mc admin top`` command.
+   ``mc admin top`` replaced by :mc-cmd:`mc support top`.
 
 Description
 -----------

--- a/source/reference/deprecated/mc-ilm-add.rst
+++ b/source/reference/deprecated/mc-ilm-add.rst
@@ -14,7 +14,7 @@
 
 .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
 
-   ``mc ilm add`` replaced by :mc-cmd:`mc ilm rule add`
+   ``mc ilm add`` replaced by :mc-cmd:`mc ilm rule add`.
 
 Syntax
 ------

--- a/source/reference/deprecated/mc-ilm-edit.rst
+++ b/source/reference/deprecated/mc-ilm-edit.rst
@@ -14,7 +14,7 @@
 
 .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
 
-   ``mc ilm edit`` replaced by :mc-cmd:`mc ilm rule edit`
+   ``mc ilm edit`` replaced by :mc-cmd:`mc ilm rule edit`.
 
 
 Syntax

--- a/source/reference/deprecated/mc-ilm-export.rst
+++ b/source/reference/deprecated/mc-ilm-export.rst
@@ -14,7 +14,7 @@
 
 .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
 
-   ``mc ilm export`` replaced by :mc-cmd:`mc ilm rule export`
+   ``mc ilm export`` replaced by :mc-cmd:`mc ilm rule export`.
 
 
 Syntax

--- a/source/reference/deprecated/mc-ilm-import.rst
+++ b/source/reference/deprecated/mc-ilm-import.rst
@@ -14,7 +14,7 @@
 
 .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
 
-   ``mc ilm import`` replaced by :mc-cmd:`mc ilm rule import`
+   ``mc ilm import`` replaced by :mc-cmd:`mc ilm rule import`.
 
 
 Syntax

--- a/source/reference/deprecated/mc-ilm-ls.rst
+++ b/source/reference/deprecated/mc-ilm-ls.rst
@@ -14,7 +14,7 @@
 
 .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
 
-   ``mc ilm ls`` replaced by :mc-cmd:`mc ilm rule ls`
+   ``mc ilm ls`` replaced by :mc-cmd:`mc ilm rule ls`.
 
 
 Syntax

--- a/source/reference/deprecated/mc-ilm-rm.rst
+++ b/source/reference/deprecated/mc-ilm-rm.rst
@@ -15,7 +15,7 @@
 
 .. versionchanged:: RELEASE.2022-12-24T15-21-38Z
 
-   ``mc ilm rm`` replaced by :mc-cmd:`mc ilm rule rm`
+   ``mc ilm rm`` replaced by :mc-cmd:`mc ilm rule rm`.
 
 
 Syntax

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -120,11 +120,6 @@ The following table lists :mc:`mc admin` commands:
           :start-after: start-mc-admin-service-desc
           :end-before: end-mc-admin-service-desc
 
-   * - :mc-cmd:`mc admin top`
-     - .. include:: /reference/minio-mc-admin/mc-admin-top.rst
-          :start-after: start-mc-admin-top-desc
-          :end-before: end-mc-admin-top-desc
-
    * - :mc-cmd:`mc admin trace`
      - .. include:: /reference/minio-mc-admin/mc-admin-trace.rst
           :start-after: start-mc-admin-trace-desc
@@ -212,7 +207,6 @@ See :ref:`minio-mc-global-options`.
    /reference/minio-mc-admin/mc-admin-rebalance
    /reference/minio-mc-admin/mc-admin-replicate
    /reference/minio-mc-admin/mc-admin-service
-   /reference/minio-mc-admin/mc-admin-top
    /reference/minio-mc-admin/mc-admin-trace
    /reference/minio-mc-admin/mc-admin-update
    /reference/minio-mc-admin/mc-admin-user

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -27,10 +27,6 @@ Table of Deprecated Commands
      - Replacement Command
      - Version of Change
 
-   * - ``mc replicate diff``
-     - :mc-cmd:`mc replicate backlog`
-     - mc RELEASE.2023-07-18T21-05-38Z
-
    * - ``mc ilm add``
      - :mc-cmd:`mc ilm rule add`
      - mc RELEASE.2022-12-24T15-21-38Z
@@ -54,6 +50,10 @@ Table of Deprecated Commands
    * - ``mc ilm rm``
      - :mc-cmd:`mc ilm rule rm`
      - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc replicate diff``
+     - :mc-cmd:`mc replicate backlog`
+     - mc RELEASE.2023-07-18T21-05-38Z
 
 
 Table of Deprecated Admin Commands

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -68,6 +68,26 @@ Table of Deprecated Admin Commands
      - Replacement Command
      - Version of Change
 
+   * - ``mc admin bucket remote add``
+     - :mc-cmd:`mc replicate add`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket remote ls``
+     - :mc-cmd:`mc replicate ls`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket remote rm``
+     - :mc-cmd:`mc replicate rm`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket remote update``
+     - :mc-cmd:`mc replicate update`
+     - mc RELEASE.2022-12-24T15-21-38Z
+
+   * - ``mc admin bucket quota``
+     - :mc-cmd:`mc quota clear`, :mc-cmd:`mc quota info`, :mc-cmd:`mc quota set`
+     - mc RELEASE.2022-12-13T00-23-28Z
+
    * - ``mc admin idp ldap add``
      - :mc-cmd:`mc idp ldap add`
      - mc RELEASE.2023-05-26T23-31-54Z
@@ -168,26 +188,9 @@ Table of Deprecated Admin Commands
      - :mc:`mc ilm tier ls`
      - mc RELEASE.2022-12-24T15-21-38Z
 
-   * - ``mc admin bucket remote add``
-     - :mc-cmd:`mc replicate add`
-     - mc RELEASE.2022-12-24T15-21-38Z
-
-   * - ``mc admin bucket remote rm``
-     - :mc-cmd:`mc replicate rm`
-     - mc RELEASE.2022-12-24T15-21-38Z
-
-   * - ``mc admin bucket remote ls``
-     - :mc-cmd:`mc replicate ls`
-     - mc RELEASE.2022-12-24T15-21-38Z
-
-   * - ``mc admin bucket remote update``
-     - :mc-cmd:`mc replicate update`
-     - mc RELEASE.2022-12-24T15-21-38Z
-
-   * - ``mc admin bucket quota``
-     - :mc-cmd:`mc quota clear`, :mc-cmd:`mc quota info`, :mc-cmd:`mc quota set`
-     - mc RELEASE.2022-12-13T00-23-28Z
-
+   * - ``mc admin top``
+     - :mc:`mc support top`
+     - mc RELEASE.2022-08-11T00-30-48Z
 
 .. toctree::
    :titlesonly:
@@ -199,9 +202,10 @@ Table of Deprecated Admin Commands
    /reference/deprecated/mc-ilm-import
    /reference/deprecated/mc-ilm-ls
    /reference/deprecated/mc-ilm-rm
+   /reference/deprecated/mc-admin-bucket-quota
    /reference/deprecated/mc-admin-idp-ldap
    /reference/deprecated/mc-admin-idp-ldap-policy
    /reference/deprecated/mc-admin-idp-openid
-   /reference/deprecated/mc-admin-tier
-   /reference/deprecated/mc-admin-bucket-quota
    /reference/deprecated/mc-admin-speedtest
+   /reference/deprecated/mc-admin-tier
+   /reference/deprecated/mc-admin-top


### PR DESCRIPTION
First batch of mc deprecation cleanup:

[x] Reorder section TOC: `mc` alphabetical, then `mc admin` alphabetical.
[x] Standardize deprecation notice format and wording.
[x] Move `mc admin top` to deprecated section.

Staged
http://192.241.195.202:9000/staging/DOCS-896-cleanup-mc-admin-top/linux/reference/minio-mc-deprecated.html

Partially addresses https://github.com/minio/docs/issues/896