### PR TITLE
Allow links into closed tabs

### DIFF
--- a/source/_static/js/main.js
+++ b/source/_static/js/main.js
@@ -505,12 +505,9 @@ window.addEventListener("DOMContentLoaded", (event) => {
     }
   })();
 
-// ------------------------------------------------
-// Tab switching for hidden anchors
-// ------------------------------------------------
-
-  // Target ID - where the browser should scroll to
-  const hashElem = document.getElementById(window.location.hash.substring(1));
+  // ------------------------------------------------
+  // Tab switching for hidden anchors
+  // ------------------------------------------------
 
   // If the element is hidden, neither scrollIntoView nor hashScroll will work.
   // This function checks whether the element is visible or not.
@@ -518,22 +515,43 @@ window.addEventListener("DOMContentLoaded", (event) => {
     var style = window.getComputedStyle(elem);
     return (elem.offsetWidth > 0 || elem.offsetHeight > 0) && style.display !== 'none' && style.visibility !== 'hidden';
   }
-
-  // Check if the hash is valid
-  // If it is, but not visible, the corresponding tab is also not visible.
-  // Make the tab active and scroll to it
-  if(hashElem) {
-    if(!isHashElemeVisible(hashElem)) {
-      hashElem.closest(".sd-tab-content").previousElementSibling.click();
-
-      setTimeout(() => {
-        hashElem.scrollIntoView();
-      }, 100);
-    }
-    else {
-      hashElem.scrollIntoView();
+  
+  function hashScroll() {
+    // Target ID - where the browser should scroll to
+    const hashElem = document.getElementById(window.location.hash.substring(1));
+  
+    // Check if the hash is valid
+    // If it is, but not visible, the corresponding tab is also not visible.
+    // Make the tab active and scroll to it
+    if(hashElem) {
+      if(!isHashElemeVisible(hashElem)) {
+        hashElem.closest(".sd-tab-content").previousElementSibling.click();
+  
+        setTimeout(() => {
+          hashElem.scrollIntoView({ behavior: 'smooth' });
+        }, 100);
+      }
+      else {
+        hashElem.scrollIntoView({ behavior: 'smooth' });
+      }
     }
   }
+  
+  // Listen for hash changes
+  window.addEventListener("hashchange", () => {
+    hashScroll();
+  });
+
+  // Listen for click events on internal references
+  const references = document.querySelectorAll("a.reference.internal");
+
+  if(references.length > 0) {
+    references.forEach((item) => {
+      item.addEventListener("click", () => {
+        hashScroll();
+      });
+    });
+  }
+  
+  hashScroll()
 });
-
-

--- a/source/_static/js/main.js
+++ b/source/_static/js/main.js
@@ -504,15 +504,36 @@ window.addEventListener("DOMContentLoaded", (event) => {
       });
     }
   })();
+
 // ------------------------------------------------
 // Tab switching for hidden anchors
 // ------------------------------------------------
 
-    document.getElementById((document.getElementById(window.location.hash.substring(1)))
-        .closest("div")
-        .previousSibling.getAttributes("for"))
-    .click();
+  // Target ID - where the browser should scroll to
+  const hashElem = document.getElementById(window.location.hash.substring(1));
 
+  // If the element is hidden, neither scrollIntoView nor hashScroll will work.
+  // This function checks whether the element is visible or not.
+  function isHashElemeVisible(elem) {
+    var style = window.getComputedStyle(elem);
+    return (elem.offsetWidth > 0 || elem.offsetHeight > 0) && style.display !== 'none' && style.visibility !== 'hidden';
+  }
+
+  // Check if the hash is valid
+  // If it is, but not visible, the corresponding tab is also not visible.
+  // Make the tab active and scroll to it
+  if(hashElem) {
+    if(!isHashElemeVisible(hashElem)) {
+      hashElem.closest(".sd-tab-content").previousElementSibling.click();
+
+      setTimeout(() => {
+        hashElem.scrollIntoView();
+      }, 100);
+    }
+    else {
+      hashElem.scrollIntoView();
+    }
+  }
 });
 
 

--- a/source/_static/js/main.js
+++ b/source/_static/js/main.js
@@ -504,6 +504,15 @@ window.addEventListener("DOMContentLoaded", (event) => {
       });
     }
   })();
+// ------------------------------------------------
+// Tab switching for hidden anchors
+// ------------------------------------------------
+
+    document.getElementById((document.getElementById(window.location.hash.substring(1)))
+        .closest("div")
+        .previousSibling.getAttributes("for"))
+    .click();
+
 });
 
 

--- a/source/_static/js/main.js
+++ b/source/_static/js/main.js
@@ -505,3 +505,11 @@ window.addEventListener("DOMContentLoaded", (event) => {
     }
   })();
 });
+
+
+window.addEventListener("hashchange", function() {
+  document.getElementById((document.getElementById(window.location.hash.substring(1)))
+          .closest("div")
+	  .previousSibling.getAttribute("for"))
+        .click();
+});

--- a/source/_static/js/main.js
+++ b/source/_static/js/main.js
@@ -537,9 +537,3 @@ window.addEventListener("DOMContentLoaded", (event) => {
 });
 
 
-window.addEventListener("hashchange", function() {
-  document.getElementById((document.getElementById(window.location.hash.substring(1)))
-          .closest("div")
-	  .previousSibling.getAttribute("for"))
-        .click();
-});

--- a/source/_static/scss/includes/_base.scss
+++ b/source/_static/scss/includes/_base.scss
@@ -11,7 +11,6 @@
 
 html {
     font-size: $root-font-size;
-    scroll-behavior: smooth;
     scroll-padding: 1rem;
 
     @include breakpoint-min(breakpoints(lg)) { 

--- a/source/_static/scss/includes/_layout.scss
+++ b/source/_static/scss/includes/_layout.scss
@@ -48,7 +48,6 @@
         .content {
             @include breakpoint-min(breakpoints(lg)) { 
                 overflow: auto;
-                scroll-behavior: smooth;
                 scroll-padding: 2rem;
             }
 


### PR DESCRIPTION
JS update to allow a link into a closed tab. 

Tested with 
```
:mc-conf:`~browser.hsts_seconds`
```
which goes to a tab in [this section](https://min.io/docs/minio/linux/reference/minio-server/settings/console.html#strict-transport-security)

@rushenn Ravind and Andrea came up with this, need a JS intervention to ensure it's actually reasonable. 🙏🏻 

Staged
http://192.241.195.202:9000/staging/link-into-tab/linux/reference/minio-server/settings/console.html#strict-transport-security