### PR TITLE
Tweak helm deployment strategy

### DIFF
--- a/source/operations/install-deploy-manage/deploy-minio-tenant-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant-helm.rst
@@ -141,7 +141,7 @@ You can modify the Operator deployment after installation.
      .. code-block:: shell
         :class: copyable
 
-        kubectl port-forward svc/minio 9000 -n MINIO_TENANT_NAMESPACE
+        kubectl port-forward svc/MINIO_TENANT_NAME-hl 9000 -n MINIO_TENANT_NAMESPACE
 
    * Create an alias for the Tenant service:
 
@@ -165,7 +165,7 @@ Deploy a Tenant using a Local Helm Chart
 ----------------------------------------
 
 The following procedure deploys a Tenant using a local copy of the Helm Charts.
-This method may support easier pre-configuration of the Tenant compared to the :ref:`repo-based installation  <deploy-tenant-helm-repo>`
+This method may support easier pre-configuration of the Tenant compared to the :ref:`repo-based installation  <deploy-tenant-helm-repo>`.
 
 #. Download the Helm charts
 
@@ -223,7 +223,7 @@ This method may support easier pre-configuration of the Tenant compared to the :
      .. code-block:: shell
         :class: copyable
 
-        kubectl port-forward svc/myminio-hl 9000 -n MINIO_TENANT_NAMESPACE
+        kubectl port-forward svc/MINIO_TENANT_NAME-hl 9000 -n MINIO_TENANT_NAMESPACE
 
    * Create an alias for the Tenant service:
 

--- a/source/operations/install-deploy-manage/deploy-operator-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-helm.rst
@@ -31,7 +31,7 @@ To install the Operator with Helm you will need the following:
 
 For more about Operator installation requirements, including supported Kubernetes versions and TLS certificates, see the :ref:`Operator deployment prerequisites <minio-operator-prerequisites>`.
 
-This procedure assumes familiarity the with referenced Kubernetes concepts and utilities.
+This procedure assumes familiarity with the referenced Kubernetes concepts and utilities.
 While this documentation may provide guidance for configuring or deploying Kubernetes-related resources on a best-effort basis, it is not a replacement for the official :kube-docs:`Kubernetes Documentation <>`.
 
 .. _minio-k8s-deploy-operator-helm-repo:
@@ -84,7 +84,7 @@ You can modify the Operator deployment after installation.
    .. code-block:: shell
       :class: copyable
 
-      helm install 
+      helm install \
         --namespace minio-operator \
         --create-namespace \
         operator minio-operator/operator
@@ -213,7 +213,7 @@ This method may support easier pre-configuration of the Operator compared to the
       helm install \
       --namespace minio-operator \
       --create-namespace \
-      minio-operator operator-|operator-version-stable|.tgz
+      operator operator-|operator-version-stable|.tgz
 
 #. Configure Operator
 


### PR DESCRIPTION
Important @ravindk89 : the installation of the tenant will end up with CrashLooping pods unless a Standard storageclass is previously installed - similar to the following. Please document this where best you see fit.
```
cat <<EOF | kubectl apply -f -
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: standard
provisioner: rancher.io/local-path
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
EOF