### PR TITLE
Restore previous Go SDK install command

### DIFF
--- a/source/developers/minio-drivers.rst
+++ b/source/developers/minio-drivers.rst
@@ -34,10 +34,11 @@ Quickstart Guide: :doc:`/developers/go/minio-go`
 Reference: :doc:`/developers/go/API`
 
 Download from GitHub
+
   .. code-block:: shell
      :class: copyable
 
-     go install github.com/minio/minio-go/v7@latest
+     go get github.com/minio/minio-go/v7
 
 
 .. _python-sdk:


### PR DESCRIPTION
Now that I know why. The additional context to do go get in a project directory doesn't fit in the format of this page, but it's in the Quickstart update. 