### PR TITLE
Document security header envvars and config items

### DIFF
--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -183,12 +183,13 @@ Content Security Policy
 
 *Optional*
 
-Set the ``Content-Security-Policy`` header in MinIO Console responses.
+Set the `Content-Security-Policy <https://en.wikipedia.org/wiki/Content_Security_Policy>`__ header in MinIO Console responses.
 Defaults to ``default-src 'self' 'unsafe-eval' 'unsafe-inline';``
 
 .. tab-set::
 
    .. tab-item:: Environment Variable
+      :sync: envvar
 
       .. envvar:: MINIO_BROWSER_CONTENT_SECURITY_POLICY
 
@@ -198,8 +199,9 @@ Defaults to ``default-src 'self' 'unsafe-eval' 'unsafe-inline';``
          set MINIO_BROWSER_CONTENT_SECURITY_POLICY="default-src 'self' 'unsafe-eval' 'unsafe-inline';"
 
    .. tab-item:: Configuration Setting
+      :sync: config
 
-      .. mc-conf:: csp_policy
+      .. mc-conf:: browser csp_policy
          :delimiter: " "
 
       .. code-block:: shell
@@ -214,29 +216,75 @@ Strict Transport Security
 
 *Optional*
 
+Set the `Strict-Transport-Security <https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>`__ header in MinIO Console responses.
+Set the appropriate environment variable or configuration settings according to the HSTS requirements for your environment.
+
 .. tab-set::
 
    .. tab-item:: Environment Variables
+      :sync: envvar
 
       .. envvar:: MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS
+
+         Set to ``on`` to append ``includeSubDomains`` to the ``Strict-Transport-Security`` header.
+	 Defaults to ``off``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
 
 
       .. envvar:: MINIO_BROWSER_HSTS_PRELOAD
 
+	 Set to ``on`` to include this header in the HSTS preloading list.
+	 Defaults to ``off``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
 
       .. envvar:: MINIO_BROWSER_HSTS_SECONDS
 
+	 The ``max_age`` the configured policy remains in effect, in seconds. 
+	 Defaults to ``0``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         set MINIO_BROWSER_HSTS_SECONDS=31536000
 
    .. tab-item:: Configuration Settings
+      :sync: config
 
-      .. mc-conf:: hsts_include_subdomains
+      .. mc-conf:: browser hsts_include_subdomains
          :delimiter: " "
 		     
-      .. mc-conf:: hsts_preload
+      .. code-block:: shell
+
+         mc admin config set browser \
+            hsts_include_subdomains="on" \
+            [ARGUMENT=VALUE ...]
+	    
+      .. mc-conf:: browser hsts_preload
          :delimiter: " "
-		     
-      .. mc-conf:: hsts_seconds
+     
+      .. code-block:: shell
+
+         mc admin config set browser \
+            hsts_preload="on" \
+            [ARGUMENT=VALUE ...]
+	    
+      .. mc-conf:: browser hsts_seconds
          :delimiter: " "
+        	
+      .. code-block:: shell
+
+         mc admin config set browser \
+            hsts_seconds="0" \
+            [ARGUMENT=VALUE ...]
+
 
 
 Referrer Policy
@@ -244,18 +292,32 @@ Referrer Policy
 
 *Optional*
 
+Set the `Referrer-Policy <https://www.w3.org/TR/referrer-policy/>`__ header in MinIO Console responses.
+Defaults to ``strict-origin-when-cross-origin``.
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
+      :sync: envvar
 
       .. envvar:: MINIO_BROWSER_REFERRER_POLICY
 
+      .. code-block:: shell
+         :class: copyable
+
+         set MINIO_BROWSER_REFERRER_POLICY="strict-origin-when-cross-origin"
 
    .. tab-item:: Configuration Setting
+      :sync: config
 
-      .. mc-conf:: referrer_policy
+      .. mc-conf:: browser referrer_policy
          :delimiter: " "
 
+      .. code-block:: shell
+
+         mc admin config set browser \
+            referrer_policy="strict-origin-when-cross-origin" \
+            [ARGUMENT=VALUE ...]
 
 
 Prometheus Settings

--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -24,7 +24,7 @@ The following settings control behavior for the embedded MinIO Console.
 MinIO Console
 ~~~~~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -42,7 +42,7 @@ MinIO Console
 Animation
 ~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -62,7 +62,7 @@ Animation
 Browser Redirect
 ~~~~~~~~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -83,7 +83,7 @@ Browser Redirect
 Browser Redirect URL
 ~~~~~~~~~~~~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -108,7 +108,7 @@ Browser Redirect URL
 Session Duration
 ~~~~~~~~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -137,7 +137,7 @@ Session Duration
 Server URL
 ~~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -162,7 +162,7 @@ Server URL
 Log Query URL
 ~~~~~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -181,7 +181,10 @@ Log Query URL
 Content Security Policy
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-:optional:
+*Optional*
+
+Set the ``Content-Security-Policy`` header in MinIO Console responses.
+Defaults to ``default-src 'self' 'unsafe-eval' 'unsafe-inline';``
 
 .. tab-set::
 
@@ -189,18 +192,27 @@ Content Security Policy
 
       .. envvar:: MINIO_BROWSER_CONTENT_SECURITY_POLICY
 
+      .. code-block:: shell
+         :class: copyable
+
+         set MINIO_BROWSER_CONTENT_SECURITY_POLICY="default-src 'self' 'unsafe-eval' 'unsafe-inline';"
 
    .. tab-item:: Configuration Setting
 
       .. mc-conf:: csp_policy
          :delimiter: " "
 
+      .. code-block:: shell
+
+         mc admin config set browser \
+            csp_policy="default-src 'self' 'unsafe-eval' 'unsafe-inline';" \
+            [ARGUMENT=VALUE ...]
 
 
 Strict Transport Security
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -230,7 +242,7 @@ Strict Transport Security
 Referrer Policy
 ~~~~~~~~~~~~~~~
 
-:optional:
+*Optional*
 
 .. tab-set::
 
@@ -254,13 +266,13 @@ The following settings manage how MinIO interacts with your Prometheus service.
 Prometheus URL
 ~~~~~~~~~~~~~~
 
+*Optional*
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_PROMETHEUS_URL
-
-         *Optional*
 
          Specify the URL for a Prometheus service configured to :ref:`scrape MinIO metrics <minio-metrics-collect-using-prometheus>`.
 
@@ -276,13 +288,13 @@ Prometheus URL
 Prometheus Job ID
 ~~~~~~~~~~~~~~~~~
 
+*Optional*
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_PROMETHEUS_JOB_ID
-
-         *Optional*
 
          Specify the custom Prometheus job ID used for :ref:`scraping MinIO metrics <minio-metrics-collect-using-prometheus>`. 
 
@@ -298,13 +310,13 @@ Prometheus Job ID
 Prometheus Auth Token
 ~~~~~~~~~~~~~~~~~~~~~
 
+*Optional*
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_PROMETHEUS_AUTH_TOKEN
-
-         *Optional*
 
          Specify the :prometheus-docs:`basic auth token <guides/basic-auth/>` the Console should use to connect to a Prometheus service.
 

--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -312,6 +312,7 @@ Examples
 
 The following examples show the rendered header for the given configuration settings.
 The equivalent environment variables generate the same result.
+All examples use a value of ``31536000``, which is the number of seconds in a calendar year (365 days).
 
 ``hsts_seconds``
 

--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -227,6 +227,17 @@ Other HSTS settings are optional.
    .. tab-item:: Environment Variables
       :sync: envvar
 
+      .. envvar:: MINIO_BROWSER_HSTS_SECONDS
+
+         The ``max_age`` the configured policy remains in effect, in seconds.
+         Defaults to ``0``, disabled.
+         You **must** configure a *non-zero* duration to enable the ``Strict-Transport-Security`` header.
+
+         .. code-block:: shell
+            :class: copyable
+
+            set MINIO_BROWSER_HSTS_SECONDS=31536000
+
       .. envvar:: MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS
 
          Set to ``on`` to also apply the configured HSTS policy to all MinIO Console subdomains.
@@ -247,7 +258,14 @@ Other HSTS settings are optional.
 
             set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
 
-      .. envvar:: MINIO_BROWSER_HSTS_SECONDS
+   .. tab-item:: Configuration Settings
+      :sync: config
+
+      The following configuration settings require a service restart to take effect.
+      To restart the service, use :mc-cmd:`mc admin service restart`.
+
+      .. mc-conf:: browser hsts_seconds
+         :delimiter: " "
 
          The ``max_age`` the configured policy remains in effect, in seconds.
          Defaults to ``0``, disabled.
@@ -256,13 +274,9 @@ Other HSTS settings are optional.
          .. code-block:: shell
             :class: copyable
 
-            set MINIO_BROWSER_HSTS_SECONDS=31536000
-
-   .. tab-item:: Configuration Settings
-      :sync: config
-
-      The following configuration settings require a service restart to take effect.
-      You can do this with :mc-cmd:`mc admin service restart`.
+            mc admin config set browser \
+               hsts_seconds="31536000" \
+               [ARGUMENT=VALUE ...]
 
       .. mc-conf:: browser hsts_include_subdomains
          :delimiter: " "
@@ -289,20 +303,6 @@ Other HSTS settings are optional.
 
             mc admin config set browser \
                hsts_preload="on" \
-               hsts_seconds="31536000" \
-               [ARGUMENT=VALUE ...]
-
-      .. mc-conf:: browser hsts_seconds
-         :delimiter: " "
-
-         The ``max_age`` the configured policy remains in effect, in seconds.
-         Defaults to ``0``, disabled.
-         You **must** configure a *non-zero* duration to enable the ``Strict-Transport-Security`` header.
-
-         .. code-block:: shell
-            :class: copyable
-
-            mc admin config set browser \
                hsts_seconds="31536000" \
                [ARGUMENT=VALUE ...]
 

--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -24,13 +24,13 @@ The following settings control behavior for the embedded MinIO Console.
 MinIO Console
 ~~~~~~~~~~~~~
 
+:optional:
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_BROWSER
-
-         *Optional*
 
          Specify ``off`` to disable the embedded MinIO Console.
 
@@ -42,13 +42,13 @@ MinIO Console
 Animation
 ~~~~~~~~~
 
+:optional:
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_BROWSER_LOGIN_ANIMATION
-
-         *Optional*
 
          .. versionadded:: MinIO Server RELEASE.2023-05-04T21-44-30Z
 
@@ -61,6 +61,8 @@ Animation
 
 Browser Redirect
 ~~~~~~~~~~~~~~~~
+
+:optional:
 
 .. tab-set::
 
@@ -81,13 +83,13 @@ Browser Redirect
 Browser Redirect URL
 ~~~~~~~~~~~~~~~~~~~~
 
+:optional:
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_BROWSER_REDIRECT_URL
-
-         *Optional*
 
          Specify the Fully Qualified Domain Name (FQDN) the MinIO Console listens for incoming connections on.
    
@@ -106,13 +108,13 @@ Browser Redirect URL
 Session Duration
 ~~~~~~~~~~~~~~~~
 
+:optional:
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_BROWSER_SESSION_DURATION
-
-         *Optional*
 
          .. versionadded:: MinIO Server RELEASE.2023-08-23T10-07-06Z
 
@@ -135,13 +137,13 @@ Session Duration
 Server URL
 ~~~~~~~~~~
 
+:optional:
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_SERVER_URL
-
-         *Optional*
 
          Specify the Fully Qualified Domain Name (FQDN) the MinIO Console must use for connecting to the MinIO Server.
          The Console also uses this value for setting the root hostname when generating presigned URLs.
@@ -160,13 +162,13 @@ Server URL
 Log Query URL
 ~~~~~~~~~~~~~
 
+:optional:
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
 
       .. envvar:: MINIO_LOG_QUERY_URL
-
-         *Optional*
 
          Specify the URL of a PostgreSQL service to which MinIO writes :ref:`Audit logs <minio-logging-publish-audit-logs>`. 
          The embedded MinIO Console provides a Log Search tool that allows querying the PostgreSQL service for collected logs.
@@ -175,6 +177,74 @@ Log Query URL
 
       This setting does not have a configuration variable setting.
       Use the Environment Variable instead.
+
+Content Security Policy
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:optional:
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+
+      .. envvar:: MINIO_BROWSER_CONTENT_SECURITY_POLICY
+
+
+   .. tab-item:: Configuration Setting
+
+      .. mc-conf:: csp_policy
+         :delimiter: " "
+
+
+
+Strict Transport Security
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:optional:
+
+.. tab-set::
+
+   .. tab-item:: Environment Variables
+
+      .. envvar:: MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS
+
+
+      .. envvar:: MINIO_BROWSER_HSTS_PRELOAD
+
+
+      .. envvar:: MINIO_BROWSER_HSTS_SECONDS
+
+
+   .. tab-item:: Configuration Settings
+
+      .. mc-conf:: hsts_include_subdomains
+         :delimiter: " "
+		     
+      .. mc-conf:: hsts_preload
+         :delimiter: " "
+		     
+      .. mc-conf:: hsts_seconds
+         :delimiter: " "
+
+
+Referrer Policy
+~~~~~~~~~~~~~~~
+
+:optional:
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+
+      .. envvar:: MINIO_BROWSER_REFERRER_POLICY
+
+
+   .. tab-item:: Configuration Setting
+
+      .. mc-conf:: referrer_policy
+         :delimiter: " "
+
+
 
 Prometheus Settings
 -------------------

--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -318,36 +318,36 @@ The equivalent environment variables generate the same result.
   .. code-block:: shell
      :class: copyable
 
-     mc admin config set ALIAS browser hsts_seconds=500
+     mc admin config set ALIAS browser hsts_seconds=31536000
 
   .. code-block:: shell
      :class: copyable
 
-     Strict-Transport-Security: max-age=500
+     Strict-Transport-Security: max-age=31536000
 
 ``hsts_include_subdomains``
 
   .. code-block:: shell
      :class: copyable
 
-     mc admin config set ALIAS browser hsts_seconds=500 hsts_include_subdomains=on
+     mc admin config set ALIAS browser hsts_seconds=31536000 hsts_include_subdomains=on
 
   .. code-block:: shell
      :class: copyable
 
-     Strict-Transport-Security: max-age=500; includeSubDomains
+     Strict-Transport-Security: max-age=31536000; includeSubDomains
 
 ``hsts_preload``
 
   .. code-block:: shell
      :class: copyable
 
-     mc admin config set ALIAS browser hsts_seconds=500 hsts_include_subdomains=on hsts_preload=on
+     mc admin config set ALIAS browser hsts_seconds=31536000 hsts_include_subdomains=on hsts_preload=on
 
   .. code-block:: shell
      :class: copyable
 
-     Strict-Transport-Security: max-age=500; includeSubDomains; preload
+     Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 
 
 Referrer Policy

--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -193,10 +193,10 @@ Defaults to ``default-src 'self' 'unsafe-eval' 'unsafe-inline';``
 
       .. envvar:: MINIO_BROWSER_CONTENT_SECURITY_POLICY
 
-      .. code-block:: shell
-         :class: copyable
+         .. code-block:: shell
+            :class: copyable
 
-         set MINIO_BROWSER_CONTENT_SECURITY_POLICY="default-src 'self' 'unsafe-eval' 'unsafe-inline';"
+            set MINIO_BROWSER_CONTENT_SECURITY_POLICY="default-src 'self' 'unsafe-eval' 'unsafe-inline';"
 
    .. tab-item:: Configuration Setting
       :sync: config
@@ -204,11 +204,12 @@ Defaults to ``default-src 'self' 'unsafe-eval' 'unsafe-inline';``
       .. mc-conf:: browser csp_policy
          :delimiter: " "
 
-      .. code-block:: shell
-
-         mc admin config set browser \
-            csp_policy="default-src 'self' 'unsafe-eval' 'unsafe-inline';" \
-            [ARGUMENT=VALUE ...]
+         .. code-block:: shell
+            :class: copyable
+		 
+            mc admin config set browser \
+               csp_policy="default-src 'self' 'unsafe-eval' 'unsafe-inline';" \
+               [ARGUMENT=VALUE ...]
 
 
 Strict Transport Security
@@ -216,8 +217,9 @@ Strict Transport Security
 
 *Optional*
 
-Set the `Strict-Transport-Security <https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>`__ header in MinIO Console responses.
-Set the appropriate environment variable or configuration settings according to the HSTS requirements for your environment.
+Configure MinIO console to generate a `Strict-Transport-Security <https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>`__ header in its responses.
+
+To generate the header, you **must** set a duration using either :envvar:`MINIO_BROWSER_HSTS_SECONDS` or :mc-conf:`~browser.hsts_seconds`.
 
 .. tab-set::
 
@@ -226,65 +228,125 @@ Set the appropriate environment variable or configuration settings according to 
 
       .. envvar:: MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS
 
-         Set to ``on`` to append ``includeSubDomains`` to the ``Strict-Transport-Security`` header.
-	 Defaults to ``off``.
+         Set to ``on`` to also apply the configured HSTS policy to all MinIO Console subdomains.
+         Defaults to ``off``.
 
-      .. code-block:: shell
-         :class: copyable
+         .. code-block:: shell
+            :class: copyable
 
-         set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
-
+            set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
 
       .. envvar:: MINIO_BROWSER_HSTS_PRELOAD
 
-	 Set to ``on`` to include this header in the HSTS preloading list.
-	 Defaults to ``off``.
+         Set to ``on`` to direct the client browser to add the MinIO Console domain to its HSTS preload list.
+         Defaults to ``off``.
 
-      .. code-block:: shell
-         :class: copyable
+         .. code-block:: shell
+            :class: copyable
 
-         set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
+            set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
 
       .. envvar:: MINIO_BROWSER_HSTS_SECONDS
 
-	 The ``max_age`` the configured policy remains in effect, in seconds. 
-	 Defaults to ``0``.
+         The ``max_age`` the configured policy remains in effect, in seconds.
+         Defaults to ``0``, disabled.
+         You **must** configure a *non-zero* duration to enable the ``Strict-Transport-Security`` header.
 
-      .. code-block:: shell
-         :class: copyable
+         .. code-block:: shell
+            :class: copyable
 
-         set MINIO_BROWSER_HSTS_SECONDS=31536000
+            set MINIO_BROWSER_HSTS_SECONDS=31536000
 
    .. tab-item:: Configuration Settings
       :sync: config
 
+      The following configuration settings require a service restart to take effect.
+      You can do this with :mc-cmd:`mc admin service restart`.
+
       .. mc-conf:: browser hsts_include_subdomains
          :delimiter: " "
-		     
-      .. code-block:: shell
 
-         mc admin config set browser \
-            hsts_include_subdomains="on" \
-            [ARGUMENT=VALUE ...]
-	    
+         Set to ``on`` to also apply the configured HSTS policy to all MinIO Console subdomains.
+         Defaults to ``off``.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin config set browser \
+               hsts_include_subdomains="on" \
+               hsts_seconds="31536000" \
+               [ARGUMENT=VALUE ...]
+
       .. mc-conf:: browser hsts_preload
          :delimiter: " "
-     
-      .. code-block:: shell
 
-         mc admin config set browser \
-            hsts_preload="on" \
-            [ARGUMENT=VALUE ...]
-	    
+         Set to ``on`` to direct the client browser to add the MinIO Console domain to its HSTS preload list.
+         Defaults to ``off``.
+
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin config set browser \
+               hsts_preload="on" \
+               hsts_seconds="31536000" \
+               [ARGUMENT=VALUE ...]
+
       .. mc-conf:: browser hsts_seconds
          :delimiter: " "
-        	
-      .. code-block:: shell
 
-         mc admin config set browser \
-            hsts_seconds="0" \
-            [ARGUMENT=VALUE ...]
+         The ``max_age`` the configured policy remains in effect, in seconds.
+         Defaults to ``0``, disabled.
+         You **must** configure a *non-zero* duration to enable the ``Strict-Transport-Security`` header.
 
+         .. code-block:: shell
+            :class: copyable
+
+            mc admin config set browser \
+               hsts_seconds="31536000" \
+               [ARGUMENT=VALUE ...]
+
+
+Examples
+++++++++
+
+The following examples show the rendered header for the given configuration settings.
+The equivalent environment variables generate the same result.
+
+``hsts_seconds``
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc admin config set play browser hsts_seconds=500
+
+  .. code-block:: shell
+     :class: copyable
+
+     Strict-Transport-Security: max-age=500
+
+``hsts_include_subdomains``
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc admin config set play browser hsts_seconds=500 hsts_include_subdomains=on
+
+  .. code-block:: shell
+     :class: copyable
+
+     Strict-Transport-Security: max-age=500; includeSubDomains
+
+``hsts_preload``
+
+  .. code-block:: shell
+     :class: copyable
+
+     mc admin config set play browser hsts_seconds=500 hsts_include_subdomains=on hsts_preload=on
+
+  .. code-block:: shell
+     :class: copyable
+
+     Strict-Transport-Security: max-age=500; includeSubDomains; preload
 
 
 Referrer Policy
@@ -302,10 +364,10 @@ Defaults to ``strict-origin-when-cross-origin``.
 
       .. envvar:: MINIO_BROWSER_REFERRER_POLICY
 
-      .. code-block:: shell
-         :class: copyable
+         .. code-block:: shell
+            :class: copyable
 
-         set MINIO_BROWSER_REFERRER_POLICY="strict-origin-when-cross-origin"
+            set MINIO_BROWSER_REFERRER_POLICY="strict-origin-when-cross-origin"
 
    .. tab-item:: Configuration Setting
       :sync: config
@@ -313,11 +375,11 @@ Defaults to ``strict-origin-when-cross-origin``.
       .. mc-conf:: browser referrer_policy
          :delimiter: " "
 
-      .. code-block:: shell
+         .. code-block:: shell
 
-         mc admin config set browser \
-            referrer_policy="strict-origin-when-cross-origin" \
-            [ARGUMENT=VALUE ...]
+            mc admin config set browser \
+               referrer_policy="strict-origin-when-cross-origin" \
+               [ARGUMENT=VALUE ...]
 
 
 Prometheus Settings

--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -183,7 +183,7 @@ Content Security Policy
 
 *Optional*
 
-Set the `Content-Security-Policy <https://en.wikipedia.org/wiki/Content_Security_Policy>`__ header in MinIO Console responses.
+Configure MinIO Console to generate a `Content-Security-Policy <https://en.wikipedia.org/wiki/Content_Security_Policy>`__ header in HTTP responses.
 Defaults to ``default-src 'self' 'unsafe-eval' 'unsafe-inline';``
 
 .. tab-set::
@@ -217,9 +217,10 @@ Strict Transport Security
 
 *Optional*
 
-Configure MinIO console to generate a `Strict-Transport-Security <https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>`__ header in its responses.
+Configure MinIO console to generate a `Strict-Transport-Security <https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>`__ header in HTTP responses.
 
 To generate the header, you **must** set a duration using either :envvar:`MINIO_BROWSER_HSTS_SECONDS` or :mc-conf:`~browser.hsts_seconds`.
+Other HSTS settings are optional.
 
 .. tab-set::
 
@@ -317,7 +318,7 @@ The equivalent environment variables generate the same result.
   .. code-block:: shell
      :class: copyable
 
-     mc admin config set play browser hsts_seconds=500
+     mc admin config set ALIAS browser hsts_seconds=500
 
   .. code-block:: shell
      :class: copyable
@@ -329,7 +330,7 @@ The equivalent environment variables generate the same result.
   .. code-block:: shell
      :class: copyable
 
-     mc admin config set play browser hsts_seconds=500 hsts_include_subdomains=on
+     mc admin config set ALIAS browser hsts_seconds=500 hsts_include_subdomains=on
 
   .. code-block:: shell
      :class: copyable
@@ -341,7 +342,7 @@ The equivalent environment variables generate the same result.
   .. code-block:: shell
      :class: copyable
 
-     mc admin config set play browser hsts_seconds=500 hsts_include_subdomains=on hsts_preload=on
+     mc admin config set ALIAS browser hsts_seconds=500 hsts_include_subdomains=on hsts_preload=on
 
   .. code-block:: shell
      :class: copyable
@@ -354,7 +355,7 @@ Referrer Policy
 
 *Optional*
 
-Set the `Referrer-Policy <https://www.w3.org/TR/referrer-policy/>`__ header in MinIO Console responses.
+Configure MinIO Console to generate a `Referrer-Policy <https://www.w3.org/TR/referrer-policy/>`__ header in HTTP responses.
 Defaults to ``strict-origin-when-cross-origin``.
 
 .. tab-set::


### PR DESCRIPTION
New settings to configure security headers for requests returned from MinIO Console.

- `Content-Security-Policy`
- `Strict-Transport-Security`
- `Referrer-Policy`

Staged
http://192.241.195.202:9000/staging/DOCS-1102/linux/reference/minio-server/settings/console.html#content-security-policy

Partially addresses https://github.com/minio/docs/issues/1102