### PR TITLE
Fix broken Prometheus doc links

### DIFF
--- a/source/operations/monitoring.rst
+++ b/source/operations/monitoring.rst
@@ -19,7 +19,7 @@ Metrics and Alerts
 MinIO provides point-in-time metrics on cluster status and operations.
 The :ref:`MinIO Console <minio-console-metrics>` provides a graphical display of these metrics.
 
-For historical metrics and analytics, MinIO publishes cluster and node metrics using the :prometheus-docs:`Prometheus Data Model <data_model/>`.
+For historical metrics and analytics, MinIO publishes cluster and node metrics using the :prometheus-docs:`Prometheus Data Model <concepts/data_model/>`.
 You can use any scraping tool which supports that data model to pull metrics data from MinIO for further analysis and alerting.
 
 The following table lists tutorials for integrating MinIO metrics with select third-party monitoring software.

--- a/source/operations/monitoring/metrics-and-alerts.rst
+++ b/source/operations/monitoring/metrics-and-alerts.rst
@@ -12,7 +12,7 @@ Metrics and Alerts
    :local:
    :depth: 3
 
-MinIO publishes cluster and node metrics using the :prometheus-docs:`Prometheus Data Model <data_model/>`.
+MinIO publishes cluster and node metrics using the :prometheus-docs:`Prometheus Data Model <concepts/data_model/>`.
 You can use any scraping tool to pull metrics data from MinIO for further analysis and alerting.
 
 MinIO provides scraping endpoints for the following metric groups:

--- a/source/operations/monitoring/monitor-and-alert-using-influxdb.rst
+++ b/source/operations/monitoring/monitor-and-alert-using-influxdb.rst
@@ -10,7 +10,7 @@ Monitoring and Alerting using InfluxDB
    :local:
    :depth: 1
 
-MinIO publishes cluster and node metrics using the :prometheus-docs:`Prometheus Data Model <data_model/>`.
+MinIO publishes cluster and node metrics using the :prometheus-docs:`Prometheus Data Model <concepts/data_model/>`.
 `InfluxDB <https://www.influxdata.com/?ref=minio>`__ supports scraping MinIO metrics data for monitoring and alerting.
 
 The procedure on this page documents the following:


### PR DESCRIPTION
Reported by a reader: Prometheus changed the location of their Data Model page. Fix our links to match.