### PR TITLE
Reminder to install mc, not Midnight Commander

### DIFF
--- a/source/includes/minio-mc-installation.rst
+++ b/source/includes/minio-mc-installation.rst
@@ -51,6 +51,13 @@
 
          mc --help
 
+      .. admonition:: Install from the MinIO Download Page
+         :class: note
+
+         To ensure you install the correct binary, download ``mc`` from the `MinIO Download Page <https://dl.min.io/client/mc/release/>`__.
+         Other repositories, including those used by common Linux package managers, may have other software with a similar name.
+	 
+
    .. tab-item:: macOS
 
       .. code-block:: shell

--- a/source/includes/minio-mc-installation.rst
+++ b/source/includes/minio-mc-installation.rst
@@ -54,9 +54,12 @@
       .. admonition:: Install from the MinIO Download Page
          :class: note
 
-         To ensure you install the correct binary, download ``mc`` from the `MinIO Download Page <https://dl.min.io/client/mc/release/>`__.
-         Other repositories, including those used by common Linux package managers, may have other software with a similar name.
-	 
+         MinIO does not officially publish its binaries to common Linux repositories or package managers (Ubuntu, RHEL, Archlinux/AUR).
+         The only official source of MinIO binaries is the `MinIO Download Page <https://dl.min.io/client/mc/release/>`__.
+
+         MinIO does not recommend installation through a package manager, as upstream repositories may install the incorrect package or a renamed package.
+
+         All documentation assumes the installation of the *official* ``mc`` client binary through the download page *only*, with no changes to binary naming.
 
    .. tab-item:: macOS
 


### PR DESCRIPTION
Add admonition to the Linux `mc` install steps about installing the correct binary from `dl.min.io`. If you use your native package manager, you are very likely to get GNU Midnight Commander instead. 

Staged
http://192.241.195.202:9000/staging/not-midnight-commander/linux/reference/minio-mc.html#install-mc