### PR TITLE
Improve TLS configuration instructions

### DIFF
--- a/source/administration/identity-access-management/ad-ldap-access-management.rst
+++ b/source/administration/identity-access-management/ad-ldap-access-management.rst
@@ -66,7 +66,7 @@ Use either of the following methods to create a new access key:
 Mapping Policies to User DN
 ---------------------------
 
-The following commands use :mc-cmd:`mc idp ldap policy attach` to associate an existing MinIO :ref:`policy <minio-policy>` to an AD/LDAP User DN.
+The following commands use :mc:`mc idp ldap policy attach` to associate an existing MinIO :ref:`policy <minio-policy>` to an AD/LDAP User DN.
 
 .. code-block:: shell
 
@@ -91,7 +91,7 @@ The following commands use :mc-cmd:`mc idp ldap policy attach` to associate an e
 Mapping Policies to Group DN
 ----------------------------
 
-The following commands use :mc-cmd:`mc idp ldap policy attach` to associate an existing MinIO :ref:`policy <minio-policy>` to an AD/LDAP Group DN.
+The following commands use :mc:`mc idp ldap policy attach` to associate an existing MinIO :ref:`policy <minio-policy>` to an AD/LDAP Group DN.
 
 .. code-block:: shell
 

--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -120,7 +120,7 @@ user which runs the MinIO server process. The provided ``minio.service``
 file runs the process as ``minio-user``. The previous step includes instructions
 for creating this user with a home directory ``/home/minio-user``.
 
-- Place TLS certificates into ``/home/minio-user/.minio/certs``.
+- Place TLS certificates into ``/home/minio-user/.minio/certs`` on each host.
 
 - If *any* MinIO server or client uses certificates signed by an unknown
   Certificate Authority (self-signed or internal CA), you *must* place the CA


### PR DESCRIPTION
Update and clarify how to configure TLS for a distributed deployment. The existing steps were out of date, and also were not clear configuration needs to happen on each node.

Staged:
- linux
  - http://192.241.195.202:9000/staging/DOCS-447/linux/operations/network-encryption.html
  - http://192.241.195.202:9000/staging/DOCS-447/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#add-tls-ssl-certificates
  -http://192.241.195.202:9000/staging/DOCS-447/linux/operations/install-deploy-manage/expand-minio-deployment.html#add-tls-ssl-certificates
- k8s
  - http://192.241.195.202:9000/staging/DOCS-447/k8s/operations/network-encryption.html

Closes https://github.com/minio/docs/issues/447
