### PR TITLE
Typo in Helm deploy docs

### DIFF
--- a/source/operations/install-deploy-manage/deploy-operator-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-helm.rst
@@ -391,9 +391,9 @@ To deploy a Tenant with Helm:
       :substitutions:
 
       helm install \
-      --namespace Tenant-ns \
+      --namespace tenant-ns \
       --create-namespace \
-      Tenant-ns Tenant-|operator-version-stable|.tgz
+      tenant-ns tenant-|operator-version-stable|.tgz
 
    To deploy more than one Tenant, create a Helm chart with the details of the new Tenant and repeat the deployment steps.
    Redeploying the same chart updates the previously deployed Tenant.
@@ -405,7 +405,7 @@ To deploy a Tenant with Helm:
    .. code-block:: shell
       :class: copyable
 
-      kubectl --namespace Tenant-ns port-forward svc/myminio-console 9443:9443
+      kubectl --namespace tenant-ns port-forward svc/myminio-console 9443:9443
    
    .. note::
       


### PR DESCRIPTION
Incorrect capitalization of `Tenant` in the Helm deploy page causes a few of the example commands to fail.

Fixes https://github.com/minio/docs/issues/1041