### PR TITLE
Updates for two Oct 2023 mc releases

### DIFF
--- a/source/includes/common-minio-ad-ldap-params.rst
+++ b/source/includes/common-minio-ad-ldap-params.rst
@@ -127,3 +127,19 @@
    This parameter corresponds with the :envvar:`MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY` environment variable.
 
 .. end-minio-ad-ldap-params
+
+.. Descriptions for adding LDAP access keys
+   Used in the following files:                                                                
+   - /source/reference/minio-mc/mc-idp-ldap-accesskey.rst
+   - /source/reference/minio-mc/mc-idp-ldap-accesskey-info.rst
+   - /source/reference/minio-mc/mc-idp-ldap-accesskey-rm.rst
+   - /source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+
+.. start-minio-ad-ldap-accesskey-creation
+
+This command works against :ref:`access keys <minio-id-access-keys>` created by an AD/LDAP user after authenticating to MinIO.
+
+Authenticated users can manage their own long-term Access Keys using the :ref:`MinIO Console <minio-console-user-access-key>`.
+MinIO supports using :ref:`AssumeRoleWithLDAPIdentity <minio-sts-assumerolewithldapidentity>` to generate temporary access keys using the :ref:`Security Token Service <minio-security-token-service>`.
+
+.. end-minio-ad-ldap-accesskey-creation

--- a/source/includes/common-minio-ad-ldap-params.rst
+++ b/source/includes/common-minio-ad-ldap-params.rst
@@ -139,7 +139,7 @@
 
 This command works against :ref:`access keys <minio-id-access-keys>` created by an AD/LDAP user after authenticating to MinIO.
 
-Authenticated users can manage their own long-term Access Keys using the :ref:`MinIO Console <minio-console-user-access-key>`.
+Authenticated users can manage their own long-term Access Keys using the :ref:`MinIO Console <minio-console-user-access-keys>`.
 MinIO supports using :ref:`AssumeRoleWithLDAPIdentity <minio-sts-assumerolewithldapidentity>` to generate temporary access keys using the :ref:`Security Token Service <minio-security-token-service>`.
 
 .. end-minio-ad-ldap-accesskey-creation

--- a/source/reference/deprecated/mc-ilm-add.rst
+++ b/source/reference/deprecated/mc-ilm-add.rst
@@ -69,7 +69,6 @@ The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-man
                           [--noncurrent-expire-days "integer"]       \
                           [--noncurrent-expire-newer "integer"]      \
                           [--noncurrent-transition-days "integer"]   \
-                          [--noncurrent-transition-newer "integer"]  \
                           [--noncurrent-transition-tier "string"]    \
                           ALIAS
 
@@ -247,47 +246,6 @@ Parameters
    MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
    Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
    See :ref:`minio-lifecycle-management-scanner` for more information.
-   
-.. mc-cmd:: --noncurrent-transition-newer
-   :optional:
-   
-   The maximum number of non-current object versions to retain on the current tier.
-   Older object versions beyond the number to retain transition to a different, specified tier.
-
-   Use this flag to keep a certain number of non-current versions of an object accessible on the tier in a first in, first out order.
-
-   If not specified, all non-current object versions transition to the different tier.
-
-   The following table lists a number of object versions and their transition eligibility based on ``--noncurrent-transition-newer 3``:
-
-   .. list-table::
-      :widths: 50 50
-      :width: 100% 
-
-      * - v5 (current version)
-        - Current version not affected by ILM rules.
-      * - v4
-        - kept on current tier
-      * - v3
-        - kept on current tier
-      * - v2
-        - kept on current tier
-      * - v1
-        - marked for transition to other tier
-
-   MinIO retains the current version, v5, on the tier.
-   MinIO also retains the next ``3`` non-current versions on the tier, starting with the newest.
-   This means MinIO leaves ``v4``, ``v3``, and ``v2`` for the three non-current version to keep on the current tier.
-
-   ``v1`` would be a fourth non-current version, which falls outside the limit of non-current versions to retain, so MinIO marks ``v1`` for transition.
-
-   Updating the number for this flag only impacts the unmarked versions of objects.
-   Any versions already marked for transition do not change if you increase the number, and any object versions already transitioned do not transition back to the tier.
-
-   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
-   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
-   See :ref:`minio-lifecycle-management-scanner` for more information.
-
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -168,6 +168,29 @@ Syntax
 
       The :ref:`alias <alias>` of the MinIO deployment.
 
+   .. mc-cmd:: --bucket-bandwidth
+
+      Set default bandwidth limit for bucket in bits per second.
+
+      Valid units include: 
+   
+      - ``B`` for bytes
+      - ``K`` for kilobytes
+      - ``M`` for megabytes
+      - ``G`` for gigabytes
+      - ``T`` for terabytes
+      - ``Ki`` for kibibytes
+      - ``Mi`` for mibibytes
+      - ``Gi`` for gibibytes
+      - ``Ti`` for tebibytes
+
+      For example, the following command limits the replication on the ``myminio`` deployment to no more than 2 Gigabytes per second.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc admin replicate update myminio --deployment-id c1758167-4426-454f-9aae-5c3dfdf6df64 --bucket-bandwidth "2G"
+
    .. mc-cmd:: --deployment-id
       :required:
 

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -232,7 +232,8 @@ The following table lists :mc-cmd:`mc` commands:
           :start-after: start-mc-head-desc
           :end-before: end-mc-head-desc
      
-   * - | :mc:`mc idp ldap add`
+   * - | :mc:`mc idp ldap accesskey`
+       | :mc:`mc idp ldap add`
        | :mc:`mc idp ldap disable`
        | :mc:`mc idp ldap enable`
        | :mc:`mc idp ldap info`
@@ -488,7 +489,8 @@ Global Options
 
 .. program:: mc
 
-All :ref:`commands <minio-mc-commands>` support the following global options:
+All :ref:`commands <minio-mc-commands>` support the following global options.
+You can also define some of these options using :ref:`Environment Variables <minio-server-envvar-mc>`.
 
 .. option:: --debug
 
@@ -502,11 +504,15 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
 
       mc --debug ls play
 
+   Alternatively, set the environment variable :envvar:`MC_DEBUG`.
+
 .. option:: --config-dir
 
    The path to a ``JSON`` formatted configuration file that
    :program:`mc` uses for storing data. See :ref:`mc-configuration` for
    more information on how :program:`mc` uses the configuration file.
+
+   Alternatively, set the environment variable :envvar:`MC_CONFIG_DIR`.
 
 .. option:: --JSON
 
@@ -521,20 +527,28 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
 
       mc --JSON ls play 
 
+   Alternatively, set the environment variable :envvar:`MC_JSON`.
+
 .. option:: --no-color
 
    Disables the built-in color theme for console output. Useful for dumb
    terminals.
 
+   Alternatively, set the environment variable :envvar:`MC_NO_COLOR`.
+
 .. option:: --quiet
 
    Suppresses console output. 
+
+   Alternatively, set the environment variable :envvar:`MC_QUIET`.
 
 .. option:: --insecure
 
    Disables TLS/SSL certificate verification. Allows TLS connectivity to 
    servers with invalid certificates. Exercise caution when using this
    option against untrusted S3 hosts.
+
+   Alternatively, set the environment variable :envvar:`MC_INSECURE`.
 
 .. option:: --version
 
@@ -562,6 +576,7 @@ All :ref:`commands <minio-mc-commands>` support the following global options:
    /reference/minio-mc/mc-find
    /reference/minio-mc/mc-head
    /reference/minio-mc/mc-idp-ldap
+   /reference/minio-mc/mc-idp-ldap-accesskey
    /reference/minio-mc/mc-idp-ldap-policy
    /reference/minio-mc/mc-idp-openid
    /reference/minio-mc/mc-ilm

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-info.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-info.rst
@@ -23,6 +23,10 @@ The :mc:`mc idp ldap accesskey info` outputs information about the specified acc
 
 .. end-mc-idp-ldap-accesskey-info-desc
 
+.. include:: /includes/common-minio-ad-ldap-params.rst
+   :start-after: start-minio-ad-ldap-accesskey-creation
+   :end-before: end-minio-ad-ldap-accesskey-creation
+
 .. tab-set::
 
    .. tab-item:: EXAMPLE

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-info.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-info.rst
@@ -19,7 +19,7 @@ Description
 
 .. start-mc-idp-ldap-accesskey-info-desc
 
-The :mc:`mc idp ldap accesskey-info` outputs information about the specified access key(s).
+The :mc:`mc idp ldap accesskey info` outputs information about the specified access key(s).
 
 .. end-mc-idp-ldap-accesskey-info-desc
 

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-info.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-info.rst
@@ -1,0 +1,107 @@
+.. _minio-mc-idp-ldap-accesskey-info:
+
+==============================
+``mc idp ldap accesskey info``
+==============================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+.. mc:: mc idp ldap accesskey info
+
+
+Description
+-----------
+
+.. start-mc-idp-ldap-accesskey-info-desc
+
+The :mc:`mc idp ldap accesskey-info` outputs information about the specified access key(s).
+
+.. end-mc-idp-ldap-accesskey-info-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+         The following example outputs details for the access key ``mykey`` from the ``minio`` deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc idp ldap accesskey info minio/ mykey
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] idp ldap accesskey info      \
+                                             ALIAS     \
+                                             KEY       \
+                                             [KEY2] ...
+
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment configured for AD/LDAP integration.
+      - Replace ``KEY`` with the access key to delete.
+        You can list more than one access key by separating each key with a space.
+        
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment configured for AD/LDAP.
+
+   For example:
+
+   .. code-block:: none
+
+         mc idp ldap accesskey ls minio
+
+.. mc-cmd:: KEY
+   :required:
+
+   The configured access key to output information about.
+
+   You can list more than one access key by separating each key with a space.
+
+
+Example
+~~~~~~~
+
+Output information about the access keys ``mykey`` and ``mykey2`` from the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey info minio/ mykey mykey2
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
@@ -1,0 +1,189 @@
+.. _minio-mc-idp-ldap-accesskey-ls:
+
+============================
+``mc idp ldap accesskey ls``
+============================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+.. mc:: mc idp ldap accesskey ls
+.. mc:: mc idp ldap accesskey list
+
+
+Description
+-----------
+
+.. start-mc-idp-ldap-accesskey-ls-desc
+
+The :mc:`mc idp ldap accesskey-ls` displays a list of LDAP access key pairs.
+
+.. end-mc-idp-ldap-accesskey-ls-desc
+
+:mc:`mc idp ldap accesskey ls` is also known as :mc:`mc idp ldap accesskey list`.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+         The following example returns a list of access keys associated with the authenticated user on the ``minio`` :ref:`alias <alias>`:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc idp ldap accesskey ls minio/
+
+      If the authenticated user is the ``admin``, the example command returns a list of all users and their associated access keys.
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] idp ldap accesskey ls              \
+                                          ALIAS              \
+                                          [--permanent-only] \
+                                          [--temp-only]      \
+                                          [--users-only]     \
+                                          [DN] ...
+
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment configured for AD/LDAP integration.
+      - Replace ``DN`` with the string of a user's `distinguished name <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ldap/distinguished-names>`__.
+        You may list multiple distinguished names by separating each with a space.
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment configured for AD/LDAP.
+
+   For example:
+
+   .. code-block:: none
+
+         mc idp ldap accesskey ls minio
+
+.. mc-cmd:: --permanent-only
+   :optional:
+
+   Output only permanent access keys.
+
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey --temp-only`.
+
+.. mc-cmd:: --temp-only
+   :optional:
+
+   Output only temporary access keys.
+
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey --permanent-only`.
+
+.. mc-cmd:: --users-only
+   :optional:
+
+   Output only the user distinguished names.
+
+Examples
+~~~~~~~~
+
+List All Access Keys
+++++++++++++++++++++
+
+To return a list of all access keys, you must first authenticate as the ``admin`` user.
+Once authenticated, the following command returns all AD/LDAP access keys on the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey ls minio
+
+.. note::
+
+   If not authenticated as an admin, the command returns a list of access keys for the authenticated user only.
+
+List User Distinguished Names
++++++++++++++++++++++++++++++
+
+To return a list of DNs for a deployment, you must first authenticate as the ``admin`` user.
+Once authenticated, the following command outputs the AD/LDAP distinguished names on the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey ls minio --users-only
+
+List Temporary Access Keys
+++++++++++++++++++++++++++
+
+To return a list of all temporary access keys for a deployment, you must first authenticate as the ``admin`` user.
+Once authenticated, the following command outputs a list of distinguished names with their associated temporary access keys.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey ls minio --temp-only
+
+List a User's Access Keys
++++++++++++++++++++++++++
+
+The following command returns the AD/LDAP access keys for the user ``bobfisher`` on the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey list minio/ uid=bobfisher,dc=min,dc=io
+
+List Access Keys for Multiple Users
++++++++++++++++++++++++++++++++++++
+
+The following command returns the AD/LDAP access keys for the users ``bobfisher`` and ``cody3`` on the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey list minio/ uid=bobfisher,dc=min,dc=io uid=cody3,dc=min,dc=io
+
+List Access Keys for Authenticated User
++++++++++++++++++++++++++++++++++++++++
+
+The following command returns the AD/LDAP access keys for the currently authenticated user on the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey list minio/ 
+
+.. note:: 
+
+   If the authenticated user is the ``admin``, the command returns a list of all users and access keys on the deployment.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
@@ -11,8 +11,8 @@
    :depth: 2
 
 
-.. mc:: mc idp ldap accesskey ls
 .. mc:: mc idp ldap accesskey list
+.. mc:: mc idp ldap accesskey ls
 
 
 Description
@@ -20,7 +20,7 @@ Description
 
 .. start-mc-idp-ldap-accesskey-ls-desc
 
-The :mc:`mc idp ldap accesskey-ls` displays a list of LDAP access key pairs.
+The :mc:`mc idp ldap accesskey ls` displays a list of LDAP access key pairs.
 
 .. end-mc-idp-ldap-accesskey-ls-desc
 
@@ -82,14 +82,14 @@ Parameters
 
    Output only permanent access keys.
 
-   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey --temp-only`.
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey ls --temp-only`.
 
 .. mc-cmd:: --temp-only
    :optional:
 
    Output only temporary access keys.
 
-   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey --permanent-only`.
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey ls --permanent-only`.
 
 .. mc-cmd:: --users-only
    :optional:

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
@@ -26,6 +26,10 @@ The :mc:`mc idp ldap accesskey ls` displays a list of LDAP access key pairs.
 
 :mc:`mc idp ldap accesskey ls` is also known as :mc:`mc idp ldap accesskey list`.
 
+.. include:: /includes/common-minio-ad-ldap-params.rst
+   :start-after: start-minio-ad-ldap-accesskey-creation
+   :end-before: end-minio-ad-ldap-accesskey-creation
+
 .. tab-set::
 
    .. tab-item:: EXAMPLE

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
@@ -41,7 +41,7 @@ The :mc:`mc idp ldap accesskey ls` displays a list of LDAP access key pairs.
 
          mc idp ldap accesskey ls minio/
 
-      If the authenticated user is the ``admin``, the example command returns a list of all users and their associated access keys.
+      If the authenticated user has the ``admin:ListUsers`` permission, the example command returns a list of all users and their associated access keys.
 
    .. tab-item:: SYNTAX
 
@@ -116,12 +116,12 @@ Once authenticated, the following command returns all AD/LDAP access keys on the
 
 .. note::
 
-   If not authenticated as an admin, the command returns a list of access keys for the authenticated user only.
+   If the user does not have the ``admin:ListUsers`` permission, the command returns a list of access keys for the authenticated user only.
 
 List User Distinguished Names
 +++++++++++++++++++++++++++++
 
-To return a list of DNs for a deployment, you must first authenticate as the ``admin`` user.
+To return a list of DNs for a deployment, you must first authenticate as a user with the ``admin:ListUsers`` permission.
 Once authenticated, the following command outputs the AD/LDAP distinguished names on the ``minio`` deployment.
 
 .. code-block:: shell
@@ -132,7 +132,7 @@ Once authenticated, the following command outputs the AD/LDAP distinguished name
 List Temporary Access Keys
 ++++++++++++++++++++++++++
 
-To return a list of all temporary access keys for a deployment, you must first authenticate as the ``admin`` user.
+To return a list of all temporary access keys for a deployment, you must first authenticate as a user with the ``admin:ListUsers`` permission.
 Once authenticated, the following command outputs a list of distinguished names with their associated temporary access keys.
 
 .. code-block:: shell
@@ -172,7 +172,7 @@ The following command returns the AD/LDAP access keys for the currently authenti
 
 .. note:: 
 
-   If the authenticated user is the ``admin``, the command returns a list of all users and access keys on the deployment.
+   If the authenticated user has the ``admin:ListUsers`` permission, the command returns a list of all users and access keys on the deployment.
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-rm.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-rm.rst
@@ -1,0 +1,105 @@
+.. _minio-mc-idp-ldap-accesskey-rm:
+
+============================
+``mc idp ldap accesskey rm``
+============================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+.. mc:: mc idp ldap accesskey rm
+.. mc:: mc idp ldap accesskey remove
+
+
+Description
+-----------
+
+.. start-mc-idp-ldap-accesskey-rm-desc
+
+The :mc:`mc idp ldap accesskey-rm` deletes the specified access key from the local server.
+
+.. end-mc-idp-ldap-accesskey-rm-desc
+
+:mc:`mc idp ldap accesskey rm` is also known as :mc:`mc idp ldap accesskey remove`.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+         The following example deletes the access key ``mykey`` from the ``minio`` deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc idp ldap accesskey rm minio/ mykey
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] idp ldap accesskey rm              \
+                                          ALIAS              \
+                                          KEY
+
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment configured for AD/LDAP integration.
+      - Replace ``KEY`` with the access key to delete.
+        
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment configured for AD/LDAP.
+
+   For example:
+
+   .. code-block:: none
+
+         mc idp ldap accesskey ls minio
+
+.. mc-cmd:: KEY
+   :required:
+
+   The configured access key to delete.
+
+Example
+~~~~~~~
+
+Delete the access key ``mykey`` from the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey rm minio/ mykey
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-rm.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-rm.rst
@@ -26,6 +26,10 @@ The :mc:`mc idp ldap accesskey rm` deletes the specified access key from the loc
 
 :mc:`mc idp ldap accesskey rm` is also known as :mc:`mc idp ldap accesskey remove`.
 
+.. include:: /includes/common-minio-ad-ldap-params.rst
+   :start-after: start-minio-ad-ldap-accesskey-creation
+   :end-before: end-minio-ad-ldap-accesskey-creation
+
 .. tab-set::
 
    .. tab-item:: EXAMPLE

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-rm.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-rm.rst
@@ -20,7 +20,7 @@ Description
 
 .. start-mc-idp-ldap-accesskey-rm-desc
 
-The :mc:`mc idp ldap accesskey-rm` deletes the specified access key from the local server.
+The :mc:`mc idp ldap accesskey rm` deletes the specified access key from the local server.
 
 .. end-mc-idp-ldap-accesskey-rm-desc
 

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
@@ -25,6 +25,10 @@ The :mc-cmd:`mc idp ldap accesskey` commands allow you to list, delete, or displ
 
 The :mc-cmd:`mc idp ldap accesskey` commands are only supported against MinIO deployments.
 
+.. include:: /includes/common-minio-ad-ldap-params.rst
+   :start-after: start-minio-ad-ldap-accesskey-creation
+   :end-before: end-minio-ad-ldap-accesskey-creation
+
 The :mc-cmd:`mc idp ldap accesskey` command has the following subcommands:
 
 .. list-table::

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
@@ -1,0 +1,58 @@
+.. _minio-mc-idp-ldap-accesskey:
+
+=========================
+``mc idp ldap accesskey``
+=========================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc idp ldap accesskey
+
+.. versionadded:: RELEASE.2023-10-30T18-43-32Z
+
+Description
+-----------
+
+.. start-mc-idp-ldap-accesskey-desc
+
+The :mc-cmd:`mc idp ldap accesskey` commands allow you to list, delete, or display information about LDAP access key pairs. 
+
+.. end-mc-idp-ldap-accesskey-desc
+
+The :mc-cmd:`mc idp ldap accesskey` commands are only supported against MinIO deployments.
+
+The :mc-cmd:`mc idp ldap accesskey` command has the following subcommands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Subcommand
+     - Description
+
+   * - :mc-cmd:`mc idp ldap accesskey ls`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+          :start-after: start-mc-idp-ldap-accesskey-ls-desc
+          :end-before: end-mc-idp-ldap-accesskey-ls-desc
+
+   * - :mc-cmd:`mc idp ldap accesskey rm`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-remove.rst
+          :start-after: start-mc-idp-ldap-accesskey-remove-desc
+          :end-before: end-mc-idp-ldap-accesskey-remove-desc
+
+   * - :mc-cmd:`mc idp ldap accesskey info`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-info.rst
+          :start-after: start-mc-idp-ldap-accesskey-info-desc
+          :end-before: end-mc-idp-ldap-accesskey-info-desc
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   /reference/minio-mc/mc-idp-ldap-accesskey-ls
+   /reference/minio-mc/mc-idp-ldap-accesskey-rm
+   /reference/minio-mc/mc-idp-ldap-accesskey-info

--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -70,7 +70,6 @@ The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-man
                           [--noncurrent-expire-days "integer"]       \
                           [--noncurrent-expire-newer "integer"]      \
                           [--noncurrent-transition-days "integer"]   \
-                          [--noncurrent-transition-newer "integer"]  \
                           [--noncurrent-transition-tier "string"]    \
                           ALIAS
 
@@ -249,46 +248,6 @@ Parameters
    Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
    See :ref:`minio-lifecycle-management-scanner` for more information.
    
-.. mc-cmd:: --noncurrent-transition-newer
-   :optional:
-   
-   The maximum number of non-current object versions to retain on the current tier.
-   Older object versions beyond the number to retain transition to a different, specified tier.
-
-   Use this flag to keep a certain number of non-current versions of an object accessible on the tier in a first in, first out order.
-
-   If not specified, all non-current object versions transition to the different tier.
-
-   The following table lists a number of object versions and their transition eligibility based on ``--noncurrent-transition-newer 3``:
-
-   .. list-table::
-      :widths: 50 50
-      :width: 100% 
-
-      * - v5 (current version)
-        - Current version not affected by ILM rules.
-      * - v4
-        - kept on current tier
-      * - v3
-        - kept on current tier
-      * - v2
-        - kept on current tier
-      * - v1
-        - marked for transition to other tier
-
-   MinIO retains the current version, v5, on the tier.
-   MinIO also retains the next ``3`` non-current versions on the tier, starting with the newest.
-   This means MinIO leaves ``v4``, ``v3``, and ``v2`` for the three non-current version to keep on the current tier.
-
-   ``v1`` would be a fourth non-current version, which falls outside the limit of non-current versions to retain, so MinIO marks ``v1`` for transition.
-
-   Updating the number for this flag only impacts the unmarked versions of objects.
-   Any versions already marked for transition do not change if you increase the number, and any object versions already transitioned do not transition back to the tier.
-
-   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
-   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
-   See :ref:`minio-lifecycle-management-scanner` for more information.
-
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-ilm-rule-edit.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-edit.rst
@@ -67,7 +67,6 @@ rule on a MinIO bucket.
                           [--noncurrent-expire-days "string"]                 \
                           [--noncurrent-expire-newer "string"]                \
                           [--noncurrent-transition-days "string"]             \
-                          [--noncurrent-transition-newer value]               \
                           [--noncurrent-transition-tier "string"]             \
                           [--tags]                                            \
                           ALIAS
@@ -209,46 +208,6 @@ Parameters
    lifecycle management rules. Slow scanning due to high IO workloads or
    limited system resources may delay application of lifecycle management
    rules. See :ref:`minio-lifecycle-management-scanner` for more information.
-
-.. mc-cmd:: --noncurrent-transition-newer
-   :optional:
-
-   The maximum number of non-current object versions to retain on the current tier.
-   Older object versions beyond the number to retain transition to a different, specified tier.
-
-   Use this flag to keep a certain number of non-current versions of an object accessible on the tier in a first in, first out order.
-
-   If not specified, all non-current object versions transition to the different tier.
-
-   The following table lists a number of object versions and their transition eligibility based on ``--noncurrent-transition-newer 3``:
-
-   .. list-table::
-      :widths: 50 50
-      :width: 100% 
-
-      * - v5 (current version)
-        - Current version not affected by ILM rules.
-      * - v4
-        - kept on current tier
-      * - v3
-        - kept on current tier
-      * - v2
-        - kept on current tier
-      * - v1
-        - marked for transition to other tier
-
-   MinIO retains the current version, v5, on the tier.
-   MinIO also retains the next ``3`` non-current versions on the tier, starting with the newest.
-   This means MinIO leaves ``v4``, ``v3``, and ``v2`` for the three non-current version to keep on the current tier.
-
-   ``v1`` would be a fourth non-current version, which falls outside the limit of non-current versions to retain, so MinIO marks ``v1`` for transition.
-
-   Updating the number for this flag only impacts the unmarked versions of objects.
-   Any versions already marked for transition do not change if you increase the number, and any object versions already transitioned do not transition back to the tier.
-
-   MinIO uses a scanner process to check objects against all configured lifecycle management rules. 
-   Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
-   See :ref:`minio-lifecycle-management-scanner` for more information.
 
 
 .. mc-cmd:: --noncurrent-transition-tier

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -240,6 +240,10 @@ Parameters
 
       In prior versions, specifying ``/path/to/directory`` would result in the removal of the ``/path/to`` folder if ``directory`` did not exist.
 
+.. mc-cmd:: --retry
+
+   In case of errors during mirror process, retry on each errored object.
+
 .. mc-cmd:: storage-class, sc
    
 

--- a/source/reference/minio-mc/mc-mv.rst
+++ b/source/reference/minio-mc/mc-mv.rst
@@ -341,7 +341,7 @@ the storage class on the destination S3-compatible host.
 
 
 Behavior
-~~~~~~~~
+--------
 
 Object Names on Move
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-support-top-locks.rst
+++ b/source/reference/minio-mc/mc-support-top-locks.rst
@@ -19,9 +19,19 @@ Syntax
 
 .. start-mc-support-top-locks-desc
 
-The :mc:`mc support top locks` command lists the ten oldest locks on a MinIO deployment.
+The :mc:`mc support top locks` command lists the ten oldest :ref:`locks <minio-object-locking>` on a MinIO deployment.
 
 .. end-mc-support-top-locks-desc
+
+The command outputs the age of the lock, type of lock, owner, and resource.
+The output resembles the following:
+
+.. code-block:: shell
+
+   Since                 Type    Owner                 Resource
+   13 hours ago          WRITE   10.68.100.18:9000     .minio.sys/leader.lock
+   13 hours ago          WRITE   10.68.100.18:9000     .minio.sys/callhome/runCallhome.lock
+   13 hours ago          WRITE   10.68.100.23:9000     .minio.sys/new-drive-healing/0/0
 
 .. tab-set::
 

--- a/source/reference/minio-mc/minio-client-settings.rst
+++ b/source/reference/minio-mc/minio-client-settings.rst
@@ -81,3 +81,239 @@ Examples
          :class: copyable
 
          export MC_HOST_myalias=https://Q3AM3UQ867SPQQA43P2F:zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG:eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiJOVUlCT1JaWVRWMkhHMkJNUlNYUiIsImF1ZCI6IlBvRWdYUDZ1Vk80NUlzRU5SbmdEWGo1QXU1WWEiLCJhenAiOiJQb0VnWFA2dVZPNDVJc0VOUm5nRFhqNUF1NVlhIiwiZXhwIjoxNTM0ODk2NjI5LCJpYXQiOjE1MzQ4OTMwMjksImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0Ojk0NDMvb2F1dGgyL3Rva2VuIiwianRpIjoiNjY2OTZjZTctN2U1Ny00ZjU5LWI0MWQtM2E1YTMzZGZiNjA4In0.eJONnVaSVHypiXKEARSMnSKgr-2mlC2Sr4fEGJitLcJF_at3LeNdTHv0_oHsv6ZZA3zueVGgFlVXMlREgr9LXA@play.min.io
+
+Configuration Directory
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify the path to the configuration folder the MinIO Client should use.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_CONFIG_DIR
+
+         Replace ``<ALIAS>`` at the end of the environment variable with the ``alias`` to set the host for.
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+Progress Bar
+~~~~~~~~~~~~
+
+Disable the MinIO Client progress bar.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_QUIET
+
+         Replace ``<ALIAS>`` at the end of the environment variable with the ``alias`` to set the host for.
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+Color Theme
+~~~~~~~~~~~
+
+Disable the color theme used for MinIO Client output.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_NO_COLOR
+
+         Replace ``<ALIAS>`` at the end of the environment variable with the ``alias`` to set the host for.
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+
+JSON
+~~~~
+
+Enable formatting the output as JSON lines.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_JSON
+
+         Replace ``<ALIAS>`` at the end of the environment variable with the ``alias`` to set the host for.
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+Debug
+~~~~~
+
+Enable the debug output.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_DEBUG
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+Disable SSL
+~~~~~~~~~~~
+
+Disable SSL certificate verification.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_INSECURE
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+Limit Download Bandwidth
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Limit the download bandwidth the MinIO Client uses for certain commands.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_LIMIT_DOWNLOAD
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+If not specified, the MinIO Client uses all available bandwidth.
+
+Limit client-side download rates to no more than the specified rate in KiB/s, MiB/s, or GiB/s. This affects only the download from the local device running the MinIO Client. Valid units include:
+
+- B for bytes
+- K for kilobytes
+- M for megabytes
+- G for gigabytes
+- Ki for kibibytes
+- Mi for mibibytes
+- Gi for gibibytes
+
+For example, to limit download rates to no more than 1 GiB/s, use the following on a Linux system:
+
+.. code-block:: shell
+   :class: copyable
+
+   export MC_LIMIT_DOWNLOAD=1G
+
+Refer to your operating system instructions for equivalent commands on non-Linux systems.
+
+Limit Upload Bandwidth
+~~~~~~~~~~~~~~~~~~~~~~
+
+Limit the upload bandwidth the MinIO Client uses for certain commands.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_LIMIT_UPLOAD
+
+         Replace ``<ALIAS>`` at the end of the environment variable with the ``alias`` to set the host for.
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+If not specified, the MinIO Client uses all available bandwidth.
+
+Limit client-side upload rates to no more than the specified rate in KiB/s, MiB/s, or GiB/s. This affects only the upload from the local device running the MinIO Client. Valid units include:
+
+- B for bytes
+- K for kilobytes
+- M for megabytes
+- G for gigabytes
+- Ki for kibibytes
+- Mi for mibibytes
+- Gi for gibibytes
+
+For example, to limit upload rates to no more than 1 GiB/s, use the following on a Linux system:
+
+.. code-block:: shell
+   :class: copyable
+
+   export MC_LIMIT_UPLOAD=1G
+
+Refer to your operating system instructions for equivalent commands on non-Linux systems.
+
+Encrypt
+~~~~~~~
+
+Encrypt and decrypt options using :ref:`server-side encryption <minio-sse-data-encryption>` with server managed keys.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_ENCRYPT
+
+      Specify the key with the :envvar:`MC_ENCRYPT_KEY` environment variable.
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+Encrypt Key
+~~~~~~~~~~~
+
+Specify the key to use for encrypting and decrypting objects.
+Must also enable the :envvar:`MC_ENCRYPT` environment variable.
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :selected:
+
+      .. envvar:: MC_ENCRYPT_KEY
+
+   .. tab-item:: Configuration Setting
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option


### PR DESCRIPTION
Updates for October 2023 MinIO Client releases
    
- Adds output sample for `mc support top locks`
- Adds `mc idp ldap accesskey` and subcommands
    
Closes #1056
    
- Adds environment variables for most global flags
- Adds --retry flag to mc mirror
- Adds --bucket-bandwidth flag to mc admin replicate update
    
Partially addresses #1045

- Removes unsupported `--noncurrent-transition-newer` flags from commands.

Staged:
http://192.241.195.202:9000/staging/mc-oct-2023/linux/reference/minio-mc.html
