### PR TITLE
DOCS-1022: Use 'mc idp ldap policy' for AD/LDAP policy assignments

### DIFF
--- a/source/administration/identity-access-management/ad-ldap-access-management.rst
+++ b/source/administration/identity-access-management/ad-ldap-access-management.rst
@@ -66,12 +66,15 @@ Use either of the following methods to create a new access key:
 Mapping Policies to User DN
 ---------------------------
 
-Consider the following policy assignments:
+The following commands use :mc-cmd:`mc idp ldap policy attach` to associate an existing MinIO :ref:`policy <minio-policy>` to an AD/LDAP User DN.
 
 .. code-block:: shell
 
-   mc admin policy attach myminio consoleAdmin --user='cn=sisko,cn=users,dc=example,dc=com'
-   mc admin policy attach myminio readwrite,diagnostics --user='cn=dax,cn=users,dc=example,dc=com'
+   mc idp ldap policy attach myminio consoleAdmin \ 
+     --user='cn=sisko,cn=users,dc=example,dc=com'
+   
+   mc idp ldap policy attach myminio readwrite,diagnostics \
+     --user='cn=dax,cn=users,dc=example,dc=com'
 
 - MinIO would assign an authenticated user with DN matching 
   ``cn=sisko,cn=users,dc=example,dc=com`` the :userpolicy:`consoleAdmin`
@@ -88,12 +91,15 @@ Consider the following policy assignments:
 Mapping Policies to Group DN
 ----------------------------
 
-Consider the following policy assignments:
+The following commands use :mc-cmd:`mc idp ldap policy attach` to associate an existing MinIO :ref:`policy <minio-policy>` to an AD/LDAP Group DN.
 
 .. code-block:: shell
 
-   mc admin policy attach myminio consoleAdmin --group='cn=ops,cn=groups,dc=example,dc=com'
-   mc admin policy attach myminio diagnostics --group='cn=engineering,cn=groups,dc=example,dc=com'
+   mc idp ldap policy attach myminio consoleAdmin \
+     --group='cn=ops,cn=groups,dc=example,dc=com'
+
+   mc idp ldap policy attach myminio diagnostics \
+     --group='cn=engineering,cn=groups,dc=example,dc=com'
 
 - MinIO would assign any authenticating user with membership in the
   ``cn=ops,cn=groups,dc=example,dc=com`` AD/LDAP group the

--- a/source/reference/minio-mc-admin/mc-admin-policy-attach.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-attach.rst
@@ -55,6 +55,13 @@ Exactly one :mc-cmd:`~mc admin policy attach --user` or one :mc-cmd:`~mc admin p
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
+.. important::
+
+   This command is intended for use managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
+
+   For attaching policies to OpenID-managed users, see :ref:`minio-external-identity-management-openid`.
+
+   For attaching policies to Active Directory/LDAP users or groups, use :mc-cmd:`mc idp ldap policy attach`.
 
 Parameters
 ~~~~~~~~~~

--- a/source/reference/minio-mc-admin/mc-admin-policy-attach.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-attach.rst
@@ -57,7 +57,7 @@ Exactly one :mc-cmd:`~mc admin policy attach --user` or one :mc-cmd:`~mc admin p
 
 .. important::
 
-   This command is intended for use managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
+   This command is intended for managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
 
    For attaching policies to OpenID-managed users, see :ref:`minio-external-identity-management-openid`.
 

--- a/source/reference/minio-mc-admin/mc-admin-policy-detach.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-detach.rst
@@ -53,7 +53,7 @@ Exactly one :mc-cmd:`~mc admin policy detach --user` or one :mc-cmd:`~mc admin p
 
 .. important::
 
-   This command is intended for use managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
+   This command is intended for managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
 
    For managing policies to OpenID-managed users, see :ref:`minio-external-identity-management-openid`.
 

--- a/source/reference/minio-mc-admin/mc-admin-policy-detach.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-detach.rst
@@ -15,7 +15,7 @@ Syntax
 
 .. start-mc-admin-policy-detach-desc
 
-Remove one or more IAM policies from a user or group identity. 
+Remove one or more IAM policies from either a :ref:`MinIO-managed user or a group <minio-users>`. 
 
 .. end-mc-admin-policy-detach-desc
 
@@ -50,6 +50,14 @@ Exactly one :mc-cmd:`~mc admin policy detach --user` or one :mc-cmd:`~mc admin p
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
+
+.. important::
+
+   This command is intended for use managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
+
+   For managing policies to OpenID-managed users, see :ref:`minio-external-identity-management-openid`.
+
+   For detaching policies from Active Directory/LDAP users or groups, use :mc-cmd:`mc idp ldap policy detach`.
 
 Parameters
 ~~~~~~~~~~

--- a/source/reference/minio-mc-admin/mc-admin-policy-entities.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-entities.rst
@@ -59,7 +59,7 @@ For example, you can list all of the users and groups attached to a policy or li
 
 .. important::
 
-   This command is intended for use managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
+   This command is intended for managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
 
    For managing policies to OpenID-managed users, see :ref:`minio-external-identity-management-openid`.
 

--- a/source/reference/minio-mc-admin/mc-admin-policy-entities.rst
+++ b/source/reference/minio-mc-admin/mc-admin-policy-entities.rst
@@ -57,6 +57,13 @@ For example, you can list all of the users and groups attached to a policy or li
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
 
+.. important::
+
+   This command is intended for use managing policy associations for :ref:`MinIO-managed <minio-users>` users only.
+
+   For managing policies to OpenID-managed users, see :ref:`minio-external-identity-management-openid`.
+
+   For viewing policies for Active Directory/LDAP users or groups, use :mc-cmd:`mc idp ldap policy entities`.
 
 Parameters
 ~~~~~~~~~~


### PR DESCRIPTION
# Summary

In the shuffle of migrating some policy attachment functionality from `mc admin idp policy attach|detach|entities`, the AD/LDAP access management page went unmodified.

This PR ensures we use the correct command, while also including some guidance for users who land on the `mc admin idp policy` pages to redirect them to a better place for OIDC/ADLDAP setups

Closes #1022