### PR TITLE
Clarify several small items in the mc reference

### DIFF
--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -23,7 +23,7 @@ The :mc:`mc mirror` command synchronizes content to MinIO deployment, similar to
 .. note::
    
    :mc:`mc mirror` only synchronizes the current object without any version information or metadata.
-   To synchronize an object's version history and metadata, consider using :mc:`mc replicate` or :mc:`mc admin replicate`.
+   To synchronize an object's version history and metadata, consider using :mc:`mc replicate` for :ref:`bucket replication <minio-bucket-replication-serverside>` or :mc:`mc admin replicate` for :ref:`site replication <minio-site-replication-overview>`.
 
 
 .. tab-set::

--- a/source/reference/minio-mc/mc-version-enable.rst
+++ b/source/reference/minio-mc/mc-version-enable.rst
@@ -113,7 +113,7 @@ Behavior
 Bucket Versioning with Existing Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enabling bucket versioning on a bucket with existing data immediately creates a null value version ID for each unversioned object.
+Enabling bucket versioning on a bucket with existing data immediately creates a ``NULL`` value version ID for each unversioned object.
 
 
 S3 Compatibility

--- a/source/reference/minio-mc/mc-version-enable.rst
+++ b/source/reference/minio-mc/mc-version-enable.rst
@@ -113,7 +113,7 @@ Behavior
 Bucket Versioning with Existing Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enabling bucket versioning on a bucket with existing data immediately applies a versioning ID to any unversioned object.
+Enabling bucket versioning on a bucket with existing data immediately creates a null value version ID for each unversioned object.
 
 
 S3 Compatibility

--- a/source/reference/minio-mc/mc-version.rst
+++ b/source/reference/minio-mc/mc-version.rst
@@ -59,7 +59,7 @@ See :mc:`mc retention` for more information on configuring object locking.
 Bucket Versioning with Existing Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enabling bucket versioning on a bucket with existing data immediately applies a versioning ID to any unversioned object.
+Enabling bucket versioning on a bucket with existing data immediately creates a null value version ID for each unversioned object.
 
 Disabling bucket versioning on a bucket with existing versioned data does *not* remove any versioned objects.
 Applications can continue to access versioned data after disabling bucket versioning.


### PR DESCRIPTION
A few opportunistic text updates:

- `mc mirror` recommends `mc replicate` and `mc admin replicate` for other use cases. Mention what they are for.
- Clarify that `mc version` creates a null version id for existing unversioned objects when bucket versioning is enabled.

http://192.241.195.202:9000/staging/mc-mirror-clarification/linux/reference/minio-mc/mc-mirror.html
http://192.241.195.202:9000/staging/mc-mirror-clarification/linux/reference/minio-mc/mc-version.html#bucket-versioning-with-existing-data