### PR TITLE
Use 9001 as the default console address port

### DIFF
--- a/source/administration/minio-console.rst
+++ b/source/administration/minio-console.rst
@@ -128,13 +128,13 @@ each MinIO Server in the deployment.
 For example, the following command starts a distributed MinIO deployment using
 a static port assignment of ``9090`` for the MinIO Console. This deployment
 would respond to S3 API operations on the default MinIO server port ``:9000``
-and browser access on the MinIO Console port ``:9090``.
+and browser access on the MinIO Console port ``:9001``.
 
 .. code-block:: shell
    :class: copyable
 
    minio server https://minio-{1...4}.example.net/mnt/drive-{1...4} \
-         --console-address ":9090"
+         --console-address ":9001"
 
 Deployments behind network routing components which require static ports for 
 routing rules may require setting a static MinIO Console port. For example,

--- a/source/extra/examples/minio-dev.yaml
+++ b/source/extra/examples/minio-dev.yaml
@@ -27,7 +27,7 @@ spec:
     - /bin/bash
     - -c
     args: 
-    - minio server /data --console-address :9090
+    - minio server /data --console-address :9001
     volumeMounts:
     - mountPath: /data
       name: localvolume # Corresponds to the `spec.volumes` Persistent Volume

--- a/source/includes/common/common-deploy.rst
+++ b/source/includes/common/common-deploy.rst
@@ -73,7 +73,7 @@ Include any other environment variables as required for your local deployment.
 
    .. tab-item:: MinIO Console
 
-      You can access the MinIO Console by entering any of the hostnames or IP addresses from the MinIO server ``Console`` block in your preferred browser, such as http://localhost:9090.
+      You can access the MinIO Console by entering any of the hostnames or IP addresses from the MinIO server ``Console`` block in your preferred browser, such as http://localhost:9001.
 
       Log in with the :envvar:`MINIO_ROOT_USER` and :envvar:`MINIO_ROOT_PASSWORD` configured in the environment file specified to the container.
 

--- a/source/includes/common/common-minio-kes.rst
+++ b/source/includes/common/common-minio-kes.rst
@@ -75,7 +75,7 @@ Run the following command in a terminal or shell to start the MinIO server as a 
    :substitutions:
 
    export MINIO_CONFIG_ENV_FILE=|minioconfigpath|/minio
-   minio server --console-address :9090
+   minio server --console-address :9001
 
 .. end-kes-minio-start-server-desc
 
@@ -177,7 +177,7 @@ You can use either the MinIO Console or the MinIO :mc:`mc` CLI to enable bucket-
 
    .. tab-item:: MinIO Console
 
-      Open the MinIO Console by navigating to http://127.0.0.1:9090 in your preferred browser and logging in with the root credentials specified to the MinIO container.
+      Open the MinIO Console by navigating to http://127.0.0.1:9001 in your preferred browser and logging in with the root credentials specified to the MinIO container.
       If you deployed MinIO using a different Console listen port, substitute ``9090`` with that port value.
 
       Once logged in, create a new Bucket and name it to your preference.

--- a/source/includes/container/common-deploy.rst
+++ b/source/includes/container/common-deploy.rst
@@ -71,7 +71,7 @@ The instructions include examples for both quay.io and DockerHub:
 
    .. tab-item:: MinIO Web Console
 
-      You can access the MinIO Web Console by entering http://localhost:9090 in your preferred browser.
+      You can access the MinIO Web Console by entering http://localhost:9001 in your preferred browser.
       Any traffic to the MinIO Console port on the local host redirects to the container.
 
       Log in with the :envvar:`MINIO_ROOT_USER` and :envvar:`MINIO_ROOT_PASSWORD` configured in the environment file specified to the container.

--- a/source/includes/container/common-minio-kes.rst
+++ b/source/includes/container/common-minio-kes.rst
@@ -11,7 +11,7 @@ The commands in this section create the following resources:
    :substitutions:
 
    sudo podman pod create  \
-     -p 9000:9000 -p 9090:9090 -p 7373:7373  \
+     -p 9000:9000 -p 9001:9001 -p 7373:7373  \
      -v |kescertpath|:/certs  \
      -v |miniodatapath|:/mnt/minio  \
      -v |kesconfigpath|:/etc/default/  \
@@ -33,7 +33,7 @@ The commands in this section create the following resources:
      --pod "|namespace|"  \
      -e "MINIO_CONFIG_ENV_FILE=/etc/default/minio"  \
      quay.io/minio/minio:|minio-latest| server  \
-       --console-address ":9090"
+       --console-address ":9001"
 
 You can verify the status of the containers using the following commands:
 

--- a/source/includes/container/quickstart.rst
+++ b/source/includes/container/quickstart.rst
@@ -50,11 +50,11 @@ Procedure
 
                podman run \
                   -p 9000:9000 \
-                  -p 9090:9090 \
+                  -p 9001:9001 \
                   -v ~/minio/data:/data \
                   -e "MINIO_ROOT_USER=ROOTNAME" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
-                  quay.io/minio/minio server /data --console-address ":9090"
+                  quay.io/minio/minio server /data --console-address ":9001"
    
             The example above works this way:
    
@@ -75,11 +75,11 @@ Procedure
    
                podman run \
                   -p 9000:9000 \
-                  -p 9090:9090 \
+                  -p 9001:9001 \
                   -v D:\minio\data:/data \
                   -e "MINIO_ROOT_USER=ROOTNAME" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
-                  quay.io/minio/minio server /data --console-address ":9090"
+                  quay.io/minio/minio server /data --console-address ":9001"
    
             The example above works this way:
    
@@ -106,12 +106,12 @@ Procedure
    
                docker run \
                   -p 9000:9000 \
-                  -p 9090:9090 \
+                  -p 9001:9001 \
                   --name minio \
                   -v ~/minio/data:/data \
                   -e "MINIO_ROOT_USER=ROOTNAME" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
-                  quay.io/minio/minio server /data --console-address ":9090"
+                  quay.io/minio/minio server /data --console-address ":9001"
          
             The example above works this way:
    
@@ -133,12 +133,12 @@ Procedure
    
                docker run \
                   -p 9000:9000 \
-                  -p 9090:9090 \
+                  -p 9001:9001 \
                   --name minio1 \
                   -v D:\minio\data:/data \
                   -e "MINIO_ROOT_USER=ROOTUSER" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
-                  quay.io/minio/minio server /data --console-address ":9090"
+                  quay.io/minio/minio server /data --console-address ":9001"
                
             The example above works this way:
    
@@ -165,13 +165,13 @@ Procedure
    
                docker run \
                   -p 9000:9000 \
-                  -p 9090:9090 \
+                  -p 9001:9001 \
                   --user $(id -u):$(id -g) \
                   --name minio1 \
                   -e "MINIO_ROOT_USER=ROOTUSER" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
                   -v ${HOME}/minio/data:/data \
-                  quay.io/minio/minio server /data --console-address ":9090"
+                  quay.io/minio/minio server /data --console-address ":9001"
          
             The example above works this way:
    
@@ -198,13 +198,13 @@ Procedure
    
                docker run \
                   -p 9000:9000 \
-                  -p 9090:9090 \
+                  -p 9001:9001 \
                   --name minio1 \
                   --security-opt "credentialspec=file://path/to/file.json"
                   -e "MINIO_ROOT_USER=ROOTUSER" \
                   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
                   -v D:\data:/data \
-                  quay.io/minio/minio server /data --console-address ":9090"
+                  quay.io/minio/minio server /data --console-address ":9001"
    
             The example above works this way:
    
@@ -222,7 +222,7 @@ Procedure
 #. Connect your Browser to the MinIO Server
 
    Access the :ref:`minio-console` by going to a browser and going to ``http://127.0.0.1:9000`` or one of the Console addresses specified in the :mc:`minio server` command's output.
-   For example, :guilabel:`Console: http://192.0.2.10:9090 http://127.0.0.1:9090` in the example output indicates two possible addresses to use for connecting to the Console.
+   For example, :guilabel:`Console: http://192.0.2.10:9001 http://127.0.0.1:9001` in the example output indicates two possible addresses to use for connecting to the Console.
 
    While port ``9000`` is used for connecting to the API, MinIO automatically redirects browser access to the MinIO Console.
 

--- a/source/includes/container/steps-configure-keycloak-identity-management.rst
+++ b/source/includes/container/steps-configure-keycloak-identity-management.rst
@@ -1,6 +1,6 @@
 .. |KEYCLOAK_URL| replace:: localhost:8080
 .. |MINIO_S3_URL| replace:: localhost:9000
-.. |MINIO_CONSOLE_URL| replace:: localhost:9090
+.. |MINIO_CONSOLE_URL| replace:: localhost:9001
 
 1) Create the Podman Pod
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -12,7 +12,7 @@ This ensures both containers can communicate normally.
    :class: copyable
 
    podman pod create \ 
-        -p 9000:9000 -p 9090:9090 -p 8080:8080 \
+        -p 9000:9000 -p 9001:9001 -p 8080:8080 \
         -v ~/minio-keycloak/minio:/mnt/minio \
         -n minio-keycloak
 
@@ -81,9 +81,9 @@ The following command starts the MinIO Container and attaches it to the ``minio-
    podman run -dt \
           --name minio-server \
           --pod minio-keycloak \
-          quay.io/minio/minio:RELEASE.2023-02-22T18-23-45Z server /mnt/data --console-address :9090
+          quay.io/minio/minio:RELEASE.2023-02-22T18-23-45Z server /mnt/data --console-address :9001
 
-Go to ``localhost:9090`` to access the MinIO Console.
+Go to ``localhost:9001`` to access the MinIO Console.
 Log in using the default credentials ``minioadmin:minioadmin``.
 
 7) Configure MinIO for Keycloak Authentication

--- a/source/includes/container/steps-configure-minio-kes-aws.rst
+++ b/source/includes/container/steps-configure-minio-kes-aws.rst
@@ -107,7 +107,7 @@ You can use either the MinIO Console or the MinIO :mc:`mc` CLI to enable bucket-
 
    .. tab-item:: MinIO Console
 
-      Open the MinIO Console by navigating to http://127.0.0.1:9090 in your preferred browser and logging in with the root credentials specified to the MinIO container.
+      Open the MinIO Console by navigating to http://127.0.0.1:9001 in your preferred browser and logging in with the root credentials specified to the MinIO container.
 
       Once logged in, create a new Bucket and name it to your preference.
       Select the Gear :octicon:`gear` icon to open the management view.

--- a/source/includes/container/steps-configure-minio-kes-azure.rst
+++ b/source/includes/container/steps-configure-minio-kes-azure.rst
@@ -91,7 +91,7 @@ You can use either the MinIO Console or the MinIO :mc:`mc` CLI to enable bucket-
 
    .. tab-item:: MinIO Console
 
-      Open the MinIO Console by navigating to http://127.0.0.1:9090 in your preferred browser and logging in with the root credentials specified to the MinIO container.
+      Open the MinIO Console by navigating to http://127.0.0.1:9001 in your preferred browser and logging in with the root credentials specified to the MinIO container.
 
       Once logged in, create a new Bucket and name it to your preference.
       Select the Gear :octicon:`gear` icon to open the management view.

--- a/source/includes/container/steps-configure-minio-kes-gcp.rst
+++ b/source/includes/container/steps-configure-minio-kes-gcp.rst
@@ -94,7 +94,7 @@ You can use either the MinIO Console or the MinIO :mc:`mc` CLI to enable bucket-
 
    .. tab-item:: MinIO Console
 
-      Open the MinIO Console by navigating to http://127.0.0.1:9090 in your preferred browser and logging in with the root credentials specified to the MinIO container.
+      Open the MinIO Console by navigating to http://127.0.0.1:9001 in your preferred browser and logging in with the root credentials specified to the MinIO container.
 
       Once logged in, create a new Bucket and name it to your preference.
       Select the Gear :octicon:`gear` icon to open the management view.

--- a/source/includes/container/steps-configure-minio-kes-hashicorp.rst
+++ b/source/includes/container/steps-configure-minio-kes-hashicorp.rst
@@ -94,7 +94,7 @@ You can use either the MinIO Console or the MinIO :mc:`mc` CLI to enable bucket-
 
    .. tab-item:: MinIO Console
 
-      Open the MinIO Console by navigating to http://127.0.0.1:9090 in your preferred browser and logging in with the root credentials specified to the MinIO container.
+      Open the MinIO Console by navigating to http://127.0.0.1:9001 in your preferred browser and logging in with the root credentials specified to the MinIO container.
 
       Once logged in, create a new Bucket and name it to your preference.
       Select the Gear :octicon:`gear` icon to open the management view.

--- a/source/includes/container/steps-deploy-minio-single-node-multi-drive.rst
+++ b/source/includes/container/steps-deploy-minio-single-node-multi-drive.rst
@@ -27,7 +27,7 @@ Select the container management interface of your choice for the relevant comman
          :class: copyable
 
          podman run -dt                                  \
-           -p 9000:9000 -p 9090:9090                     \
+           -p 9000:9000 -p 9001:9001                     \
            -v PATH1:/data-1                              \
            -v PATH2:/data-2                              \
            -v PATH3:/data-3                              \
@@ -35,7 +35,7 @@ Select the container management interface of your choice for the relevant comman
            -v /etc/default/minio:/etc/config.env         \
            -e "MINIO_CONFIG_ENV_FILE=/etc/config.env"    \
            --name "minio_local"                          \
-           minio server --console-address ":9090"
+           minio server --console-address ":9001"
 
       Specify any other :podman-docs:`options <markdown/podman-run.1.html>` to ``podman run`` as necessary for your local environment.
 
@@ -47,7 +47,7 @@ Select the container management interface of your choice for the relevant comman
          :class: copyable
 
          docker run -dt                                  \
-           -p 9000:9000 -p 9090:9090                     \
+           -p 9000:9000 -p 9001:9001                     \
            -v PATH1:/data-1                              \
            -v PATH2:/data-2                              \
            -v PATH3:/data-3                              \
@@ -55,7 +55,7 @@ Select the container management interface of your choice for the relevant comman
            -v /etc/default/minio:/etc/config.env         \
            -e "MINIO_CONFIG_ENV_FILE=/etc/config.env"    \
            --name "minio_local"                          \
-           minio server --console-address ":9090"
+           minio server --console-address ":9001"
 
       Specify any other `options <https://docs.docker.com/engine/reference/commandline/run/>`__ to ``docker run`` as necessary for your local environment.
 
@@ -83,7 +83,7 @@ The following table describes each line of the command and provides additional c
      - Directs Podman/Docker to create and start the container as a detached (``-d``) background process with a pseudo-TTY (``-t``).
        This allows the container to run in the background with an open TTY for bash-like access.
 
-   * - ``-p 9000:9000 -p 9090:9090``
+   * - ``-p 9000:9000 -p 9001:9001``
      - Binds the ports ``9000`` and ``9090`` on the local machine to the same ports on the container.
        This allows access to the container through the local machine.
 
@@ -114,9 +114,9 @@ The following table describes each line of the command and provides additional c
        Omit this value to allow Podman/Docker to automatically generate a container name.
        You can replace this value to best reflect your requirements.
 
-   * - ``minio server --console-address ":9090"``
+   * - ``minio server --console-address ":9001"``
      - Starts the MinIO server using the ``minio:minio`` image pulled from an earlier step.
-       The :mc-cmd:`minio server --console-address ":9090" <minio server --console-address>` option directs the server to set a static port for the MinIO Console Web Interface.
+       The :mc-cmd:`minio server --console-address ":9001" <minio server --console-address>` option directs the server to set a static port for the MinIO Console Web Interface.
        This option is *required* for containerized environments.
 
        If you modify this value, ensure you set the proper port mapping using the ``-p`` flag to Podman/Docker to ensure traffic forwarding between the local host and the container.
@@ -134,7 +134,7 @@ The following table describes each line of the command and provides additional c
    API: http://10.0.2.100:9000  http://127.0.0.1:9000       
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
-   Console: http://10.0.2.100:9090 http://127.0.0.1:9090    
+   Console: http://10.0.2.100:9001 http://127.0.0.1:9001    
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
 

--- a/source/includes/container/steps-deploy-minio-single-node-single-drive.rst
+++ b/source/includes/container/steps-deploy-minio-single-node-single-drive.rst
@@ -27,12 +27,12 @@ Select the container management interface of your choice for the relevant comman
          :class: copyable
 
          podman run -dt                                  \
-           -p 9000:9000 -p 9090:9090                     \
+           -p 9000:9000 -p 9001:9001                     \
            -v PATH:/mnt/data                             \
            -v /etc/default/minio:/etc/config.env         \
            -e "MINIO_CONFIG_ENV_FILE=/etc/config.env"    \
            --name "minio_local"                          \
-           minio server --console-address ":9090"
+           minio server --console-address ":9001"
 
       Specify any other :podman-docs:`options <markdown/podman-run.1.html>` to ``podman run`` as necessary for your local environment.
 
@@ -44,12 +44,12 @@ Select the container management interface of your choice for the relevant comman
          :class: copyable
 
          docker run -dt                                  \
-           -p 9000:9000 -p 9090:9090                     \
+           -p 9000:9000 -p 9001:9001                     \
            -v PATH:/mnt/data                             \
            -v /etc/default/minio:/etc/config.env         \
            -e "MINIO_CONFIG_ENV_FILE=/etc/config.env"    \
            --name "minio_local"                          \
-           minio server --console-address ":9090"
+           minio server --console-address ":9001"
 
       Specify any other `options <https://docs.docker.com/engine/reference/commandline/run/>`__ to ``docker run`` as necessary for your local environment.
 
@@ -76,7 +76,7 @@ The following table describes each line of the command and provides additional c
      - Directs Podman/Docker to create and start the container as a detached (``-d``) background process with a pseudo-TTY (``-t``).
        This allows the container to run in the background with an open TTY for bash-like access.
 
-   * - ``-p 9000:9000 -p 9090:9090``
+   * - ``-p 9000:9000 -p 9001:9001``
      - Binds the ports ``9000`` and ``9090`` on the local machine to the same ports on the container.
        This allows access to the container through the local machine.
 
@@ -105,9 +105,9 @@ The following table describes each line of the command and provides additional c
        Omit this value to allow Podman/Docker to automatically generate a container name.
        You can replace this value to best reflect your requirements.
 
-   * - ``minio server --console-address ":9090"``
+   * - ``minio server --console-address ":9001"``
      - Starts the MinIO server using the ``minio:minio`` image pulled from an earlier step.
-       The :mc-cmd:`minio server --console-address ":9090" <minio server --console-address>` option directs the server to set a static port for the MinIO Console Web Interface.
+       The :mc-cmd:`minio server --console-address ":9001" <minio server --console-address>` option directs the server to set a static port for the MinIO Console Web Interface.
        This option is *required* for containerized environments.
 
        If you modify this value, ensure you set the proper port mapping using the ``-p`` flag to Podman/Docker to ensure traffic forwarding between the local host and the container.
@@ -128,7 +128,7 @@ The command should return a unique ID for the created container.
    API: http://10.0.2.100:9000  http://127.0.0.1:9000       
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
-   Console: http://10.0.2.100:9090 http://127.0.0.1:9090    
+   Console: http://10.0.2.100:9001 http://127.0.0.1:9001    
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
 

--- a/source/includes/k8s/quickstart.rst
+++ b/source/includes/k8s/quickstart.rst
@@ -128,7 +128,7 @@ Procedure
 
 #. **Connect your Browser to the MinIO Server**
 
-   Access the :ref:`minio-console` by opening a browser on the local machine and navigating to ``http://127.0.0.1:9090``.
+   Access the :ref:`minio-console` by opening a browser on the local machine and navigating to ``http://127.0.0.1:9001``.
 
    Log in to the Console with the credentials ``minioadmin | minioadmin``.
    These are the default :ref:`root user <minio-users-root>` credentials.

--- a/source/includes/k8s/steps-configure-ad-ldap-external-identity-management.rst
+++ b/source/includes/k8s/steps-configure-ad-ldap-external-identity-management.rst
@@ -17,7 +17,7 @@ The command returns output similar to the following:
 
    Starting port forward of the Console UI.
 
-   To connect open a browser and go to http://localhost:9090
+   To connect open a browser and go to http://localhost:9001
 
    Current JWT to login: TOKEN
 

--- a/source/includes/k8s/steps-configure-minio-kes-aws.rst
+++ b/source/includes/k8s/steps-configure-minio-kes-aws.rst
@@ -17,7 +17,7 @@ The command returns output similar to the following:
 
    Starting port forward of the Console UI.
 
-   To connect open a browser and go to http://localhost:9090
+   To connect open a browser and go to http://localhost:9001
 
    Current JWT to login: TOKEN
 

--- a/source/includes/k8s/steps-configure-minio-kes-azure.rst
+++ b/source/includes/k8s/steps-configure-minio-kes-azure.rst
@@ -17,7 +17,7 @@ The command returns output similar to the following:
 
    Starting port forward of the Console UI.
 
-   To connect open a browser and go to http://localhost:9090
+   To connect open a browser and go to http://localhost:9001
 
    Current JWT to login: TOKEN
 

--- a/source/includes/k8s/steps-configure-minio-kes-gcp.rst
+++ b/source/includes/k8s/steps-configure-minio-kes-gcp.rst
@@ -17,7 +17,7 @@ The command returns output similar to the following:
 
    Starting port forward of the Console UI.
 
-   To connect open a browser and go to http://localhost:9090
+   To connect open a browser and go to http://localhost:9001
 
    Current JWT to login: TOKEN
 

--- a/source/includes/k8s/steps-configure-minio-kes-hashicorp.rst
+++ b/source/includes/k8s/steps-configure-minio-kes-hashicorp.rst
@@ -17,7 +17,7 @@ The command returns output similar to the following:
 
    Starting port forward of the Console UI.
 
-   To connect open a browser and go to http://localhost:9090
+   To connect open a browser and go to http://localhost:9001
 
    Current JWT to login: TOKEN
 

--- a/source/includes/k8s/steps-configure-openid-external-identity-management.rst
+++ b/source/includes/k8s/steps-configure-openid-external-identity-management.rst
@@ -17,7 +17,7 @@ The command returns output similar to the following:
 
    Starting port forward of the Console UI.
 
-   To connect open a browser and go to http://localhost:9090
+   To connect open a browser and go to http://localhost:9001
 
    Current JWT to login: TOKEN
 

--- a/source/includes/linux/common-installation.rst
+++ b/source/includes/linux/common-installation.rst
@@ -119,7 +119,7 @@ The following example uses the ``~/minio-data`` folder:
    :class: copyable
 
    mkdir ~/minio-data
-   minio server ~/minio-data --console-address ":9090"
+   minio server ~/minio-data --console-address ":9001"
 
 The :mc:`minio server` process prints its output to the system console, similar
 to the following:
@@ -130,7 +130,7 @@ to the following:
    RootUser: minioadmin 
    RootPass: minioadmin 
 
-   Console: http://192.0.2.10:9090 http://127.0.0.1:9090     
+   Console: http://192.0.2.10:9001 http://127.0.0.1:9001     
    RootUser: minioadmin 
    RootPass: minioadmin 
 

--- a/source/includes/linux/deploy-standalone.rst
+++ b/source/includes/linux/deploy-standalone.rst
@@ -60,7 +60,7 @@ The following example uses the ``~/minio-data`` folder:
    :class: copyable
 
    mkdir ~/minio-data
-   minio server ~/minio-data --console-address ":9090"
+   minio server ~/minio-data --console-address ":9001"
 
 
 The :mc:`minio server` process prints its output to the system console, similar
@@ -72,7 +72,7 @@ to the following:
    RootUser: minioadmin 
    RootPass: minioadmin 
 
-   Console: http://192.0.2.10:9090 http://127.0.0.1:9090     
+   Console: http://192.0.2.10:9001 http://127.0.0.1:9001     
    RootUser: minioadmin 
    RootPass: minioadmin 
 

--- a/source/includes/linux/quickstart.rst
+++ b/source/includes/linux/quickstart.rst
@@ -45,7 +45,7 @@ Procedure
       :class: copyable
 
       mkdir ~/minio
-      minio server ~/minio --console-address :9090
+      minio server ~/minio --console-address :9001
 
    The ``mkdir`` command creates the folder explicitly at the specified path.
 
@@ -60,7 +60,7 @@ Procedure
       RootUser: minioadmin
       RootPass: minioadmin
 
-      Console: http://192.0.2.10:9090 http://127.0.0.1:9090
+      Console: http://192.0.2.10:9001 http://127.0.0.1:9001
       RootUser: minioadmin
       RootPass: minioadmin
 
@@ -75,7 +75,7 @@ Procedure
 
    Open http://127.0.0.1:9000 in a web browser to access the :ref:`MinIO Console <minio-console>`. 
    You can alternatively enter any of the network addresses specified as part of the server command output.
-   For example, :guilabel:`Console: http://192.0.2.10:9090 http://127.0.0.1:9090` in the example output indicates two possible addresses to use for connecting to the Console.
+   For example, :guilabel:`Console: http://192.0.2.10:9001 http://127.0.0.1:9001` in the example output indicates two possible addresses to use for connecting to the Console.
 
    While the port ``9000`` is used for connecting to the API, MinIO automatically redirects browser access to the MinIO Console.
 

--- a/source/includes/linux/steps-configure-keycloak-identity-management.rst
+++ b/source/includes/linux/steps-configure-keycloak-identity-management.rst
@@ -1,6 +1,6 @@
 .. |KEYCLOAK_URL| replace:: keycloak-url.example.net:8080
 .. |MINIO_S3_URL| replace:: minio-url.example.net:9000
-.. |MINIO_CONSOLE_URL| replace:: minio-url.example.net:9090
+.. |MINIO_CONSOLE_URL| replace:: minio-url.example.net:9001
 
 1) Configure or Create a Client for Accessing Keycloak
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/includes/linux/steps-deploy-minio-single-node-multi-drive.rst
+++ b/source/includes/linux/steps-deploy-minio-single-node-multi-drive.rst
@@ -36,7 +36,7 @@ The ``journalctl`` output should resemble the following:
    API: http://192.168.2.100:9000  http://127.0.0.1:9000       
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
-   Console: http://192.168.2.100:9090 http://127.0.0.1:9090    
+   Console: http://192.168.2.100:9001 http://127.0.0.1:9001    
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
 

--- a/source/includes/linux/steps-deploy-minio-single-node-single-drive.rst
+++ b/source/includes/linux/steps-deploy-minio-single-node-single-drive.rst
@@ -36,7 +36,7 @@ The ``journalctl`` output should resemble the following:
    API: http://192.168.2.100:9000  http://127.0.0.1:9000       
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
-   Console: http://192.168.2.100:9090 http://127.0.0.1:9090    
+   Console: http://192.168.2.100:9001 http://127.0.0.1:9001    
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
 

--- a/source/includes/macos/common-installation.rst
+++ b/source/includes/macos/common-installation.rst
@@ -54,7 +54,7 @@ If desired, you can replace ``~/data`` with another location to which the user h
    :class: copyable
 
    export MINIO_CONFIG_ENV_FILE=/etc/default/minio
-   minio server --console-address :9090
+   minio server --console-address :9001
 
 .. code-block:: shell
 
@@ -62,7 +62,7 @@ If desired, you can replace ``~/data`` with another location to which the user h
    API: http://192.168.2.100:9000  http://127.0.0.1:9000       
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
-   Console: http://192.168.2.100:9090 http://127.0.0.1:9090    
+   Console: http://192.168.2.100:9001 http://127.0.0.1:9001    
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
 

--- a/source/includes/macos/quickstart.rst
+++ b/source/includes/macos/quickstart.rst
@@ -43,7 +43,7 @@ Procedure
 #. **Connect your Browser to the MinIO Server**
 
    Access the :ref:`minio-console` by going to a browser (such as Safari) and going to ``https://127.0.0.1:9000`` or one of the Console addresses specified in the :mc:`minio server` command's output.
-   For example, :guilabel:`Console: http://192.0.2.10:9090 http://127.0.0.1:9090` in the example output indicates two possible addresses to use for connecting to the Console.
+   For example, :guilabel:`Console: http://192.0.2.10:9001 http://127.0.0.1:9001` in the example output indicates two possible addresses to use for connecting to the Console.
 
    While port ``9000`` is used for connecting to the API, MinIO automatically redirects browser access to the MinIO Console.
 

--- a/source/includes/windows/common-minio-kes.rst
+++ b/source/includes/windows/common-minio-kes.rst
@@ -81,7 +81,7 @@ Run the following command in a terminal or shell to start the MinIO server as a 
    :substitutions:
 
    export MINIO_CONFIG_ENV_FILE=|minioconfigpath|\config\minio
-   C:\minio.exe server --console-address :9090
+   C:\minio.exe server --console-address :9001
 
 .. end-kes-minio-start-server-desc
 

--- a/source/includes/windows/quickstart.rst
+++ b/source/includes/windows/quickstart.rst
@@ -61,7 +61,7 @@ Procedure
    .. code-block::
       :class: copyable
 
-      .\minio.exe server C:\minio --console-address :9090
+      .\minio.exe server C:\minio --console-address :9001
 
    The :mc:`minio server` process prints its output to the system console, similar to the following:
 
@@ -71,7 +71,7 @@ Procedure
       RootUser: minioadmin
       RootPass: minioadmin
 
-      Console: http://192.0.2.10:9090 http://127.0.0.1:9090
+      Console: http://192.0.2.10:9001 http://127.0.0.1:9001
       RootUser: minioadmin
       RootPass: minioadmin
 
@@ -87,8 +87,8 @@ Procedure
 
 #. Connect your Browser to the MinIO Server
 
-   Access the :ref:`minio-console` by going to a browser (such as Microsoft Edge) and going to ``http://127.0.0.1:9090`` or one of the Console addresses specified in the :mc:`minio server` command's output.
-   For example, ``Console: http://192.0.2.10:9090 http://127.0.0.1:9090`` in the example output indicates two possible addresses to use for connecting to the Console.
+   Access the :ref:`minio-console` by going to a browser (such as Microsoft Edge) and going to ``http://127.0.0.1:9001`` or one of the Console addresses specified in the :mc:`minio server` command's output.
+   For example, ``Console: http://192.0.2.10:9001 http://127.0.0.1:9001`` in the example output indicates two possible addresses to use for connecting to the Console.
 
    While port ``9000`` is used for connecting to the API, MinIO automatically redirects browser access to the MinIO Console.
 

--- a/source/includes/windows/steps-deploy-minio-single-node-single-drive.rst
+++ b/source/includes/windows/steps-deploy-minio-single-node-single-drive.rst
@@ -43,7 +43,7 @@ The ``journalctl`` output should resemble the following:
    API: http://192.168.2.100:9000  http://127.0.0.1:9000       
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
-   Console: http://192.168.2.100:9090 http://127.0.0.1:9090    
+   Console: http://192.168.2.100:9001 http://127.0.0.1:9001    
    RootUser: myminioadmin 
    RootPass: minio-secret-key-change-me 
 

--- a/source/integrations/setup-nginx-proxy-with-minio.rst
+++ b/source/integrations/setup-nginx-proxy-with-minio.rst
@@ -35,7 +35,7 @@ There are two models for proxying requests to the MinIO Server API and the MinIO
       
       - Proxy requests to the root ``https://minio.example.net`` to the MinIO Server listening on ``https://minio.local:9000``.
 
-      - Proxy requests to the subpath ``https://minio.example.net/minio/ui`` to the MinIO Console listening on ``https://minio.local:9090``.
+      - Proxy requests to the subpath ``https://minio.example.net/minio/ui`` to the MinIO Console listening on ``https://minio.local:9001``.
 
       The following location blocks provide a template for further customization in your unique environment:
 
@@ -52,10 +52,10 @@ There are two models for proxying requests to the MinIO Server API and the MinIO
 
          upstream minio_console {
             least_conn;
-            server minio-01.internal-domain.com:9090;
-            server minio-02.internal-domain.com:9090;
-            server minio-03.internal-domain.com:9090;
-            server minio-04.internal-domain.com:9090;
+            server minio-01.internal-domain.com:9001;
+            server minio-02.internal-domain.com:9001;
+            server minio-03.internal-domain.com:9001;
+            server minio-04.internal-domain.com:9001;
          }
 
          server {
@@ -129,7 +129,7 @@ There are two models for proxying requests to the MinIO Server API and the MinIO
 
       - Proxy request to the subdomain ``minio.example.net`` to the MinIO Server listening on ``https://minio.local:9000``
 
-      - Proxy requests to the subdomain ``console.example.net`` to the MinIO Console listening on ``https://minio.local:9090``
+      - Proxy requests to the subdomain ``console.example.net`` to the MinIO Console listening on ``https://minio.local:9001``
 
       The following location blocks provide a template for further customization in your unique environment:
 
@@ -146,10 +146,10 @@ There are two models for proxying requests to the MinIO Server API and the MinIO
 
          upstream minio_console {
             least_conn;
-            server minio-01.internal-domain.com:9090;
-            server minio-02.internal-domain.com:9090;
-            server minio-03.internal-domain.com:9090;
-            server minio-04.internal-domain.com:9090;
+            server minio-01.internal-domain.com:9001;
+            server minio-02.internal-domain.com:9001;
+            server minio-03.internal-domain.com:9001;
+            server minio-04.internal-domain.com:9001;
          }
 
          server {

--- a/source/operations/install-deploy-manage/deploy-operator-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-helm.rst
@@ -171,9 +171,9 @@ You can modify the Operator deployment after installation.
    .. code-block:: shell
       :class: copyable
 
-      kubectl port-forward svc/console -n minio-operator 9090:9090
+      kubectl port-forward svc/console -n minio-operator 9001:9001
 
-   You can then use ``http://localhost:9090`` to access the MinIO Operator Console.
+   You can then use ``http://localhost:9001`` to access the MinIO Operator Console.
 
    Once you access the Console, use the Console JWT to log in.
 
@@ -469,13 +469,13 @@ This method may support easier pre-configuration of the Operator compared to the
       .. code-block:: shell
          :class: copyable
 
-         kubectl --namespace minio-operator port-forward svc/console 9090:9090
+         kubectl --namespace minio-operator port-forward svc/console 9001:9001
 
       This command forwards the pod port ``9090`` to the matching port on the local machine while active in the shell.
       The ``kubectl port-forward`` command only functions while active in the shell session.
       Terminating the session closes the ports on the local machine.
 
-   C. Access the Console by navigating to ``http://localhost:9090`` in a browser and login with the JWT.
+   C. Access the Console by navigating to ``http://localhost:9001`` in a browser and login with the JWT.
       
    .. note::
       

--- a/source/operations/install-deploy-manage/upgrade-minio-operator.rst
+++ b/source/operations/install-deploy-manage/upgrade-minio-operator.rst
@@ -127,7 +127,7 @@ The following steps back up the existing yaml files, perform some clean up, and 
       - name: MINIO_PROMETHEUS_JOB_ID
         value: minio-job
       - name: MINIO_PROMETHEUS_URL
-        value: http://<TENANT_NAME>-prometheus-hl-svc:9090
+        value: http://<TENANT_NAME>-prometheus-hl-svc:9001
 
    - Replace ``<TENANT_NAME>`` in the ``name`` or ``value`` lines with the name of your tenant.
 

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -48,7 +48,7 @@ You can optionally configure synchronization of existing objects, delete operati
          :class: copyable
 
          mc replicate add                                                     \
-            --remote-bucket https://user:secret@minio.mysite.tld:9090/bucket  \
+            --remote-bucket https://user:secret@minio.mysite.tld:9001/bucket  \
             --replicate "delete,delete-marker,existing-objects"               \
             myminio/mydata
 
@@ -94,7 +94,7 @@ Parameters
 
    .. code-block:: none
 
-      mc replicate add --remote-bucket https://user:secret@myminio.cloudprovider.tld:9090/bucket play/mybucket
+      mc replicate add --remote-bucket https://user:secret@myminio.cloudprovider.tld:9001/bucket play/mybucket
 
 .. mc-cmd:: --remote-bucket
    :required:
@@ -105,7 +105,7 @@ Parameters
 
    .. code-block::
 
-      https://user:secret@myminio.cloudprovider.tld:9090/bucket
+      https://user:secret@myminio.cloudprovider.tld:9001/bucket
 
 .. mc-cmd:: --bandwidth
    :optional:

--- a/source/reference/minio-mc/mc-replicate-update.rst
+++ b/source/reference/minio-mc/mc-replicate-update.rst
@@ -219,7 +219,7 @@ Parameters
 
    .. code-block::
 
-      https://user:secret@myminio.cloudprovider.tld:9090/bucket
+      https://user:secret@myminio.cloudprovider.tld:9001/bucket
 
 .. mc-cmd:: --replicate
    :optional:
@@ -323,7 +323,7 @@ Use :mc:`mc replicate update` to modify an existing replication rule.
 
    mc replicate update ALIAS/PATH \
       --id ID                     \
-      --remote-bucket https://user:secret@minio.mycloud.tld:9090/mybucket
+      --remote-bucket https://user:secret@minio.mycloud.tld:9001/mybucket
 
 - Replace :mc-cmd:`ALIAS <mc replicate update ALIAS>` with the :mc:`alias <mc alias>` of the MinIO deployment.
 


### PR DESCRIPTION
As state in  https://github.com/minio/minio/pull/18561#issuecomment-1833303435 , consistent use 9001 as the console port， to avoid confusion for new users.