### PR TITLE
Fix the name of RoleArn param in AssumeRoleWithWebIdentity requests

### DIFF
--- a/source/administration/identity-access-management/oidc-access-management.rst
+++ b/source/administration/identity-access-management/oidc-access-management.rst
@@ -18,7 +18,7 @@ identities.
 For identities managed by the external OpenID Connect (OIDC) compatible provider, MinIO can use either of two methods to assign policies to the authenticated user.
 
 1. Use the `JSON Web Token claim <https://datatracker.ietf.org/doc/html/rfc7519#section-4>`__ returned as part of the OIDC authentication flow to identify the :ref:`policies <minio-policy>` to assign to the authenticated user.
-2. Use the ``RoleARN`` specified in the authorization request to assign the policies attached to the provider's RolePolicy.
+2. Use the ``RoleArn`` specified in the authorization request to assign the policies attached to the provider's RolePolicy.
    
 MinIO by default denies access to all actions or resources not explicitly allowed by a user's assigned or inherited :ref:`policies <minio-policy>`. 
 Users managed by an OIDC provider must specify the necessary policies as part of the JWT claim. If the user JWT claim has no matching MinIO policies, that user has no permissions to access any action or resource on the MinIO deployment.
@@ -60,7 +60,7 @@ The login flow for an application using :abbr:`OIDC (OpenID Connect)` credential
    MinIO only supports the `OpenID Authorization Code Flow <https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth>`__. 
    Authentication using Implicit Flow is not supported.
 
-6. MinIO verifies the ``RoleARN`` in the API call and checks for the :ref:`RolePolicy <minio-external-identity-management-openid-access-control>` to use. 
+6. MinIO verifies the ``RoleArn`` in the API call and checks for the :ref:`RolePolicy <minio-external-identity-management-openid-access-control>` to use.
    Any authentication request with the RoleARN receives the same policy access permissions.
 7. MinIO returns temporary credentials in the STS API response in the form of an access key, secret key, and session token. 
    The credentials have permissions matching those policies specified in the RolePolicy.

--- a/source/developers/security-token-service/AssumeRoleWithWebIdentity.rst
+++ b/source/developers/security-token-service/AssumeRoleWithWebIdentity.rst
@@ -119,7 +119,7 @@ This endpoint supports the following query parameters:
        See :ref:`minio-access-management` for more information on MinIO
        authentication and authorization.
 
-   * - ``RoleARN``
+   * - ``RoleArn``
      - string
      - *Optional*   
 

--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -27,10 +27,10 @@ may be optional depending on the provider.
 
 .. start-minio-openid-role-policy
 
-Specify a comma-separated list of :ref:`policy names <minio-policy>` to use for the request's ``RoleARN`` for all authentication requests for the provider.
+Specify a comma-separated list of :ref:`policy names <minio-policy>` to use for the request's ``RoleArn`` for all authentication requests for the provider.
 The specified policy or policies must already exist on the MinIO Server.
 
-To use this OIDC configuration, you must specify the corresponding :ref:`RoleARN <minio-assumerolewithwebidentity-query-parameters>` in the STS request body.
+To use this OIDC configuration, you must specify the corresponding :ref:`RoleArn <minio-assumerolewithwebidentity-query-parameters>` in the STS request body.
 
 .. end-minio-openid-role-policy
 


### PR DESCRIPTION
In `AssumeRoleWithWebIdentity` requests, the RoleArn form paramter is designated to specify the role to be assumed. It is crucial to note that the correct key is RoleArn, not RoleARN.

When I used the "RoleARN" form key instead of "RoleArn," I encountered an error similar to the following:
```xml
<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/"><Error><Type></Type><Code>InvalidParameterValue</Code><Message>Role arn:minio:iam:::role/dummy-internal does not exist</Message></Error><RequestId>XXX</RequestId></ErrorResponse>
```

Despite this, certain documentation erroneously employs RoleARN. To rectify this inconsistency, I have replaced the instances of RoleARN with the correct RoleArn. However, for other documents that use RoleARN without specifying the form parameter, no modifications have been made.

Ref: https://github.com/minio/minio/blob/ba245c6c463c1ae9b652aa4cf44b2e603c68b045/cmd/sts-handlers.go#L50C2-L50C12