### PR TITLE
Change port to 9090 for port forward command for helm minio-operator

### DIFF
--- a/source/operations/install-deploy-manage/deploy-operator-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-helm.rst
@@ -171,9 +171,9 @@ You can modify the Operator deployment after installation.
    .. code-block:: shell
       :class: copyable
 
-      kubectl port-forward svc/console -n minio-operator 9001:9001
+      kubectl port-forward svc/console -n minio-operator 9090:9090
 
-   You can then use ``http://localhost:9001`` to access the MinIO Operator Console.
+   You can then use ``http://localhost:9090`` to access the MinIO Operator Console.
 
    Once you access the Console, use the Console JWT to log in.
 


### PR DESCRIPTION
Installing the latest minio operator helm chart sets the console port to 9090 not 9001. I fixed the port in the port-forward command.
```
k get svc -n minio-operator 
NAME       TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
console    ClusterIP   10.97.140.40    <none>        9090/TCP,9443/TCP   21m
operator   ClusterIP   10.106.20.115   <none>        4221/TCP            21m
sts        ClusterIP   10.106.182.83   <none>        4223/TCP            21m
```