### PR TITLE
Removing reference to unsupported decom with tiering

### DIFF
--- a/source/operations/install-deploy-manage/decommission-server-pool.rst
+++ b/source/operations/install-deploy-manage/decommission-server-pool.rst
@@ -120,14 +120,6 @@ However, if Pool 1 were full (e.g. 200TB of used space), decommissioning would
 completely fill the remaining pools and potentially prevent any further write
 operations.
 
-Decommissioning Does Not Support Tiering
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-MinIO does not support decommissioning pools in deployments with
-:ref:`tiering <minio-lifecycle-management-tiering>` configured. The MinIO
-server rejects decommissioning attempts if any bucket in the deployment
-has a tiering configuration.
-
 Considerations
 --------------
 


### PR DESCRIPTION
Per community Slack, correcting conflicting docs notes about decommissioning when tiering is enabled.

Support for this was added in March 2023.