### PR TITLE
DOCS-1071: mc.RELEASE.2023-11-15T22-45-58Z PARTIAL

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -235,21 +235,50 @@ Syntax
 
 .. mc-cmd:: --stats
 
+   Accumulates aggregated statistics for each traced function call during the current trace session.
+
+   The output table includes the following columns.
+
+   .. list-table::
+      :stub-columns: 1
+      :widths: 30 70
+
+      * - Call
+        - The name of the captured function.
+
+      * - Count
+        - The number of times the Call occurred.
+
+      * - RPM
+        - The Rate Per Minute (RPM) of that Call.
+
+      * - Avg Time
+        - The average time required for the Call to complete.
+
+      * - Min Time
+        - The minimum time spent for the Call to complete.
+
+      * - Avg TTFB
+        - .. versionadded:: RELEASE.2023-11-15T22-45-58Z
+
+          The average Time To First Byte (TTFB) for the Call.
+
+      * - Max TTFB
+        - .. versionadded:: RELEASE.2023-11-15T22-45-58Z
+        
+          The maximum Time To First Byte for the Call.
+
+      * - Errors
+        - The number of Calls that failed with an error.
+
+      * - RX Avg
+        - The average number of Bytes Received (RX) for the Call.
+
+      * - TX AVG
+        - The average number of Bytes Sent (TX) for the Call.
+
    Accumulate stats, such as name, count, duration, min time, max time, time to first byte, or errors.
    Accumulates up to 15 stat entries.
-
-   The output resembles the following:
-
-   .. code-block:: shell
-
-      Duration: 1m18s ∙●∙
-      Call                	Count      	RPM  	Avg Time	TTFB Time	Min Time  	Max Time   	Errors	RX Avg	TX Avg 	
-      s3.HeadBucket       	169 (79.3%)	130.8	1.395ms 	0s       	369.392µs 	10.486821ms	0     	135 B 	0 B    	
-      s3.GetObject        	34 (16.0%) 	26.3 	1.39ms  	1.278ms  	558.722µs 	2.688192ms 	0     	90 B  	759 B  	
-      s3.ListBuckets      	4 (1.9%)   	3.1  	6.617ms 	5.573ms  	4.602269ms	7.708086ms 	0     	93 B  	7.5 KiB	
-      s3.ListObjectsV2    	3 (1.4%)   	2.3  	34.621ms	34.393ms 	2.015213ms	99.601832ms	0     	93 B  	2.6 KiB	
-      s3.GetBucketLocation	2 (0.9%)   	1.5  	991µs   	796µs    	920.966µs 	1.061579ms 	0     	122 B 	245 B  	
-      s3.ListObjectsV1    	1 (0.5%)   	0.8  	998µs   	837µs    	998.367µs 	998.367µs  	0     	124 B 	364 B  		 
 
 .. mc-cmd:: --verbose
    

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -165,6 +165,8 @@ The following table lists :mc-cmd:`mc` commands:
    * - | :mc:`mc alias list`
        | :mc:`mc alias remove`
        | :mc:`mc alias set`
+       | :mc:`mc alias import`
+       | :mc:`mc alias export`
      - .. include:: /reference/minio-mc/mc-alias.rst
           :start-after: start-mc-alias-desc
           :end-before: end-mc-alias-desc

--- a/source/reference/minio-mc/mc-alias-export.rst
+++ b/source/reference/minio-mc/mc-alias-export.rst
@@ -1,0 +1,123 @@
+.. _minio-mc-alias-export:
+
+===================
+``mc alias export``
+===================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc alias export
+
+.. versionadded:: mc.RELEASE.2023-11-15T22-45-58Z
+
+Syntax
+------
+
+.. start-mc-alias-export-desc
+
+The :mc:`mc alias export` command exports an alias configuration from the existing :ref:`configuration <mc-configuration>`.
+
+.. end-mc-alias-export-desc
+
+The command outputs the result to ``STDOUT`` where you can either capture the output as a file *or* perform further modifications to the output as necessary.
+
+Use the :mc:`mc alias import` command to import the resulting JSON configuration.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command exports an alias configuration from the existing host and outputs it to a file:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc alias export play > play.json
+
+      The command outputs the file to Standard Out (``STDOUT``).
+      You can alternatively pipe the output to a utility of your choice for further operations.
+
+
+   .. tab-item:: SYNTAX
+
+      The :mc:`mc alias export` command has the following syntax:
+
+      .. code-block:: shell
+
+         mc [GLOBALFLAGS] alias export ALIAS
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The name of the alias to export.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Behavior
+--------
+
+JSON Format
+~~~~~~~~~~~
+
+The command outputs a JSON object with the following schema:
+
+.. code-block:: json
+
+   {
+      "url" : "https://hostname:port",
+      "accessKey": "<STRING>",
+      "secretKey": "<STRING>",
+      "api": "s3v4",
+      "path": "auto"
+   }
+
+You can use the :mc:`mc alias import` to import the JSON document.
+
+Examples
+--------
+
+Export and Transform an Alias
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example exports the alias for the `play.min.io <https://play.min.io>`__ sandbox.
+It then transforms the configuration using the `jq <https://jqlang.github.io/jq/>`__ utility and creates a new alias from the modified configuration:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc alias export play | jq '.accessKey = "minioadmin" | .secretKey = "minioadmin"' | mc alias import play-custom
+
+Back Up An Alias Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command exports an alias configuration to a JSON file.
+You can then back up that file using your preferred process.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc alias export play > play-backup.json
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility
+

--- a/source/reference/minio-mc/mc-alias-import.rst
+++ b/source/reference/minio-mc/mc-alias-import.rst
@@ -1,0 +1,128 @@
+.. _minio-mc-alias-import:
+
+===================
+``mc alias import``
+===================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc alias import
+
+Syntax
+------
+
+.. start-mc-alias-import-desc
+
+The :mc:`mc alias import` command imports an alias configuration from a JSON document.
+
+.. end-mc-alias-import-desc
+
+You can use :mc:`mc alias export` to create the necessary JSON for import.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following command imports an alias configuration from a JSON document:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc alias import newalias ./credentials.json
+
+      Use :mc:`mc alias list newalias <mc alias list>` to confirm the import succeeded.
+
+   .. tab-item:: SYNTAX
+
+      The :mc:`mc alias import` command has the following syntax:
+
+      .. code-block:: shell
+
+         mc [GLOBALFLAGS] alias import ALIAS PATH|STDIN
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The name of the alias to assign to the imported configuration.
+
+.. mc-cmd:: PATH
+   :required:
+
+   The full path to the JSON object representing the alias configuration to import.
+
+   Mutually exclusive with the :mc-cmd:`~mc alias import STDIN` parameter.
+
+.. mc-cmd:: STDIN
+   :required:
+
+   Directs the command to use the Standard Input (STDIN) as the source of the JSON object for import.
+
+   Mutually exclusive with the :mc-cmd:`~mc alias import PATH` parameter.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Behavior
+--------
+
+JSON Format
+~~~~~~~~~~~
+
+The JSON object **must** have the following format:
+
+.. code-block:: json
+
+   {
+      "url" : "https://hostname:port",
+      "accessKey": "<STRING>",
+      "secretKey": "<STRING>",
+      "api": "s3v4",
+      "path": "auto"
+   }
+
+You can use the :mc:`mc alias export` command to export an existing alias from the local host configuration.
+Alternatively, you can manually extract the necessary JSOn fields from the :mc:`mc` :ref:`configuration file <mc-configuration>`.
+
+Examples
+--------
+
+Import an Alias Using Standard Input
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example imports a custom alias for the `play.min.io <https://play.min.io>`__ sandbox.
+You can modify this example to use user credentials you have already created or validated as existing on the sandbox:
+
+.. code-block:: shell
+   :class: copyable
+
+   echo '
+   {
+    "url": "https://play.min.io",
+    "accessKey": "minioadmin",
+    "secretKey": "minioadmin",
+    "api": "s3v4",
+    "path": "auto"
+   }' | mc alias import play-minioadmin
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility
+

--- a/source/reference/minio-mc/mc-alias.rst
+++ b/source/reference/minio-mc/mc-alias.rst
@@ -52,6 +52,16 @@ Subcommands
           :start-after: start-mc-alias-set-desc
           :end-before: end-mc-alias-set-desc
 
+   * - :mc:`~mc alias import`
+     - .. include:: /reference/minio-mc/mc-alias-import.rst
+          :start-after: start-mc-alias-import-desc
+          :end-before: end-mc-alias-import-desc
+
+   * - :mc:`~mc alias export`
+     - .. include:: /reference/minio-mc/mc-alias-export.rst
+          :start-after: start-mc-alias-export-desc
+          :end-before: end-mc-alias-export-desc
+
 .. toctree::
    :titlesonly:
    :hidden:
@@ -59,3 +69,5 @@ Subcommands
    /reference/minio-mc/mc-alias-list
    /reference/minio-mc/mc-alias-remove
    /reference/minio-mc/mc-alias-set
+   /reference/minio-mc/mc-alias-import
+   /reference/minio-mc/mc-alias-export

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
@@ -44,9 +44,9 @@ The :mc-cmd:`mc idp ldap accesskey` command has the following subcommands:
           :end-before: end-mc-idp-ldap-accesskey-ls-desc
 
    * - :mc-cmd:`mc idp ldap accesskey rm`
-     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-remove.rst
-          :start-after: start-mc-idp-ldap-accesskey-remove-desc
-          :end-before: end-mc-idp-ldap-accesskey-remove-desc
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-rm.rst
+          :start-after: start-mc-idp-ldap-accesskey-rm-desc
+          :end-before: end-mc-idp-ldap-accesskey-rm-desc
 
    * - :mc-cmd:`mc idp ldap accesskey info`
      - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-info.rst


### PR DESCRIPTION
Partially addresses #1071 

Just documenting `mc alias import` and `mc alias export`, the former of which we seem to have missed a year or so back.

Staged: 

http://192.241.195.202:9000/staging/DOCS-1071/linux/reference/minio-mc/mc-alias-import.html

http://192.241.195.202:9000/staging/DOCS-1071/linux/reference/minio-mc/mc-alias-export.html