### PR TITLE
Doc updates for mc RELEASE.2024-01-11T05-49-32Z

### DIFF
--- a/source/reference/minio-mc/mc-alias-set.rst
+++ b/source/reference/minio-mc/mc-alias-set.rst
@@ -70,7 +70,7 @@ Parameters
    *Required* The name to associate to the S3-compatible service.
    Aliases are case-sensitive and must meet the following requirements:
 
-   - Contain only `ASCII <https://en.wikipedia.org/wiki/ASCII>`__ letters and numbers (``[a-zA-Z0-9]``), hyphen ``-``, or underscore ``_``.
+   - Contain only `ASCII <https://en.wikipedia.org/wiki/ASCII>`__ lower case letters (``a-z``), upper case letters (``A-Z``), numbers (``[0-9]``), hyphen (``-``), or underscore (``_``).
    - 2 or more characters in length.
    - The first character must be a letter.
 

--- a/source/reference/minio-mc/mc-alias-set.rst
+++ b/source/reference/minio-mc/mc-alias-set.rst
@@ -78,7 +78,7 @@ Parameters
 
       An alias may also be a single letter (``[a-zA-Z]``).
 
-   Examples include:
+   Examples of some valid alias values include:
 
    - ``myminio``
    - ``Test-1``

--- a/source/reference/minio-mc/mc-alias-set.rst
+++ b/source/reference/minio-mc/mc-alias-set.rst
@@ -76,7 +76,7 @@ Parameters
 
    .. versionchanged:: RELEASE.2024-01-11T05-49-32Z
 
-      An alias may also be a single letter (``[a-zA-Z]``).
+      An alias may also be a single letter (``a-z`` or ``A-Z``).
 
    Examples of some valid alias values include:
 

--- a/source/reference/minio-mc/mc-alias-set.rst
+++ b/source/reference/minio-mc/mc-alias-set.rst
@@ -68,6 +68,22 @@ Parameters
 .. mc-cmd:: ALIAS
 
    *Required* The name to associate to the S3-compatible service.
+   Aliases are case-sensitive and must meet the following requirements:
+
+   - Contain only `ASCII <https://en.wikipedia.org/wiki/ASCII>`__ letters and numbers (``[a-zA-Z0-9]``), hyphen ``-``, or underscore ``_``.
+   - 2 or more characters in length.
+   - The first character must be a letter.
+
+   .. versionchanged:: RELEASE.2024-01-11T05-49-32Z
+
+      An alias may also be a single letter (``[a-zA-Z]``).
+
+   Examples include:
+
+   - ``myminio``
+   - ``Test-1``
+   - ``A``
+   - ``a``
 
 .. mc-cmd:: URL
 

--- a/source/reference/minio-mc/mc-tag-set.rst
+++ b/source/reference/minio-mc/mc-tag-set.rst
@@ -99,7 +99,7 @@ Parameters
 
    .. code-block:: shell
 
-      mc tag set myminio/mybucket/prefix1 "key1=value1" --exclude-folders --recursive
+      mc tag set myminio/vacation-photos/cancun "destination=international" --exclude-folders --recursive
    
 .. mc-cmd:: --recursive, r
    :optional:

--- a/source/reference/minio-mc/mc-tag-set.rst
+++ b/source/reference/minio-mc/mc-tag-set.rst
@@ -95,7 +95,9 @@ Parameters
    Tags are only applied to objects at the specified path.
    Requires :mc-cmd:`~mc tag set --recursive`.
 
-   The following example applies the tag ``key1=value1`` to objects at ``mybucket/prefix1`` but not ``mybucket/prefix1/prefix2``:
+   The following example applies the tag ``destination=international`` to objects at ``vacation-photos/cancun/`` but not ``vacation-photos/cancun/ocean/`` or other prefixes.
+   
+   For example, the above would add the tags to the object at``vacation-photos/cancun/pretty-beach.jpg`` but not to the object at``vacation-photos/cancun/ocean/tropical-fish.jpg``.
 
    .. code-block:: shell
 

--- a/source/reference/minio-mc/mc-tag-set.rst
+++ b/source/reference/minio-mc/mc-tag-set.rst
@@ -86,6 +86,21 @@ Parameters
 
       mc tag set myminio/mybucket/object.txt "key1=value1&key2=value2"
 
+.. mc-cmd:: --exclude-folders
+   :optional:
+
+   .. versionadded:: RELEASE.2024-01-11T05-49-32Z
+
+   When used with :mc-cmd:`~mc tag set --recursive`, causes :mc:`mc tag set` to *not* traverse child prefixes.
+   Tags are only applied to objects at the specified path.
+   Requires :mc-cmd:`~mc tag set --recursive`.
+
+   The following example applies the tag ``key1=value1`` to objects at ``mybucket/prefix1`` but not ``mybucket/prefix1/prefix2``:
+
+   .. code-block:: shell
+
+      mc tag set myminio/mybucket/prefix1 "key1=value1" --exclude-folders --recursive
+   
 .. mc-cmd:: --recursive, r
    :optional:
 

--- a/source/reference/minio-mc/mc-tag-set.rst
+++ b/source/reference/minio-mc/mc-tag-set.rst
@@ -91,7 +91,7 @@ Parameters
 
    .. versionadded:: RELEASE.2024-01-11T05-49-32Z
 
-   When used with :mc-cmd:`~mc tag set --recursive`, causes :mc:`mc tag set` to *not* traverse child prefixes.
+   When used with :mc-cmd:`~mc tag set --recursive`, causes :mc:`mc tag set` to **not** traverse child prefixes.
    Tags are only applied to objects at the specified path.
    Requires :mc-cmd:`~mc tag set --recursive`.
 


### PR DESCRIPTION
Doc updates for the following:

- Document alias naming requirements, including new minimum length rules
- `mc tag set --exclude-folders` modifies the behavior of `--recursive`

Staged:
http://192.241.195.202:9000/staging/DOCS-1106/linux/reference/minio-mc/mc-alias-set.html#mc.alias.set.ALIAS
http://192.241.195.202:9000/staging/DOCS-1106/linux/reference/minio-mc/mc-tag-set.html#mc.tag.set.-exclude-folders

Fixes https://github.com/minio/docs/issues/1106