### PR TITLE
Add --action for mc undo

### DIFF
--- a/source/reference/minio-mc/mc-undo.rst
+++ b/source/reference/minio-mc/mc-undo.rst
@@ -63,12 +63,28 @@ Parameters
 .. mc-cmd:: --action
    :optional:
 
-   For recursive undo of the most recent change, specify the type of operation to undo.
+   Undo the most recent change of the specified type.
    Accepted values are ``DELETE`` or ``PUT``.
-   Requires :mc-cmd:`~mc undo --recursive` and is mutually exclusive with :mc-cmd:`~mc undo --last`.
-   
-   By default, :mc:`mc undo` reverses both ``DELETE`` and ``PUT``.
-   Use :mc-cmd:`~mc undo --action` to choose one or the other, but only for recursive undo of the most recent change.
+
+   By default, :mc:`mc undo` reverses both ``DELETE`` and ``PUT`` operations.
+   Use :mc-cmd:`~mc undo --action` to choose one or the other, but only for the most recent operation of the specified type.
+
+   The following command undoes the most recent ``PUT`` for the file ``today.zip`` in bucket ``data``:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc undo myminio/data/today.zip --action "PUT"
+
+   This example undoes the most recent ``DELETE`` for the prefix ``archive`` and any child objects:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc undo myminio/data/today.zip --action "PUT"
+      mc undo myminio/data/archive --recursive --action "DELETE"
+
+   Mutually exclusive with :mc-cmd:`~mc undo --last`.
 
 .. mc-cmd:: --dry-run
    :optional:

--- a/source/reference/minio-mc/mc-undo.rst
+++ b/source/reference/minio-mc/mc-undo.rst
@@ -39,11 +39,12 @@ The :mc:`mc undo` command reverses changes due to either a ``PUT`` or ``DELETE``
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] undo               \
-                          TARGET             \
-                          [--last "integer"] \
-                          [--recursive, r]   \
-                          [--force]          \
+         mc [GLOBALFLAGS] undo                \
+                          TARGET              \
+                          [--action "type"]*  \
+                          [--force]           \
+                          [--last "integer"]* \
+                          [--recursive, r]*   \
                           [--dry-run]
 
       .. include:: /includes/common-minio-mc.rst
@@ -59,29 +60,40 @@ Parameters
    The full path to the object or prefix where the command should run.
    The path must include the :ref:`ALIAS <minio-mc-alias>`, bucket, and prefix or object name.
 
-.. mc-cmd:: --last
+.. mc-cmd:: --action
    :optional:
 
-   Accepts an integer value specifying the number of ``PUT`` and/or ``DELETE`` changes to undo.
+   For recursive undo of the most recent change, specify the type of operation to undo.
+   Accepted values are ``DELETE`` or ``PUT``.
+   Requires :mc-cmd:`~mc undo --recursive` and is mutually exclusive with :mc-cmd:`~mc undo --last`.
    
-   If not specified, the command undoes one (``1``) operation.
-
-.. mc-cmd:: --recursive, r
-   :optional:
-
-   Performs the command in a recursive fashion.
-   Use this flag to undo changes on a prefix, for example.
-
-.. mc-cmd:: --force
-   :optional:
-
-   Force a recursive operation.
+   By default, :mc:`mc undo` reverses both ``DELETE`` and ``PUT``.
+   Use :mc-cmd:`~mc undo --action` to choose one or the other, but only for recursive undo of the most recent change.
 
 .. mc-cmd:: --dry-run
    :optional:
 
    Output the results of the command without actually performing the operations.
    Use this flag to test the outcome of running the command in a particular way.
+
+.. mc-cmd:: --force
+   :optional:
+
+   Force a recursive operation.
+
+.. mc-cmd:: --last
+   :optional:
+
+   Accepts an integer value specifying the number of ``PUT`` and/or ``DELETE`` changes to undo.
+   
+   If not specified, the command undoes one (``1``) operation.
+   Mutually exclusive with :mc-cmd:`~mc undo --action`.
+
+.. mc-cmd:: --recursive, r
+   :optional:
+
+   Performs the command in a recursive fashion.
+   Use this flag to undo changes on a prefix, for example.
 
 
 Global Flags

--- a/source/reference/minio-mc/mc-undo.rst
+++ b/source/reference/minio-mc/mc-undo.rst
@@ -41,15 +41,16 @@ The :mc:`mc undo` command reverses changes due to either a ``PUT`` or ``DELETE``
 
          mc [GLOBALFLAGS] undo                \
                           TARGET              \
-                          [--action "type"]*  \
+                          [--action "type"]   \
                           [--force]           \
-                          [--last "integer"]* \
-                          [--recursive, r]*   \
+                          [--last "integer"]  \
+                          [--recursive, r]    \
                           [--dry-run]
 
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
          :end-before: end-minio-syntax
+
 
 Parameters
 ~~~~~~~~~~

--- a/source/reference/minio-mc/mc-undo.rst
+++ b/source/reference/minio-mc/mc-undo.rst
@@ -25,7 +25,7 @@ The :mc:`mc undo` command reverses changes due to either a ``PUT`` or ``DELETE``
 
    .. tab-item:: EXAMPLE
 
-      The following command undoes the last three uploads and/or removals of the ``file.zip`` object on the ``myminio`` deployment in the ``data`` bucket:
+      The following command reverts the last three uploads and/or deletions of the ``file.zip`` object on the ``myminio`` deployment in the ``data`` bucket:
 
       .. code-block:: shell
          :class: copyable
@@ -69,19 +69,18 @@ Parameters
    By default, :mc:`mc undo` reverses both ``DELETE`` and ``PUT`` operations.
    Use :mc-cmd:`~mc undo --action` to choose one or the other, but only for the most recent operation of the specified type.
 
-   The following command undoes the most recent ``PUT`` for the file ``today.zip`` in bucket ``data``:
+   The following command reverts the most recent ``PUT`` for the object ``today.zip`` in bucket ``data``, reverting to the previous object version:
 
    .. code-block:: shell
       :class: copyable
 
       mc undo myminio/data/today.zip --action "PUT"
 
-   This example undoes the most recent ``DELETE`` for the prefix ``archive`` and any child objects:
+   This example reverts the most recent ``DELETE`` for the prefix ``archive``, recursively restoring it and any child objects:
 
    .. code-block:: shell
       :class: copyable
 
-      mc undo myminio/data/today.zip --action "PUT"
       mc undo myminio/data/archive --recursive --action "DELETE"
 
    Mutually exclusive with :mc-cmd:`~mc undo --last`.
@@ -102,7 +101,7 @@ Parameters
 
    Accepts an integer value specifying the number of ``PUT`` and/or ``DELETE`` changes to undo.
    
-   If not specified, the command undoes one (``1``) operation.
+   If not specified, the command reverses one (``1``) operation.
    Mutually exclusive with :mc-cmd:`~mc undo --action`.
 
 .. mc-cmd:: --recursive, r
@@ -125,7 +124,7 @@ Examples
 Undo the Last Three Uploads or Deletions on an Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following command undoes the last three uploads and/or removals of the ``file.zip`` object on the ``myminio`` deployment in the ``data`` bucket:
+The following command reverts the last three uploads and/or deletions of the ``file.zip`` object on the ``myminio`` deployment in the ``data`` bucket:
 
 .. code-block:: shell
    :class: copyable


### PR DESCRIPTION
Document new option for `mc undo` to restrict the command to reverse either `DELETE` or `PUT` operations, not both.

Staged
http://192.241.195.202:9000/staging/DOCS-1113/linux/reference/minio-mc/mc-undo.html

Fixes https://github.com/minio/docs/issues/1113