### PR TITLE
Docs automation: fix |java-jar-url| replacement 

### DIFF
--- a/source/developers/minio-drivers.rst
+++ b/source/developers/minio-drivers.rst
@@ -109,7 +109,7 @@ Install methods
 
   - JAR
 
-    Download the latest JAR file for |java-sdk-version| of the SDK from |java-jar-url|.
+    Download the latest JAR file for |java-sdk-version| of the SDK from the `Sonatype Maven Central Repository <https://central.sonatype.com/artifact/io.minio/minio/versions>`__.
 
 
 .. _dotnet-sdk:

--- a/source/developers/minio-drivers.rst
+++ b/source/developers/minio-drivers.rst
@@ -109,8 +109,7 @@ Install methods
 
   - JAR
 
-    Download the latest JAR file for |java-sdk-version| of the SDK from the `Sonatype Maven Central Repository <https://central.sonatype.com/artifact/io.minio/minio/versions>`__.
-
+    Download the latest JAR file for version |java-sdk-version| of the SDK from the `Sonatype Maven Central Repository <|java-jar-url|>`__.
 
 .. _dotnet-sdk:
 

--- a/source/developers/minio-drivers.rst
+++ b/source/developers/minio-drivers.rst
@@ -17,8 +17,8 @@ MinIO publishes the following Software Development Kits (SDK):
 - :ref:`Java <java-sdk>`
 - :ref:`.NET <dotnet-sdk>`
 - :ref:`JavaScript <javascript-sdk>`
-- :ref:`C++ <cpp-sdk>`
 - :ref:`Haskell <haskell-sdk>`
+- :ref:`C++ <cpp-sdk>`
 
 .. _go-sdk:
 
@@ -172,14 +172,31 @@ Install
        npm install --save-dev @types/minio
 
 
+.. _haskell-sdk:
+
+Haskell
+-------
+
+GitHub: `minio/minio-hs <https://github.com/minio/minio-hs>`__
+
+Latest Version: |haskell-sdk-version|
+
+Quickstart Guide: :doc:`/developers/haskell/minio-haskell`
+
+Install
+  Add ``minio-hs`` to your project's ``.cabal`` dependencies section.
+
+  or
+
+  If you are using ``hpack``, add ``minio-hs`` to your ``package.yaml`` file.
+
+
 .. _cpp-sdk:
 
 C++
 ---
 
 GitHub: `minio/minio-cpp <https://github.com/minio/minio-cpp>`__
-
-Latest version: |cpp-sdk-version|
 
 Reference: `MinIO C++ SDK Reference <https://minio-cpp.min.io/>`__
 
@@ -205,24 +222,6 @@ Install
        cmake -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=./vcpkg-master/scripts/buildsystems/vcpkg.cmake
        cmake --build ./build --config Debug
 
-
-.. _haskell-sdk:
-
-Haskell
--------
-
-GitHub: `minio/minio-hs <https://github.com/minio/minio-hs>`__
-
-Latest Version: |haskell-sdk-version|
-
-Quickstart Guide: :doc:`/developers/haskell/minio-haskell`
-
-Install
-  Add ``minio-hs`` to your project's ``.cabal`` dependencies section.
-
-  or
-
-  If you are using ``hpack``, add ``minio-hs`` to your ``package.yaml`` file.
 
 ..
   Rust SDK repo does not have any releases yet. Once released, unblock this section and add to toctree.

--- a/sync-docs.sh
+++ b/sync-docs.sh
@@ -51,7 +51,8 @@ function main() {
 		;;
 	    "java")
 		replace JAVAVERSION ${sdk_version}
-		;;
+                replace JAVAURL https://repo1.maven.org/maven2/io/minio/minio/${sdk_version}/
+	        ;;
 	    "js")
 		replace JAVASCRIPTVERSION ${sdk_version}
 		;;


### PR DESCRIPTION
The URL for the Java SDK JAR is a static string + the SDK version number. Use the existing `java-sdk-version` value to construct the correct URL. 

C++ doesn't have any releases, so there's no Quickstart to generate. Move it to the bottom and only link to GitHub and the Doxygen reference page. 

Staged
http://192.241.195.202:9000/staging/java-sdk-jar-url/linux/developers/minio-drivers.html