### PR TITLE
[Community request] Clarify Operator upgrade

### DIFF
--- a/source/operations/install-deploy-manage/upgrade-minio-operator.rst
+++ b/source/operations/install-deploy-manage/upgrade-minio-operator.rst
@@ -203,7 +203,7 @@ This procedure requires the following:
 Procedure
 ~~~~~~~~~
 
-This procedure upgrades the MinIO Operator from any 4.2.3 or later release to |operator-version-stable|.
+This procedure upgrades the MinIO Operator from release 4.2.3 through release 4.5.7 to release 4.5.8.
 
 1. *(Optional)* Update each MinIO Tenant to the latest stable MinIO Version.
 

--- a/source/operations/install-deploy-manage/upgrade-minio-operator.rst
+++ b/source/operations/install-deploy-manage/upgrade-minio-operator.rst
@@ -203,7 +203,8 @@ This procedure requires the following:
 Procedure
 ~~~~~~~~~
 
-This procedure upgrades the MinIO Operator from release 4.2.3 through release 4.5.7 to release 4.5.8.
+This procedure upgrades MinIO Operator release 4.2.3 through 4.5.7 to release 4.5.8.
+You can then upgrade from release 4.5.8 to |operator-version-stable|.
 
 1. *(Optional)* Update each MinIO Tenant to the latest stable MinIO Version.
 


### PR DESCRIPTION
Operator upgrade docs for 4.2.3 to 4.5.8 had an incorrect sentence saying the procedure could upgrade directly to latest stable.
This updates the description to clarify that upgrade should first upgrade to 4.5.8.

This was noted by a community Slack user.
Not staged. No GitHub issue to track.