### PR TITLE
PowerShell commands and a request type for access management fix

### DIFF
--- a/source/administration/identity-access-management/policy-based-access-control.rst
+++ b/source/administration/identity-access-management/policy-based-access-control.rst
@@ -120,7 +120,7 @@ as that user:
        | :userpolicy:`readonly` on ``audit`` bucket
      
      - | ``PUT`` and ``GET`` on ``finance`` bucket.
-       | ``PUT`` on ``audit`` bucket
+       | ``GET`` on ``audit`` bucket
 
    * - ``Auditing``
      - | :userpolicy:`readonly` on ``audit`` bucket

--- a/source/operations/monitoring/healthcheck-probe.rst
+++ b/source/operations/monitoring/healthcheck-probe.rst
@@ -16,21 +16,6 @@ endpoints return an HTTP status code indicating whether the underlying
 resource is healthy or satisfies read/write quorum. MinIO exposes no other data
 through these endpoints.
 
-.. cond:: windows
-
-   .. admonition:: Checks Using PowerShell
-      :class: note
-
-      When using PowerShell to run the following the commands, you must explicitly set ``-UserAgent ""``.
-      Otherwise, the healthcheck redirects to the Admin Console instead of the desired Healthcheck API.
-
-      For PowerShell commands, you could replace each of the ``curl`` examples below with something like the following:
-
-      .. code-block:: powershell
-         :class: copyable
-
-         Invoke-WebRequest -Uri https://minio.example.net:9000/minio/health/cluster?maintenance=true -UserAgent ""
-
 Node Liveness
 -------------
 

--- a/source/operations/monitoring/healthcheck-probe.rst
+++ b/source/operations/monitoring/healthcheck-probe.rst
@@ -16,6 +16,21 @@ endpoints return an HTTP status code indicating whether the underlying
 resource is healthy or satisfies read/write quorum. MinIO exposes no other data
 through these endpoints.
 
+.. cond:: windows
+
+   .. admonition:: Checks Using PowerShell
+      :class: note
+
+      When using PowerShell to run the following the commands, you must explicitly set ``-UserAgent ""``.
+      Otherwise, the healthcheck redirects to the Admin Console instead of the desired Healthcheck API.
+
+      For PowerShell commands, you could replace each of the ``curl`` examples below with something like the following:
+
+      .. code-block:: powershell
+         :class: copyable
+
+         Invoke-WebRequest -Uri https://minio.example.net:9000/minio/health/cluster?maintenance=true -UserAgent ""
+
 Node Liveness
 -------------
 

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
@@ -93,7 +93,7 @@ Parameters
 
    Output only temporary access keys.
 
-   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey ls --permanent-only`.
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey ls --svcacc-only`.
 
 .. mc-cmd:: --users-only
    :optional:


### PR DESCRIPTION
- Fixes a request type in an access management table

Closes #1064

- Adds an admonition about PowerShell commands to Healthcheck API page

Closes #1086

Staged:
- [Request type fix](http://192.241.195.202:9000/staging/cleanups/windows/administration/identity-access-management/policy-based-access-control.html#userpolicy.writeonly)
- [Healthcheck API](http://192.241.195.202:9000/staging/cleanups/windows/operations/monitoring/healthcheck-probe.html)