### PR TITLE
Correcting mc-conf errors

### DIFF
--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -149,6 +149,10 @@ Data Compression
 The following section documents settings for enabling data compression for objects.
 See :ref:`minio-data-compression` for tutorials on using these configuration settings.
 
+All of the settings in this section fall under the following top-level key:
+
+.. mc-conf:: compression
+
 Allow Encryption
 ~~~~~~~~~~~~~~~~
 

--- a/source/reference/minio-server/settings/iam/ldap.rst
+++ b/source/reference/minio-server/settings/iam/ldap.rst
@@ -49,6 +49,8 @@ Examples
    .. tab-item:: Configuration Setting
       :sync: config
 
+      .. mc-conf:: identity_ldap
+         
       The following settings are required when defining LDAP using :mc:`mc admin config set`:
 
       - ``enabled``
@@ -92,7 +94,7 @@ Server Address
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: server_addr
+      .. mc-conf:: identity_ldap server_addr
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -114,7 +116,7 @@ Lookup Bind DN
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: lookup_bind_dn
+      .. mc-conf:: identity_ldap lookup_bind_dn
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -136,7 +138,7 @@ Lookup Bind Password
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: lookup_bind_password
+      .. mc-conf:: identity_ldap lookup_bind_password
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -158,7 +160,7 @@ User DN Search Base DN
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: user_dn_search_base_dn
+      .. mc-conf:: identity_ldap user_dn_search_base_dn
          :delimiter: " "
 
 
@@ -181,7 +183,7 @@ User DN Search Filter
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: user_dn_search_filter
+      .. mc-conf:: identity_ldap user_dn_search_filter
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -203,7 +205,7 @@ Enabled
    .. tab-item:: Configuration Setting
       :selected:
 
-      .. mc-conf:: enabled
+      .. mc-conf:: identity_ldap enabled
          :delimiter: " "
 
 Set to ``false`` to disable the AD/LDAP configuration.
@@ -227,7 +229,7 @@ Group Search Filter
    .. tab-item:: Configuration Setting
       :sync: config
    
-      .. mc-conf:: group_search_filter
+      .. mc-conf:: identity_ldap group_search_filter
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -249,7 +251,7 @@ Group Search Base DN
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: group_search_base_dn
+      .. mc-conf:: identity_ldap group_search_base_dn
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -271,7 +273,7 @@ TLS Skip Verify
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: tls_skip_verify
+      .. mc-conf:: identity_ldap tls_skip_verify
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -293,7 +295,7 @@ Server Insecure
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: server_insecure
+      .. mc-conf:: identity_ldap server_insecure
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -315,7 +317,7 @@ Server Start TLS
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: server_starttls
+      .. mc-conf:: identity_ldap server_starttls
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -339,7 +341,7 @@ SRV Record Name
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: srv_record_name
+      .. mc-conf:: identity_ldap srv_record_name
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst
@@ -361,7 +363,7 @@ Comment
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: identity_ldap comment
+      .. mc-conf:: identity_ldap identity_ldap comment
          :delimiter: " "
 
 .. include:: /includes/common-minio-external-auth.rst

--- a/source/reference/minio-server/settings/iam/minio-identity-plugin.rst
+++ b/source/reference/minio-server/settings/iam/minio-identity-plugin.rst
@@ -32,8 +32,10 @@ The examples here represent the minimum required settings.
    .. tab-item:: Configuration Settings
       :sync: config
 
+      .. mc-conf:: identity_plugin
+
       Use :mc:`mc admin config set` to create or update the OpenID configuration. 
-      The :mc-conf:`identity_plugin url` argument is required. 
+      The ``identity_plugin url`` argument is required. 
       Specify additional optional arguments as a whitespace (" ")-delimited list.
 
       .. code-block:: shell

--- a/source/reference/minio-server/settings/iam/openid.rst
+++ b/source/reference/minio-server/settings/iam/openid.rst
@@ -30,6 +30,8 @@ Examples
    .. tab-item:: Configuration Settings
       :sync: config
 
+      .. mc-conf:: identity_openid
+
       Use :mc-cmd:`mc admin config set` to set or update the OpenID configuration.
       The :mc-conf:`~identity_openid.config_url` argument is *required*. 
       Specify additional optional arguments as a whitespace (``" "``)-delimited list.

--- a/source/reference/minio-server/settings/metrics-and-logging.rst
+++ b/source/reference/minio-server/settings/metrics-and-logging.rst
@@ -111,8 +111,9 @@ Enable
    
    .. tab-item:: Configuration Setting
 
-      There is no configuration setting for this value.
-      Use the environment variable instead.
+      .. mc-conf:: logger_webhook
+      
+      The top level key for the configuration settings to configure logging to an HTTP webhook endpoint.
 
 
 Endpoint

--- a/source/reference/minio-server/settings/notifications.rst
+++ b/source/reference/minio-server/settings/notifications.rst
@@ -32,7 +32,7 @@ Sync Events
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. mc-conf:: sync_events         
+      .. mc-conf:: api sync_events         
 
 .. include:: /includes/common-mc-admin-config.rst
    :start-after: start-minio-api-sync-events

--- a/source/reference/minio-server/settings/notifications/amqp.rst
+++ b/source/reference/minio-server/settings/notifications/amqp.rst
@@ -73,17 +73,26 @@ Enable
 
       Requires specifying :envvar:`MINIO_NOTIFY_AMQP_URL` if set to ``on``.
 
+      Specify ``on`` to enable publishing bucket notifications to an AMQP endpoint.
+
+      Defaults to ``off``.
+
    .. tab-item:: Configuration Setting
 
-      .. include:: /includes/common-mc-admin-config.rst
-         :start-after: start-minio-settings-no-config-option
-         :end-before: end-minio-settings-no-config-option
+      .. mc-conf:: notify_amqp
 
-      Configure an AMQP target with desired options to enable a setting.
+      The top-level configuration key for defining an AMQP service endpoint for use with :ref:`MinIO bucket notifications <minio-bucket-notifications>`.
 
-Specify ``on`` to enable publishing bucket notifications to an AMQP endpoint.
+      Use :mc-cmd:`mc admin config set` to set or update an AMQP service endpoint. 
+      The :mc-conf:`~notify_amqp.url` argument is *required* for each target.
+      Specify additional optional arguments as a whitespace (``" "``)-delimited list.
 
-Defaults to ``off``.
+      .. code-block:: shell
+         :class: copyable
+   
+         mc admin config set notify_amqp \ 
+           url="amqp://user:password@endpoint:port" \
+           [ARGUMENT="VALUE"] ... 
 
 URL
 ~~~


### PR DESCRIPTION
Corrects errors from `mc-conf` references not noticed until after merging #1028 .

No issue to track it.