### PR TITLE
Updates for two October releases

### DIFF
--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -562,16 +562,22 @@ The :guilabel:`Security` section displays TLS certificate settings for the MinIO
 
        MinIO also supports uploading Certificate Authority certificates for validating client certificates minted by that CA.
 
-      .. admonition:: Supported Secret Types
-         :class: note
-   
-         MinIO supports three types of :kube-docs:`secrets in Kubernetes <concepts/configuration/secret/#secret-types>`.
-      
-         #. **Opaque**, with ``private.key`` and ``public.crt`` files.
-         #. **tls**, using ``tls.key`` and ``tls.crt`` files.
-         #. `cert-manager <https://cert-manager.io/>`__` 1.7.x or later running on Kubernetes 1.21 or later.
+.. admonition:: Supported Secret Types
+   :class: note
+    
+   MinIO supports three types of :kube-docs:`secrets in Kubernetes <concepts/configuration/secret/#secret-types>`.
+       
+   #. opaque
+    
+      Using ``private.key`` and ``public.crt`` files.
+   #. tls
+     
+      Using ``tls.key`` and ``tls.crt`` files.
+   #. `cert-manager <https://cert-manager.io/>`__ 1.7.x or later 
+    
+      Running on Kubernetes 1.21 or later.
 
-         For the best support of *tls* or *cert-manager* secrets, upgrade to Operator version 5.0.10 or later.
+   For the best support of *tls* or *cert-manager* secrets, upgrade to Operator version 5.0.10 or later.
 
 .. versionadded:: Console 0.23.1
 
@@ -587,7 +593,7 @@ The :guilabel:`Security` section displays TLS certificate settings for the MinIO
 
 .. _create-tenant-encryption-section:
 
-8) The :guilabel:`Encryption` Section
+1) The :guilabel:`Encryption` Section
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :guilabel:`Encryption` section displays the :ref:`Server-Side Encryption (SSE) <minio-sse>` settings for the MinIO Tenant. 

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -562,6 +562,17 @@ The :guilabel:`Security` section displays TLS certificate settings for the MinIO
 
        MinIO also supports uploading Certificate Authority certificates for validating client certificates minted by that CA.
 
+      .. admonition:: Supported Secret Types
+         :class: note
+   
+         MinIO supports three types of :kube-docs:`secrets in Kubernetes <concepts/configuration/secret/#secret-types>`.
+      
+         #. **Opaque**, with ``private.key`` and ``public.crt`` files.
+         #. **tls**, using ``tls.key`` and ``tls.crt`` files.
+         #. `cert-manager <https://cert-manager.io/>`__` 1.7.x or later running on Kubernetes 1.21 or later.
+
+         For the best support of *tls* or *cert-manager* secrets, upgrade to Operator version 5.0.10 or later.
+
 .. versionadded:: Console 0.23.1
 
    A message displays under the certificate with the date of expiration and length of time until expiration.

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -567,10 +567,10 @@ The :guilabel:`Security` section displays TLS certificate settings for the MinIO
     
    MinIO supports three types of :kube-docs:`secrets in Kubernetes <concepts/configuration/secret/#secret-types>`.
        
-   #. opaque
+   #. ``opaque``
     
       Using ``private.key`` and ``public.crt`` files.
-   #. tls
+   #. ``tls``
      
       Using ``tls.key`` and ``tls.crt`` files.
    #. `cert-manager <https://cert-manager.io/>`__ 1.7.x or later 

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -576,8 +576,10 @@ The :guilabel:`Security` section displays TLS certificate settings for the MinIO
    #. `cert-manager <https://cert-manager.io/>`__ 1.7.x or later 
     
       Running on Kubernetes 1.21 or later.
+   
+   .. versionadded:: 5.0.10
 
-   For the best support of *tls* or *cert-manager* secrets, upgrade to Operator version 5.0.10 or later.
+      Support for *tls* or *cert-manager* secrets was added in version 5.0.10.
 
 .. versionadded:: Console 0.23.1
 

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -576,10 +576,6 @@ The :guilabel:`Security` section displays TLS certificate settings for the MinIO
    #. `cert-manager <https://cert-manager.io/>`__ 1.7.x or later 
     
       Running on Kubernetes 1.21 or later.
-   
-   .. versionadded:: 5.0.10
-
-      Support for *tls* or *cert-manager* secrets was added in version 5.0.10.
 
 .. versionadded:: Console 0.23.1
 

--- a/source/operations/network-encryption.rst
+++ b/source/operations/network-encryption.rst
@@ -214,10 +214,10 @@ Enabling TLS
 
    MinIO supports three types of :kube-docs:`secrets in Kubernetes <concepts/configuration/secret/#secret-types>`.
 
-   #. opaque
+   #. ``opaque``
     
       Using ``private.key`` and ``public.crt`` files.
-   #. tls
+   #. ``tls``
      
       Using ``tls.key`` and ``tls.crt`` files.
    #. `cert-manager <https://cert-manager.io/>`__ 1.7.x or later 

--- a/source/operations/network-encryption.rst
+++ b/source/operations/network-encryption.rst
@@ -214,9 +214,15 @@ Enabling TLS
 
    MinIO supports three types of :kube-docs:`secrets in Kubernetes <concepts/configuration/secret/#secret-types>`.
 
-   #. **Opaque**, with ``private.key`` and ``public.crt`` files.
-   #. **tls**, using ``tls.key`` and ``tls.crt`` files.
-   #. `cert-manager <https://cert-manager.io/>`__` 1.7.x or later running on Kubernetes 1.21 or later.
+   #. opaque
+    
+      Using ``private.key`` and ``public.crt`` files.
+   #. tls
+     
+      Using ``tls.key`` and ``tls.crt`` files.
+   #. `cert-manager <https://cert-manager.io/>`__ 1.7.x or later 
+    
+      Running on Kubernetes 1.21 or later.
 
    .. note::
 

--- a/source/operations/network-encryption.rst
+++ b/source/operations/network-encryption.rst
@@ -207,6 +207,21 @@ Enabling TLS
    You may also need to update URLs used by applications or clients.
 
 
+.. cond:: k8s
+
+   Supported Secret Types
+   ~~~~~~~~~~~~~~~~~~~~~~
+
+   MinIO supports three types of :kube-docs:`secrets in Kubernetes <concepts/configuration/secret/#secret-types>`.
+
+   #. **Opaque**, with ``private.key`` and ``public.crt`` files.
+   #. **tls**, using ``tls.key`` and ``tls.crt`` files.
+   #. `cert-manager <https://cert-manager.io/>`__` 1.7.x or later running on Kubernetes 1.21 or later.
+
+   .. note::
+
+      For the best support of *tls* or *cert-manager* secrets, upgrade to Operator version 5.0.10 or later.
+
 Multiple Domain-Based TLS Certificates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -233,6 +233,11 @@ Syntax
 
    Returns calls of the specified HTTP status code.
 
+.. mc-cmd:: --stats
+
+   Accumulate stats, such as name, count, duration, or errors.
+   Accumulates up to 15 stat entries.
+
 .. mc-cmd:: --verbose
    
    Returns verbose output.

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -235,8 +235,21 @@ Syntax
 
 .. mc-cmd:: --stats
 
-   Accumulate stats, such as name, count, duration, or errors.
+   Accumulate stats, such as name, count, duration, min time, max time, time to first byte, or errors.
    Accumulates up to 15 stat entries.
+
+   The output resembles the following:
+
+   .. code-block:: shell
+
+      Duration: 1m18s ∙●∙
+      Call                	Count      	RPM  	Avg Time	TTFB Time	Min Time  	Max Time   	Errors	RX Avg	TX Avg 	
+      s3.HeadBucket       	169 (79.3%)	130.8	1.395ms 	0s       	369.392µs 	10.486821ms	0     	135 B 	0 B    	
+      s3.GetObject        	34 (16.0%) 	26.3 	1.39ms  	1.278ms  	558.722µs 	2.688192ms 	0     	90 B  	759 B  	
+      s3.ListBuckets      	4 (1.9%)   	3.1  	6.617ms 	5.573ms  	4.602269ms	7.708086ms 	0     	93 B  	7.5 KiB	
+      s3.ListObjectsV2    	3 (1.4%)   	2.3  	34.621ms	34.393ms 	2.015213ms	99.601832ms	0     	93 B  	2.6 KiB	
+      s3.GetBucketLocation	2 (0.9%)   	1.5  	991µs   	796µs    	920.966µs 	1.061579ms 	0     	122 B 	245 B  	
+      s3.ListObjectsV1    	1 (0.5%)   	0.8  	998µs   	837µs    	998.367µs 	998.367µs  	0     	124 B 	364 B  		 
 
 .. mc-cmd:: --verbose
    


### PR DESCRIPTION
- Adds additional flag for `mc admin trace`
- Adds info about supported secret types for k8s

Closes #1039 

Staged:
- http://192.241.195.202:9000/staging/server-2023-10-14/k8s/operations/network-encryption.html
- http://192.241.195.202:9000/staging/server-2023-10-14/k8s/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section
- http://192.241.195.202:9000/staging/server-2023-10-14/linux/reference/minio-mc-admin/mc-admin-trace.html#mc.admin.trace.-stats

For the `mc admin trace --stats` flag, also adding example output.

Closes #1045