### PR TITLE
Updates related to three MinIO Client Dec 2023 releases

### DIFF
--- a/source/includes/common-minio-ad-ldap-params.rst
+++ b/source/includes/common-minio-ad-ldap-params.rst
@@ -139,7 +139,7 @@
 
 This command works against :ref:`access keys <minio-id-access-keys>` created by an AD/LDAP user after authenticating to MinIO.
 
-Create AD/LDAP service accounts with the :mc-cmd:`mc idp accesskey create` command.
+Create AD/LDAP service accounts with the :mc-cmd:`mc idp ldap accesskey create` command.
 
 Authenticated users can manage their own long-term Access Keys using the :ref:`MinIO Console <minio-console-user-access-keys>`.
 MinIO supports using :ref:`AssumeRoleWithLDAPIdentity <minio-sts-assumerolewithldapidentity>` to generate temporary access keys using the :ref:`Security Token Service <minio-security-token-service>`.

--- a/source/includes/common-minio-ad-ldap-params.rst
+++ b/source/includes/common-minio-ad-ldap-params.rst
@@ -139,6 +139,8 @@
 
 This command works against :ref:`access keys <minio-id-access-keys>` created by an AD/LDAP user after authenticating to MinIO.
 
+Create AD/LDAP service accounts with the :mc-cmd:`mc idp accesskey create` command.
+
 Authenticated users can manage their own long-term Access Keys using the :ref:`MinIO Console <minio-console-user-access-keys>`.
 MinIO supports using :ref:`AssumeRoleWithLDAPIdentity <minio-sts-assumerolewithldapidentity>` to generate temporary access keys using the :ref:`Security Token Service <minio-security-token-service>`.
 

--- a/source/includes/common-replication.rst
+++ b/source/includes/common-replication.rst
@@ -141,6 +141,12 @@ Each MinIO deployment ("peer site") synchronizes the following changes across th
 
 Site replication enables :ref:`bucket versioning <minio-bucket-versioning>` for all new and existing buckets on all replicated sites.
 
+.. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
+
+You can choose to replicate ILM expiration rules across peer sites.
+Enable this option either at the time of configuring the site replication or by modifying the existing site replication configuration.
+If enabled, you can also disable the replication of ILM expiration rules between sites.
+
 .. end-mc-admin-replicate-what-replicates
 
 .. start-mc-admin-replicate-what-does-not-replicate

--- a/source/includes/common-replication.rst
+++ b/source/includes/common-replication.rst
@@ -144,8 +144,8 @@ Site replication enables :ref:`bucket versioning <minio-bucket-versioning>` for 
 .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
 
 You can choose to replicate ILM expiration rules across peer sites.
-Enable this option either at the time of configuring the site replication or by modifying the existing site replication configuration.
-If enabled, you can also disable the replication of ILM expiration rules between sites.
+For new site replication configurations, use the :mc-cmd:`mc admin replicate add`  with the :mc-cmd:`~mc admin replicate add --replicate-ilm-expiry` flag. 
+For existing site replication configurations, you can enable or disable the behavior using :mc-cmd:`mc admin replicate update` with either the :mc-cmd:`~mc admin replicate update --enable-ilm-expiry-replication` or :mc-cmd:`~mc admin replicate update --disable-ilm-expiry-replication` flag, as appropriate.
 
 .. end-mc-admin-replicate-what-replicates
 

--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -95,8 +95,7 @@ Download the license file from SUBNET on a machine with access to the Internet.
    
 #. Log in to |SUBNET|
 #. Go to the :guilabel:`Deployments` tab
-#. Select the deployment from the list
-#. Select the :guilabel:`License` number near the top of the page to display the :guilabel:`Cluster License Key`
+#. Select the :guilabel:`License` button near the top of the page on the right side of the account statistics information box to display the :guilabel:`Account License`
 #. Select :guilabel:`Download`
 
 SUBNET Issues

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -105,6 +105,13 @@ Syntax
 
             mc admin replicate add minio1 minio5
 
+         The following command creates a new site replication that includes the peer sites ``minio1``, ``minio2``, and ``minio3``, and enables the replication of ILM expiration rules across sites.
+
+         .. copy-block:: shell
+            :class: copyable
+
+            mc admin replicate add minio1 minio2 minio3 --replicate-ilm-expiry
+
       .. tab-item:: SYNTAX
 
          The command has the following syntax:
@@ -115,7 +122,8 @@ Syntax
             mc [GLOBALFLAGS] admin replicate add      \
                                         ALIAS1        \
                                         ALIAS2        \
-                                        [ALIAS3 ...]
+                                        [ALIAS3 ...]  \
+                                        [--replicate-ilm-expiry]
 
    .. mc-cmd:: ALIAS
       :required:
@@ -129,6 +137,13 @@ Syntax
       To expand an existing site replication to one more new replication sites, the first :ref:`alias <alias>` must be a peer site in the site replication set to expand.
       Then include one or more additional :ref:`aliases <alias>` to add to the existing site replication.
       The deployments to add must be empty.
+
+   .. mc-cmd:: --replicate-ilm-expiry
+      :optional:
+
+      .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
+
+      Replicate :ref:`ILM expiration <minio-lifecycle-management-expiration>` rules across peers.
 
 .. mc-cmd:: update
    :fullpath:
@@ -161,7 +176,9 @@ Syntax
                                         ALIAS                           \
                                         --deployment-id [deploymentID]  \
                                         --endpoint [newEndpoint]        \
-                                        --mode ["sync" | "async"]
+                                        --mode ["sync" | "async"]       \
+                                        --enable-ilm-expiry-replication \
+                                        --disable-ilm-expiry-replication
     
    .. mc-cmd:: ALIAS
       :required:
@@ -197,6 +214,20 @@ Syntax
       The unique id of the deployment to change.
 
       The deployment ID can be found by running :mc-cmd:`mc admin replicate info ALIAS`
+
+   .. mc-cmd:: --disable-ilm-expiry-replication
+      :optional:
+
+      .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
+
+      Stops the replication of ILM expiration rules between peer sites.
+
+   .. mc-cmd:: --enable-ilm-expiry-replication
+      :optional:
+
+      .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
+
+      Start replication of ILM expiration rules between peer sites.
 
    .. mc-cmd:: --endpoint
       :required:
@@ -361,21 +392,30 @@ Syntax
                                minio1         \
                                --user janedoe
 
-         The output of any of the above examples resembles the following:
+         Display the site replication status across sites for the ILM expiration rule with rule ID of ``ckok9v5b4dtgofkbi6tg`` for a site replication configuration that contains the site ``minio1``.
+
+         .. code-block:: shell
+
+            mc admin replicate status minio1 --ilm-expiry-rule ckok9v5b4dtgofkbi6tg 
+
+         The output of the above examples resembles the following:
 
          .. code-block:: shell
 
             Bucket replication status:
-            -  30/30 Buckets in sync
+            ●  30/30 Buckets in sync
             
             Policy replication status:
-            -  5/5 Policies in sync
+            ●  5/5 Policies in sync
             
             User replication status:
-            -  3/3 Users in sync
+            ●  3/3 Users in sync
             
             Group replication status:
             No Groups present
+
+            ILM Expiry Rules replication status:
+            ●  5/5 ILM Expiry Rules in sync
             
             Object replication status:
             Replication status since 1 day 
@@ -388,16 +428,18 @@ Syntax
          
          .. code-block:: shell
             
-            mc [GLOBALFLAGS] admin replicate status     \
-                               TARGET                   \
-                               [--all]                  \
-                               [--buckets]              \
-                               [--bucket nameOfBucket]  \
-                               [--groups]               \
-                               [--group nameOfGroup]    \
-                               [--policies]             \
-                               [--policy nameOfPolicy]  \
-                               [--users]                \
+            mc [GLOBALFLAGS] admin replicate status          \
+                               TARGET                        \
+                               [--all]                       \
+                               [--buckets]                   \
+                               [--bucket nameOfBucket]       \
+                               [--groups]                    \
+                               [--group nameOfGroup]         \
+                               [--ilm-expiry-rules]          \
+                               [--ilm-expiry-rule <rule ID>] \
+                               [--policies]                  \
+                               [--policy nameOfPolicy]       \
+                               [--users]                     \
                                [--user accessKey]
 
    .. mc-cmd:: TARGET
@@ -429,6 +471,20 @@ Syntax
       :optional:
 
       Display the replication status of a specific group by including the group name after the flag.
+
+   .. mc-cmd:: --ilm-expiry-rules
+      :optional:
+
+      .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
+
+      Display sync information about ILM expiration rules.
+
+   .. mc-cmd:: --ilm expiry rule
+      :optional:
+
+      .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
+
+      Display replication status information about the specified ILM expiration rule.
 
    .. mc-cmd:: --policies
       :optional:

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -107,7 +107,7 @@ Syntax
 
          The following command creates a new site replication that includes the peer sites ``minio1``, ``minio2``, and ``minio3``, and enables the replication of ILM expiration rules across sites.
 
-         .. copy-block:: shell
+         .. code-block:: shell
             :class: copyable
 
             mc admin replicate add minio1 minio2 minio3 --replicate-ilm-expiry

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -105,8 +105,8 @@ Syntax
 
             mc admin replicate add minio1 minio5
 
-         The following command creates a new site replication that includes the peer sites ``minio1``, ``minio2``, and ``minio3``, and enables the replication of ILM expiration rules across sites.
-
+         The following command creates a new site replication configuration with ILM expiration rule synchronization between peer sites ``minio1``, ``minio2``, and ``minio3``.
+         
          .. code-block:: shell
             :class: copyable
 
@@ -221,6 +221,7 @@ Syntax
       .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
 
       Stops the replication of ILM expiration rules between peer sites.
+      Existing rules already synchronized across peers are not removed from any peer site.
 
    .. mc-cmd:: --enable-ilm-expiry-replication
       :optional:
@@ -392,12 +393,6 @@ Syntax
                                minio1         \
                                --user janedoe
 
-         Display the site replication status across sites for the ILM expiration rule with rule ID of ``ckok9v5b4dtgofkbi6tg`` for a site replication configuration that contains the site ``minio1``.
-
-         .. code-block:: shell
-
-            mc admin replicate status minio1 --ilm-expiry-rule ckok9v5b4dtgofkbi6tg 
-
          The output of the above examples resembles the following:
 
          .. code-block:: shell
@@ -423,6 +418,21 @@ Syntax
             Replicated:    0 objects (0 B)
             Queued:        - 0 objects, (0 B) (avg: 0 objects, 0 B; max: 0 objects, 0 B)
             Received:      0 objects (0 B)
+
+         Display the site replication status across sites for the ILM expiration rule with rule ID of ``ckok9v5b4dtgofkbi6tg`` for a site replication configuration that contains the site ``minio1``.
+
+         .. code-block:: shell
+
+            mc admin replicate status minio1 --ilm-expiry-rule ckok9v5b4dtgofkbi6tg
+
+         The output resembles the following:
+
+         .. code-block:: shell
+
+            ●  ILM Expiry Rule replication summary for: ckok9v5b4dtgofkbi6tg
+            
+            ILMExpiryRule   | MINIO1          | MINIO2   
+            ILM Expiry Rule | ✔               | ✔  
 
       .. tab-item:: SYNTAX
          
@@ -479,12 +489,16 @@ Syntax
 
       Display sync information about ILM expiration rules.
 
-   .. mc-cmd:: --ilm expiry rule
+      Mutually exclusive with :mc-cmd:`~mc admin replicate update --ilm-expiry-rule`
+
+   .. mc-cmd:: --ilm-expiry-rule
       :optional:
 
       .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
 
       Display replication status information about the specified ILM expiration rule.
+
+      Mutually exclusive with :mc-cmd:`~mc admin replicate update --ilm-expiry-rules`
 
    .. mc-cmd:: --policies
       :optional:

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -489,7 +489,7 @@ Syntax
 
       Display sync information about ILM expiration rules.
 
-      Mutually exclusive with :mc-cmd:`~mc admin replicate update --ilm-expiry-rule`
+      Mutually exclusive with :mc-cmd:`~mc admin replicate status --ilm-expiry-rule`
 
    .. mc-cmd:: --ilm-expiry-rule
       :optional:
@@ -498,7 +498,7 @@ Syntax
 
       Display replication status information about the specified ILM expiration rule.
 
-      Mutually exclusive with :mc-cmd:`~mc admin replicate update --ilm-expiry-rules`
+      Mutually exclusive with :mc-cmd:`~mc admin replicate status --ilm-expiry-rules`
 
    .. mc-cmd:: --policies
       :optional:

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-create.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-create.rst
@@ -132,68 +132,6 @@ Parameters
 
    Requires an interactive terminal.
 
-Examples
-~~~~~~~~
-
-Create a new access-key pair for the authenticated user
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
-The command outputs a randomly generated access key and secret key.
-
-.. code-block:: shell
-   :class: copyable
-
-   mc idp ldap accesskey create minio
-
-Create a new access-key pair with a custom access key and secret key
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-The following command creates a new access key pair with both an access key and secret key that you specify for the user currently authenticated on the ``minio`` alias.
-
-.. code-block:: shell
-   :class: copyable
-
-   mc idp ldap accesskey create minio/ --access-key my-access-key-change-me --secret-key my-secret-key-change-me
-
-Create a new access-key pair that expires after 24 hours
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
-The credentials expire after 24 hours.
-
-The command outputs a randomly generated access key and secret key.
-
-.. code-block:: shell
-   :class: copyable
-
-   mc idp ldap accesskey create minio --expiry-duration 24h
-
-Create a new access-key and prompt to login as the user
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-The following command creates a new access key pair.
-The MinIO Client will first ask you to log in as the user the access key is for on the MinIO site configured for LDAP at ``minio.example.com``.
-
-The command outputs a randomly generated access key and secret key.
-
-.. code-block:: shell
-   :class: copyable
-
-   mc idp ldap accesskey create minio --login minio.example.com
-
-Create a new access-key pair that expires after a date
-++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
-The credentials expire after February 29, 2024.
-
-The command outputs a randomly generated access key and secret key.
-
-.. code-block:: shell
-   :class: copyable
-
-   mc idp ldap accesskey create minio --expiry 2024-02-29
 
 Global Flags
 ~~~~~~~~~~~~
@@ -212,3 +150,66 @@ S3 Compatibility
 .. include:: /includes/common-minio-mc.rst
    :start-after: start-minio-mc-s3-compatibility
    :end-before: end-minio-mc-s3-compatibility
+
+Examples
+--------
+
+Create a new access-key pair for the authenticated user
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
+The command outputs a randomly generated access key and secret key.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio
+
+Create a new access-key pair with a custom access key and secret key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command creates a new access key pair with both an access key and secret key that you specify for the user currently authenticated on the ``minio`` alias.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio/ --access-key my-access-key-change-me --secret-key my-secret-key-change-me
+
+Create a new access-key pair that expires after 24 hours
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
+The credentials expire after 24 hours.
+
+The command outputs a randomly generated access key and secret key.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio --expiry-duration 24h
+
+Create a new access-key and prompt to login as the user
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command creates a new access key pair.
+The MinIO Client will first ask you to log in as the user the access key is for on the MinIO site configured for LDAP at ``minio.example.com``.
+
+The command outputs a randomly generated access key and secret key.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio --login minio.example.com
+
+Create a new access-key pair that expires after a date
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
+The credentials expire after February 29, 2024.
+
+The command outputs a randomly generated access key and secret key.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio --expiry 2024-02-29

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-create.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-create.rst
@@ -1,0 +1,214 @@
+.. _minio-mc-idp-ldap-accesskey-create:
+
+================================
+``mc idp ldap accesskey create``
+================================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+.. mc:: mc idp ldap accesskey create
+
+.. versionadded:: mc RELEASE.2023-12-23T08-47-21Z 
+
+Description
+-----------
+
+.. start-mc-idp-ldap-accesskey-create-desc
+
+The :mc:`mc idp ldap accesskey create` allows you to add LDAP access key pairs.
+
+.. end-mc-idp-ldap-accesskey-create-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+         The following example creates a new access key pair with the same policy as the authenticated user on the ``minio`` :ref:`alias <alias>`:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc idp ldap accesskey create minio/
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] idp ldap accesskey create                   \
+                                          ALIAS                       \
+                                          [--access-key <value>]      \
+                                          [--secret-key <value>]      \
+                                          [--policy <value>]          \
+                                          [--name <value>]            \
+                                          [--description <value>]     \
+                                          [--expiry-duration <value>] \ 
+                                          [--login <site>]
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment configured for AD/LDAP integration.
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment configured for AD/LDAP.
+
+   For example:
+
+   .. code-block:: none
+
+         mc idp ldap accesskey create minio
+
+.. mc-cmd:: --access-key
+   :optional:
+
+   An access key to use for the account.
+
+   Requires :mc-cmd:`~mc idp ldap accesskey create --secret-key`
+
+.. mc-cmd:: --secret-key
+   :optional:
+
+   A secret to use for the account.
+
+   Requires :mc-cmd:`~mc idp ldap accesskey create --access-key`
+
+.. mc-cmd:: --policy
+   :optional:
+
+   File path to the JSON-formatted policy to use for the account.
+
+   If not specified, the account uses the same policy as the authenticated user.
+
+.. mc-cmd:: --name
+   :optional:
+
+   A human-readable name to use for the account.
+
+.. mc-cmd:: --description
+   :optional:
+
+   Add a description for the service account.
+   For example, you might specify the reason the access key exists.
+
+.. mc-cmd:: --expiry-duration
+   :optional:
+
+   Length of time the access key pair should remain valid for use in ``#d#h#s`` format.
+       
+   For example, ``7d``, ``24h``, ``5d12h30s`` are valid strings.
+
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey create --expiry`.
+
+.. mc-cmd:: --expiry
+   :optional:
+
+   The date after which the access key expires.
+   Enter the date in YYYY-MM-DD format.
+
+   For example, to expire the credentials after December 31, 2024, enter ``2024-12-31``.
+
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey create --expiry-duration`.
+
+.. mc-cmd:: --login
+   :optional:
+
+   Prompts the user to log in using the LDAP credentials to use to generate the access key.
+   Specify the URL of the LDAP-configured MinIO Server to use for the login prompt.
+
+   Requires an interactive terminal.
+
+Examples
+~~~~~~~~
+
+Create a new access-key pair for the authenticated user
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
+The command outputs a randomly generated access key and secret key.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio
+
+Create a new access-key pair with a custom access key and secret key
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The following command creates a new access key pair with both an access key and secret key that you specify for the user currently authenticated on the ``minio`` alias.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio/ --access-key my-access-key-change-me --secret-key my-secret-key-change-me
+
+Create a new access-key pair that expires after 24 hours
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
+The credentials expire after 24 hours.
+
+The command outputs a randomly generated access key and secret key.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio --expiry-duration 24h
+
+Create a new access-key and prompt to login as the user
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The following command creates a new access key pair.
+The MinIO Client will first ask you to log in as the user the access key is for on the MinIO site configured for LDAP at ``minio.example.com``.
+
+The command outputs a randomly generated access key and secret key.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio --login minio.example.com
+
+Create a new access-key pair that expires after a date
+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The following command creates a new access key pair to use with the currently authenticated user on the ``minio`` alias.
+The credentials expire after February 29, 2024.
+
+The command outputs a randomly generated access key and secret key.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey create minio --expiry 2024-02-29
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
@@ -52,7 +52,7 @@ The :mc:`mc idp ldap accesskey ls` displays a list of LDAP access key pairs.
 
          mc [GLOBALFLAGS] idp ldap accesskey ls              \
                                           ALIAS              \
-                                          [--permanent-only] \
+                                          [--svcacc-only] \
                                           [--temp-only]      \
                                           [--users-only]     \
                                           [DN] ...
@@ -81,10 +81,10 @@ Parameters
 
          mc idp ldap accesskey ls minio
 
-.. mc-cmd:: --permanent-only
+.. mc-cmd:: --svcacc-only
    :optional:
 
-   Output only permanent access keys.
+   Output only service account access keys.
 
    Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey ls --temp-only`.
 

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
@@ -38,6 +38,11 @@ The :mc-cmd:`mc idp ldap accesskey` command has the following subcommands:
    * - Subcommand
      - Description
 
+   * - :mc-cmd:`mc idp ldap accesskey create`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-create.rst
+          :start-after: start-mc-idp-ldap-accesskey-create-desc
+          :end-before: end-mc-idp-ldap-accesskey-create-desc
+
    * - :mc-cmd:`mc idp ldap accesskey ls`
      - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
           :start-after: start-mc-idp-ldap-accesskey-ls-desc

--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -71,6 +71,8 @@ The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-man
                           [--noncurrent-expire-newer "integer"]      \
                           [--noncurrent-transition-days "integer"]   \
                           [--noncurrent-transition-tier "string"]    \
+                          [--site-gt "string"]                       \
+                          [--size-lt "string"]                       \
                           ALIAS
 
       .. include:: /includes/common-minio-mc.rst
@@ -114,7 +116,7 @@ Parameters
    - :mc-cmd:`~mc ilm rule add --expire-delete-marker`
 
 .. mc-cmd:: --expire-days
-   :required:   
+   :optional:   
 
    The number of days to retain an object after being created. 
    MinIO marks the object for deletion after the specified number of days pass. 
@@ -248,6 +250,89 @@ Parameters
    Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
    See :ref:`minio-lifecycle-management-scanner` for more information.
    
+.. mc-cmd:: --size-gt
+   :optional:
+
+   .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z 
+
+   Select objects larger than the specified value.
+   Enter the value as a number and a unit, such as ``5GiB`` for 5 gibibytes.
+
+   Valid units include:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 80
+      :width: 100%
+   
+      * - Suffix
+        - Unit Size
+   
+      * - ``k``
+        - KB (Kilobyte, 1000 Bytes)
+   
+      * - ``m``
+        - MB (Megabyte, 1000 Kilobytes)
+   
+      * - ``g``
+        - GB (Gigabyte, 1000 Megabytes)
+   
+      * - ``t``
+        - TB (Terrabyte, 1000 Gigabytes)
+   
+      * - ``ki``
+        - KiB (Kibibyte, 1024 Bites)
+   
+      * - ``mi``
+        - MiB (Mebibyte, 1024 Kibibytes)
+   
+      * - ``gi``
+        - GiB (Gibibyte, 1024 Mebibytes)
+   
+      * - ``ti``
+        - TiB (Tebibyte, 1024 Gibibytes)
+
+.. mc-cmd:: --size-lt
+   :optional:
+  
+   .. versionadded:: mc RELEASE.2023-12-02T02-03-28Z
+
+   Select objects smaller than the specified value.
+   Enter the value as a number and a unit, such as ``1M`` for 1 megabyte.
+
+   Valid units include:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 80
+      :width: 100%
+   
+      * - Suffix
+        - Unit Size
+   
+      * - ``k``
+        - KB (Kilobyte, 1000 Bytes)
+   
+      * - ``m``
+        - MB (Megabyte, 1000 Kilobytes)
+   
+      * - ``g``
+        - GB (Gigabyte, 1000 Megabytes)
+   
+      * - ``t``
+        - TB (Terrabyte, 1000 Gigabytes)
+   
+      * - ``ki``
+        - KiB (Kibibyte, 1024 Bites)
+   
+      * - ``mi``
+        - MiB (Mebibyte, 1024 Kibibytes)
+   
+      * - ``gi``
+        - GiB (Gibibyte, 1024 Mebibytes)
+   
+      * - ``ti``
+        - TiB (Tebibyte, 1024 Gibibytes)
 
 Global Flags
 ~~~~~~~~~~~~
@@ -308,6 +393,27 @@ This command looks at the contents with the ``doc/`` prefix in the ``mybucket`` 
 
 - Current objects expire after 300 days.
 - Non-current objects expire after 100 days.
+
+Transition noncurrent versions in the prefix ``/doc`` with a size greater the 1MiB
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the :mc:`mc ilm rule add` command with :mc-cmd:`~mc ilm rule add --prefix`, :mc-cmd:`~mc ilm rule add --size-gt`, and :mc-cmd:`~mc ilm rule add --noncurrent-expire-days` to expire current and non-current versions of an object at different times.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc ilm rule add --prefix "doc/" --size-gt 1MiB --transition-days "90" --transition-tier "MINIOTIER-1" \
+         --noncurrent-transition-days "45" --noncurrent-transition-tier "MINIOTIER-1" \
+         myminio/mybucket/
+
+This command looks at the contents with the ``doc/`` prefix in the ``mybucket`` bucket on the ``myminio`` deployment.
+
+The command selects the following objects:
+
+- Current objects older than 90 days larger than 1MiB.
+- Non-current objects older than 45 days larger than 1MiB.
+  
+Selected objects transition to ``MINIOTIER-1``.
 
 Required Permissions
 --------------------

--- a/source/reference/minio-mc/mc-ilm-tier-add.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-add.rst
@@ -91,6 +91,9 @@ Syntax
                          [--use-aws-role^]            \
                          [--aws-role-arn^]            \
                          [--aws-web-identity-file^]   \
+                         [--azure-sp-tenant-id^]      \
+                         [--azure-sp-client-id^]      \
+                         [--azure-sp-client-secret^]  \
                          [--account-name value^]      \
                          [--account-key value^]       \
                          [--credentials-file value^]  \
@@ -311,6 +314,30 @@ The command accepts the following arguments:
    Specify the web identity token file to use when transitioning objects.
 
    This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``s3`` **and** the source is a MinIO pod on Amazon EKS.
+
+.. mc-cmd:: --azure-sp-tenant-id
+   :optional:
+
+   Tenant ID for the `service principal account <https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1>`__ to use to log in to Azure storage.
+
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using an service principal identity.
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --azure-sp-client-id
+   :optional:
+
+   Client ID for the `service principal account <https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1>`__ to use to log in to Azure storage.
+
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using an service principal identity.
+   This option has no effect for any other value of ``TIER_TYPE``.
+
+.. mc-cmd:: --azure-sp-client-secret
+   :optional:
+
+   The client secret for the `service principal account <https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1>`__ to use to log in to Azure storage.
+
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using an service principal identity.
+   This option has no effect for any other value of ``TIER_TYPE``.
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-license-register.rst
+++ b/source/reference/minio-mc/mc-license-register.rst
@@ -49,6 +49,74 @@ The :mc-cmd:`mc license register` command connects your deployment with your |SU
 
 After registration, you can upload deployment health reports directly to SUBNET using the :mc-cmd:`mc support diag` command.
 
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+         The following example registers the ``minio`` :ref:`alias <alias>` with |SUBNET|:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc license register minio
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] license register ALIAS                      \
+                                  [--airgap]                          \
+                                  [--api-key <string>]                \
+                                  [--license <path to license file>]  \
+                                  [--name <value>]
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment.
+
+  
+.. mc-cmd:: --airgap
+   :optional:
+
+   Use in environments without network access to SUBNET (for example, airgapped, firewalled, or similar configuration).
+
+   For instructions, see the :ref:`airgap example <minio-license-register-airgap>`.
+
+   If the deployment is airgapped, but the local device where you are using the :ref:`minio client <minio-client>` has network access, you do not need to use the ``--airgap`` flag.
+
+.. mc-cmd:: --api-key
+
+   API of the account on SUBNET.
+
+   Corresponds with the ``MC_SUBNET_API_KEY`` environment variable.
+
+   To find the API key:
+
+   #. Log in to |SUBNET|
+   #. Go to the :guilabel:`Deployments` tab
+   #. Select the :guilabel:`API Key` button near the top of the page on the right side of the account statistics information box
+   #. Select copy button to the right of the key field to copy the key value to your clipboard
+
+.. mc-cmd:: --license
+   :optional:
+
+   Path to the license file to use for registering the deployment.
+   
+   You must first :ref:`download the license file <minio-subnet-license-file-download>` for the account.
+
+.. mc-cmd:: --name
+   :optional:
+
+   Specify a name other than the alias to associate to the MinIO deployment in SUBNET.
+
+   Use ``--name <value>`` replacing ``<value>`` with the name you want to use for the deployment on SUBNET.
 
 Examples
 --------
@@ -64,6 +132,18 @@ Register the MinIO deployment at alias ``minio1`` on SUBNET, using ``minio1`` as
    mc license register minio1
 
 If not already registered, a prompt asks for SUBNET credentials for the deployment.
+
+Register a Deployment Using the Account's License File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Register a new MinIO deployment at alias ``minio5`` on SUBNET, using the license file downloaded for the account:
+
+.. code-block:: shell
+   :class: copyable
+
+   mc license register minio5 /path/to/minio.license
+
+If not already downloaded, you can :ref:`download the license file <minio-subnet-license-file-download>` from SUBNET.
 
 Register a Deployment with a Different Deployment Name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -117,29 +197,7 @@ The command has the following syntax:
                             [--name value] \
                             [--airgap]
 
-Parameters
-~~~~~~~~~~
 
-.. mc-cmd:: ALIAS
-   :required:
-
-   The :ref:`alias <alias>` of the MinIO deployment.
-
-.. mc-cmd:: --name
-   :optional:
-
-   Specify a name other than the alias to associate to the MinIO deployment in SUBNET.
-
-   Use ``--name <value>`` replacing ``<value>`` with the name you want to use for the deployment on SUBNET.
-   
-.. mc-cmd:: --airgap
-   :optional:
-
-   Use in environments without network access to SUBNET (for example, airgapped, firewalled, or similar configuration).
-
-   For instructions, see the :ref:`airgap example <minio-license-register-airgap>`.
-
-   If the deployment is airgapped, but the local device where you are using the :ref:`minio client <minio-client>` has network access, you do not need to use the ``--airgap`` flag.
 
 
 Global Flags

--- a/source/reference/minio-mc/minio-client-settings.rst
+++ b/source/reference/minio-mc/minio-client-settings.rst
@@ -88,16 +88,20 @@ STS Service
 
 Use this setting to add an STS endpoint to use for `mc` commands.
 
+.. versionchanged:: mc RELEASE.2023-12-02T02-03-28Z 
+
+Supports adding multiple environment variables by alias.
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
       :selected:
 
-      .. envvar:: MC_STS_ENDPOINT
+      .. envvar:: MC_STS_ENDPOINT_<alias>
 
       .. code-block:: shell
 
-         export MC_STS_ENDPOINT=https://sts.minio-operator.svc.cluster.local:4223/sts/ns-1 
+         export MC_STS_ENDPOINT_myalias=https://sts.minio-operator.svc.cluster.local:4223/sts/ns-1 
 
    .. tab-item:: Configuration Setting
 
@@ -112,16 +116,20 @@ Web Token Identity
 
 Use this setting to add a web token identity to use for `mc` commands.
 
+.. versionchanged:: mc RELEASE.2023-12-02T02-03-28Z 
+
+Supports adding multiple environment variables by alias.
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
       :selected:
 
-      .. envvar:: MC_WEB_IDENITY_TOKEN
+      .. envvar:: MC_WEB_IDENITY_TOKEN_<alias>
 
       .. code-block:: shell
 
-         export MC_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/kubernetes.io/serviceaccount/token
+         export MC_WEB_IDENTITY_TOKEN_FILE_myalias=/var/run/secrets/kubernetes.io/serviceaccount/token
 
    .. tab-item:: Configuration Setting
 


### PR DESCRIPTION

Updates for three December 2023 MinIO Client releases.

1. mc RELEASE.2023-12-02T02-03-28Z
    - Enable/disabe ilm expiration rule replication in site replication config
    - New size filters for ilm rule add
    - Make STS related envvars alias specific
2.  mc RELEASE.2023-12-14T00-37-41Z
      - Adds flags to `mc ilm rule add` to support service principals for Azure tiers.
3.  mc RELEASE.2023-12-23T08-47-21Z  
    - Adds new `mc idp ldap accesskey create` command
    - Updates other `mc idp ldap accesskey` commands
    - Updates `mc license registe` command
    - Adds `--license` flag to `mc license reigster` command
    
Closes #1096
Closes #1088
Closes #1082

Staged:
http://192.241.195.202:9000/staging/mc-dec-2023-releases/linux/index.html

- [LDAP Accesskey](http://192.241.195.202:9000/staging/mc-dec-2023-releases/linux/reference/minio-mc/mc-idp-ldap-accesskey.html)
- [License Register](http://192.241.195.202:9000/staging/mc-dec-2023-releases/linux/reference/minio-mc/mc-license-register.html)
- [Azure service principal flags](http://192.241.195.202:9000/staging/mc-dec-2023-releases/linux/reference/minio-mc/mc-ilm-tier-add.html#mc.ilm.tier.add.-azure-sp-tenant-id)
- [mc admin replicate](http://192.241.195.202:9000/staging/mc-dec-2023-releases/linux/reference/minio-mc-admin/mc-admin-replicate.html)
- [ilm rule add](http://192.241.195.202:9000/staging/mc-dec-2023-releases/linux/reference/minio-mc/mc-ilm-rule-add.html)
- [STS envvars](http://192.241.195.202:9000/staging/mc-dec-2023-releases/linux/reference/minio-mc/minio-client-settings.html#sts-service)