### PR TITLE
Update `mc share download` syntax

### DIFF
--- a/source/reference/minio-mc/mc-share-download.rst
+++ b/source/reference/minio-mc/mc-share-download.rst
@@ -51,7 +51,7 @@ documentation on :aws-docs:`Pre-Signed URLs
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] share upload             \
+         mc [GLOBALFLAGS] share download           \
                           [--expire "string"]      \
                           [--recursive]            \
                           [--version-id "string"]  \


### PR DESCRIPTION
In following page the syntax section is not for download:
https://min.io/docs/minio/linux/reference/minio-mc/mc-share-download.html#syntax
This PR will changes syntax from upload  to download