### PR TITLE
Removing nonexistant flag

### DIFF
--- a/source/reference/kubectl-minio-plugin/kubectl-minio-init.rst
+++ b/source/reference/kubectl-minio-plugin/kubectl-minio-init.rst
@@ -50,7 +50,6 @@ Syntax
                        [--cluster-domain]        \
                        [--console-image]         \
                        [--console-tls]           \
-                       [--default-console-image] \
                        [--default-kes-image]     \
                        [--default-minio-image]   \
                        [--image]                 \


### PR DESCRIPTION
### Objective:

To correct our documentation because `--default-console-image` does not exist in our Operator plugin.

### Related:

* This is related to https://github.com/minio/operator/issues/1453 but will partially fix the issue, there is more work to do. I will create another PR for the missing update spot.