### PR TITLE
Add default background color for images

### DIFF
--- a/source/_static/scss/includes/_reset.scss
+++ b/source/_static/scss/includes/_reset.scss
@@ -185,6 +185,33 @@ li pre {
     }
 }
 
+.content__main {
+    figure {
+        box-shadow: none;
+    }
+
+    img {
+        background-color: $white;
+        border-radius: $border-radius;
+        padding: 1rem;
+    }
+
+    figcaption {
+        border: 0;
+        font-weight: normal;
+        font-style: italic;
+        
+        p {
+            margin-top: 0;
+        }
+
+        .caption-text {
+            font-weight: normal;
+            color: var(--text-muted-color);
+        }
+    }
+}
+
 // ----------------------
 // Table
 // ----------------------
@@ -340,7 +367,6 @@ span.highlighted {
 // ----------------------
 // Container - Procedure
 // ----------------------
-
 .container.procedure {
    padding: 0px;
 


### PR DESCRIPTION
**Issue**:
<img width="793" alt="Screenshot 2023-11-07 at 11 53 29" src="https://github.com/minio/docs/assets/13393018/2832944a-74a5-4e24-968d-1a3069812c2b">

**Fix**:
<img width="793" alt="Screenshot 2023-11-07 at 11 53 20" src="https://github.com/minio/docs/assets/13393018/69305855-d384-4f58-8a1c-a6f3d3dfbebe">
