### PR TITLE
Doc updates for mc RELEASE.2023-10-04T06-52-56Z

### DIFF
--- a/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
+++ b/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
@@ -127,6 +127,9 @@ Append the desired ``scrape_configs`` job generated in the previous step to the 
 
    .. tab-item:: Cluster
 
+      Cluster metrics also include node	metrics.
+      Adding a ``scrape_configs`` job for ``cluster`` covers both.
+
       .. code-block:: yaml
          :class: copyable
       

--- a/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
+++ b/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
@@ -125,10 +125,8 @@ Append the desired ``scrape_configs`` job generated in the previous step to the 
 
 .. tab-set::
 
-   .. tab-item:: Cluster metrics
+   .. tab-item:: Cluster
 
-      For server metrics:
-      
       .. code-block:: yaml
          :class: copyable
       
@@ -143,7 +141,7 @@ Append the desired ``scrape_configs`` job generated in the previous step to the 
               static_configs:
               - targets: [minio.example.net]
 
-   .. tab-item:: Bucket metrics
+   .. tab-item:: Bucket
 
       .. code-block:: yaml
          :class: copyable
@@ -159,7 +157,7 @@ Append the desired ``scrape_configs`` job generated in the previous step to the 
               static_configs:
               - targets: [minio.example.net]
 
-   .. tab-item:: Resource metrics
+   .. tab-item:: Resource
 
       .. code-block:: yaml
          :class: copyable

--- a/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
+++ b/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
@@ -78,6 +78,8 @@ Use the :mc-cmd:`mc admin prometheus generate` command to generate the scrape co
 
    .. tab-item:: Resources
 
+      .. versionadded:: RELEASE.2023-10-07T15-07-38Z
+
       The following command scrapes metrics for resources on the MinIO Server.
 
       .. code-block:: shell
@@ -127,8 +129,8 @@ Append the desired ``scrape_configs`` job generated in the previous step to the 
 
    .. tab-item:: Cluster
 
-      Cluster metrics also include node	metrics.
-      Adding a ``scrape_configs`` job for ``cluster`` covers both.
+      Cluster metrics aggregate node-level metrics and, where appropriate, attach labels to metrics for the originating node.
+      If you are already collecting ``cluster`` metrics, you do not need to add an additional ``scrape_configs`` job for ``node``.
 
       .. code-block:: yaml
          :class: copyable

--- a/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
+++ b/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
@@ -15,7 +15,7 @@ Monitoring and Alerting using Prometheus
    - `Monitoring with MinIO and Prometheus: Overview <https://youtu.be/A3vCDaFWNNs?ref=docs>`__
    - `Monitoring with MinIO and Prometheus: Lab <https://youtu.be/Oix9iXndSUY?ref=docs>`__
 
-MinIO publishes cluster, node, and bucket metrics using the :prometheus-docs:`Prometheus Data Model <concepts/data_model/#data-model>`.
+MinIO publishes cluster, node, bucket, and resource metrics using the :prometheus-docs:`Prometheus Data Model <concepts/data_model/#data-model>`.
 The procedure on this page documents the following:
 
 - Configuring a Prometheus service to scrape and display metrics from a MinIO deployment
@@ -75,6 +75,18 @@ Use the :mc-cmd:`mc admin prometheus generate` command to generate the scrape co
 
       Replace :mc-cmd:`ALIAS <mc admin prometheus generate TARGET>` with the :mc:`alias <mc alias>` of the MinIO deployment.
 
+
+   .. tab-item:: Resources
+
+      The following command scrapes metrics for resources on the MinIO Server.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin prometheus generate ALIAS resource
+
+      Replace :mc-cmd:`ALIAS <mc admin prometheus generate TARGET>` with the :mc:`alias <mc alias>` of the MinIO deployment.
+
 The command returns output similar to the following:
 
 .. code-block:: yaml
@@ -131,7 +143,7 @@ Append the desired ``scrape_configs`` job generated in the previous step to the 
               static_configs:
               - targets: [minio.example.net]
 
-   .. tab-item:: Bucket metrics:
+   .. tab-item:: Bucket metrics
 
       .. code-block:: yaml
          :class: copyable
@@ -147,6 +159,21 @@ Append the desired ``scrape_configs`` job generated in the previous step to the 
               static_configs:
               - targets: [minio.example.net]
 
+   .. tab-item:: Resource metrics
+
+      .. code-block:: yaml
+         :class: copyable
+
+         global:
+            scrape_interval: 15s
+
+         scrape_configs:
+            - job_name: minio-job-resource
+              bearer_token: TOKEN
+              metrics_path: /minio/v2/metrics/resource
+              scheme: https
+              static_configs:
+              - targets: [minio.example.net]
 
 Start the Prometheus cluster using the configuration file:
 

--- a/source/reference/minio-mc-admin/mc-admin-prometheus.rst
+++ b/source/reference/minio-mc-admin/mc-admin-prometheus.rst
@@ -64,4 +64,4 @@ Syntax
       - ``resource``
 
       If not specified, the command returns cluster metrics.
-
+      Cluster metrics also include node metrics.

--- a/source/reference/minio-mc-admin/mc-admin-prometheus.rst
+++ b/source/reference/minio-mc-admin/mc-admin-prometheus.rst
@@ -56,6 +56,10 @@ Syntax
 
       The type of metrics to scrape.
 
+      .. versionchanged:: RELEASE.2023-10-07T15-07-38Z
+
+         ``resource`` metrics added
+
       Valid values are:
 
       - ``bucket``

--- a/source/reference/minio-mc-admin/mc-admin-prometheus.rst
+++ b/source/reference/minio-mc-admin/mc-admin-prometheus.rst
@@ -56,7 +56,12 @@ Syntax
 
       The type of metrics to scrape.
 
-      Valid values are ``cluster``, ``node``, or ``bucket``.
+      Valid values are:
+
+      - ``bucket``
+      - ``cluster``
+      - ``node``
+      - ``resource``
 
       If not specified, the command returns cluster metrics.
 

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -213,6 +213,11 @@ Syntax
 
    Returns calls matching the supplied request header.
 
+.. mc-cmd:: --request-query
+
+   Returns calls matching the supplied request query parameter.
+   This debug option should only be used at the direction of MinIO Support.
+
 .. mc-cmd:: --response-duration
 
    Trace calls with response duration greater than the specified value.


### PR DESCRIPTION
Doc updates for mc release [2023-10-04T06-52-56Z](https://github.com/minio/docs/issues/1035) 

- [x] `resource` type for Prometheus metrics
- [x] Doc `mc admin trace --request-query`, ~maybe it and some other should be hidden from `mc --help`?~

Staged:
http://192.241.195.202:9000/staging/DOCS-1035/linux/operations/monitoring/collect-minio-metrics-using-prometheus.html

Fixes https://github.com/minio/docs/issues/1035