### PR TITLE
Adding mc version info for license add or update

### DIFF
--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -79,6 +79,10 @@ You can restart through the Console by selecting :guilabel:`Restart` in the top 
 
       You can register for SUBNET from the command line.
 
+      .. important:: 
+
+         Registering your deployment with SUBNET or updating the license for a deployment requires :ref:`MinIO Client <minio-client> version ``RELEASE.2023-11-20T16-30-59Z`` or newer.
+
       Refer to :mc:`mc license register` for instructions.
 
       For clusters without direct Internet access, refer to the instructions in the :ref:`airgap example <minio-license-register-airgap>` of the :mc:`mc license register` documentation.

--- a/source/reference/minio-mc/mc-license-register.rst
+++ b/source/reference/minio-mc/mc-license-register.rst
@@ -11,6 +11,10 @@
 .. mc:: mc support register
 .. mc:: mc license register
 
+.. important:: 
+
+   ``mc license register`` requires :ref:`MinIO Client <minio-client> version ``RELEASE.2023-11-20T16-30-59Z`` or newer.
+
 Command History
 ---------------
 

--- a/source/reference/minio-mc/mc-license-update.rst
+++ b/source/reference/minio-mc/mc-license-update.rst
@@ -10,6 +10,10 @@
 
 .. mc:: mc license update
 
+.. important:: 
+
+   ``mc license update`` requires :ref:`MinIO Client <minio-client>` version ``RELEASE.2023-11-20T16-30-59Z`` or newer.
+
 Description
 -----------
 


### PR DESCRIPTION
Per internal discussion, this adds some admonitions for mc license commands and the SUBNET registration section of the troubleshooting page.