### PR TITLE
Remote tier needs DeleteObjectVersion if remote bucket is versioned

### DIFF
--- a/source/extra/examples/LifecycleManagementUser.json
+++ b/source/extra/examples/LifecycleManagementUser.json
@@ -15,7 +15,8 @@
             "Action": [
                "s3:GetObject",
                "s3:PutObject",
-               "s3:DeleteObject"
+               "s3:DeleteObject",
+               "s3:DeleteObjectVersion"
             ],
             "Effect": "Allow",
             "Resource": [

--- a/source/extra/examples/LifecycleManagementUser.json
+++ b/source/extra/examples/LifecycleManagementUser.json
@@ -16,7 +16,6 @@
                "s3:GetObject",
                "s3:PutObject",
                "s3:DeleteObject",
-               "s3:DeleteObjectVersion"
             ],
             "Effect": "Allow",
             "Resource": [

--- a/source/extra/examples/LifecycleManagementUser.json
+++ b/source/extra/examples/LifecycleManagementUser.json
@@ -15,7 +15,7 @@
             "Action": [
                "s3:GetObject",
                "s3:PutObject",
-               "s3:DeleteObject",
+               "s3:DeleteObject"
             ],
             "Effect": "Allow",
             "Resource": [

--- a/source/reference/minio-mc/mc-ilm-tier.rst
+++ b/source/reference/minio-mc/mc-ilm-tier.rst
@@ -92,15 +92,22 @@ Transition Permissions
 
 Object transition lifecycle management rules require additional permissions on the remote storage tier. 
 Specifically, MinIO requires the remote tier credentials provide read, write, list, and delete permissions.
-If the remote bucket is versioned, the ``s3:DeleteObjectVersion`` permission is also required.
 
-For example, if the remote storage tier implements AWS IAM policy-based access control, the following policy provides the necessary permissions for transitioning versioned objects into and out of the remote tier:
+For example, if the remote storage tier implements AWS IAM policy-based access control, the following policy provides the necessary permissions for transitioning objects into and out of the remote tier:
 
 .. literalinclude:: /extra/examples/LifecycleManagementUser.json
    :language: json
    :class: copyable
 
 Modify the ``Resource`` for the bucket into which MinIO tiers objects.
+
+.. admonition:: Avoid remote tier object versioning
+   :class: important
+
+   MinIO strongly recommends against object versioning for remote tiers.
+   If the remote tier bucket is versioned, each source object version is transitioned to a *unique object* in the remote tier.
+   
+   If your environment requires versioning for the remote tier, you must also allow the ``s3:DeleteObjectVersion`` permission.
 
 Defer to the documentation for the supported tiering targets for more complete information on configuring users and permissions to support MinIO tiering:
 

--- a/source/reference/minio-mc/mc-ilm-tier.rst
+++ b/source/reference/minio-mc/mc-ilm-tier.rst
@@ -81,7 +81,7 @@ To create tiers for object transition, MinIO requires the following administrati
 - :policy-action:`admin:SetTier`
 - :policy-action:`admin:ListTier`
 
-For example, the following policy provides permission for configuring object transition lifecycle management rules on any bucket in the cluster:
+For example, the following policy provides sufficient permissions for configuring object transition lifecycle management rules on any bucket in the cluster:
 
 .. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
    :language: json

--- a/source/reference/minio-mc/mc-ilm-tier.rst
+++ b/source/reference/minio-mc/mc-ilm-tier.rst
@@ -92,7 +92,7 @@ Transition Permissions
 
 Object transition lifecycle management rules require additional permissions on the remote storage tier. 
 Specifically, MinIO requires the remote tier credentials provide read, write, list, and delete permissions.
-If the remote bucket is versioned, delete version permission is also required.
+If the remote bucket is versioned, the ``s3:DeleteObjectVersion`` permission is also required.
 
 For example, if the remote storage tier implements AWS IAM policy-based access control, the following policy provides the necessary permissions for transitioning versioned objects into and out of the remote tier:
 

--- a/source/reference/minio-mc/mc-ilm-tier.rst
+++ b/source/reference/minio-mc/mc-ilm-tier.rst
@@ -81,7 +81,7 @@ To create tiers for object transition, MinIO requires the following administrati
 - :policy-action:`admin:SetTier`
 - :policy-action:`admin:ListTier`
 
-For example, the following policy provides permission for configuring object transition lifecycle management rules on any bucket in the cluster:.
+For example, the following policy provides permission for configuring object transition lifecycle management rules on any bucket in the cluster:
 
 .. literalinclude:: /extra/examples/LifecycleManagementAdmin.json
    :language: json
@@ -92,8 +92,9 @@ Transition Permissions
 
 Object transition lifecycle management rules require additional permissions on the remote storage tier. 
 Specifically, MinIO requires the remote tier credentials provide read, write, list, and delete permissions.
+If the remote bucket is versioned, delete version permission is also required.
 
-For example, if the remote storage tier implements AWS IAM policy-based access control, the following policy provides the necessary permission for transitioning objects into and out of the remote tier:
+For example, if the remote storage tier implements AWS IAM policy-based access control, the following policy provides the necessary permission for transitioning versioned objects into and out of the remote tier:
 
 .. literalinclude:: /extra/examples/LifecycleManagementUser.json
    :language: json

--- a/source/reference/minio-mc/mc-ilm-tier.rst
+++ b/source/reference/minio-mc/mc-ilm-tier.rst
@@ -101,10 +101,10 @@ For example, if the remote storage tier implements AWS IAM policy-based access c
 
 Modify the ``Resource`` for the bucket into which MinIO tiers objects.
 
-.. admonition:: Avoid remote tier object versioning
+.. admonition:: Avoid enabling versioning in the remote tier
    :class: important
 
-   MinIO strongly recommends against object versioning for remote tiers.
+   MinIO strongly recommends against enabling bucket versioning for remote tiers.
    If the remote tier bucket is versioned, each source object version is transitioned to a *unique object* in the remote tier.
    
    If your environment requires versioning for the remote tier, you must also allow the ``s3:DeleteObjectVersion`` permission.

--- a/source/reference/minio-mc/mc-ilm-tier.rst
+++ b/source/reference/minio-mc/mc-ilm-tier.rst
@@ -94,7 +94,7 @@ Object transition lifecycle management rules require additional permissions on t
 Specifically, MinIO requires the remote tier credentials provide read, write, list, and delete permissions.
 If the remote bucket is versioned, delete version permission is also required.
 
-For example, if the remote storage tier implements AWS IAM policy-based access control, the following policy provides the necessary permission for transitioning versioned objects into and out of the remote tier:
+For example, if the remote storage tier implements AWS IAM policy-based access control, the following policy provides the necessary permissions for transitioning versioned objects into and out of the remote tier:
 
 .. literalinclude:: /extra/examples/LifecycleManagementUser.json
    :language: json


### PR DESCRIPTION
If the remote tier bucket is versioned, MinIO requires additional permissions to successfully transition objects. But it is not recommended, as each object version becomes a distinct object on the remote tier.

This is not new, it was omitted from the docs. Mention, but discourage.

Staged:
http://192.241.195.202:9000/staging/DOCS-1016/linux/reference/minio-mc/mc-ilm-tier.html#transition-permissions

Fixes https://github.com/minio/docs/issues/1016