### PR TITLE
sphinx-reredirects redirect for mc admin top

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Sphinx-Substitution-Extensions == 2020.9.30.0
 sphinx-sitemap == 2.5.0
 sphinx-togglebutton === 0.3.2
 sphinxcontrib-images === 0.9.4
+sphinx_reredirect === 0.1.2
 myst-parser === 1.0.0
 linkify === 1.4
 linkify-it-py === 2.0.0

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -196,10 +196,11 @@ images_config = {
    'override_image_directive' : True
 }
 
-# sphinx-reredirects
-# `.rst` assumed in the rules
+# sphinx-reredirects redirect rules
+# `.rst` for source assumed in the rules
+# `.html` for target must be included
 redirects = {
-    "reference/minio-mc-admin/mc-admin-top": "reference/deprecated/mc-admin-top"
+    "reference/minio-mc-admin/mc-admin-top": "../deprecated/mc-admin-top.html"
 }
 
 

--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -43,6 +43,7 @@ extensions = [
     'myst_parser',
     'sphinx_design',
     'sphinx.ext.intersphinx',
+    'sphinx_reredirects',
 ]
 
 # -- External Links
@@ -194,6 +195,13 @@ copybutton_selector = "div.copyable pre"
 images_config = { 
    'override_image_directive' : True
 }
+
+# sphinx-reredirects
+# `.rst` assumed in the rules
+redirects = {
+    "reference/minio-mc-admin/mc-admin-top": "reference/deprecated/mc-admin-top"
+}
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Add `sphinx-reredirects` extension and create a redirect for the former `reference/minio-mc-admin/mc-admin-top.rst`. 

To install locally:
```
pip3 install sphinx-reredirects
```
To test:
- Go to the old URL.
- You are redirected to the new deprecated URL.

Example:
```
http://192.241.195.202:9000/staging/DOCS-896-redirects/linux/reference/minio-mc-admin/mc-admin-top.html
```
redirects to
```
http://192.241.195.202:9000/staging/DOCS-896-redirects/linux/reference/deprecated/mc-admin-top.html
```


The redirect is server-side, browser without JS still gets the correct redirected page.