### PR TITLE
Small docs fixes and cleanups

### DIFF
--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -166,7 +166,7 @@ Object Retention
 ----------------
 
 MinIO Object Locking ("Object Retention") enforces Write-Once Read-Many (WORM) immutability to protect :ref:`versioned objects <minio-bucket-versioning>` from deletion. 
-MinIO supports both :ref:`duration based object retention <minio-object-locking-retention-modes>` and :ref:`indefinite Legal Hold retention <minio-object-locking-legalhold>`.
+MinIO supports both :ref:`duration based object retention <minio-object-locking-retention-modes>` and :ref:`indefinite legal hold retention <minio-object-locking-legalhold>`.
 
 .. image:: /images/retention/minio-object-locking.svg
    :alt: 30 Day Locked Objects

--- a/source/administration/object-management/object-retention.rst
+++ b/source/administration/object-management/object-retention.rst
@@ -24,7 +24,7 @@ immutability to protect :ref:`versioned objects <minio-bucket-versioning>` from
 deletion. MinIO supports both 
 :ref:`duration based object retention <minio-object-locking-retention-modes>` 
 and 
-:ref:`indefinite Legal Hold retention <minio-object-locking-legalhold>`.
+:ref:`indefinite legal hold retention <minio-object-locking-legalhold>`.
 
 MinIO Object Locking provides key data retention compliance and meets
 SEC17a-4(f), FINRA 4511(C), and CFTC 1.31(c)-(d) requirements as per 
@@ -155,7 +155,7 @@ the expiration rule.
 
 - For expiration rules operating on *non-current object versions*, 
   MinIO can only expire the non-current versions *after* the retention period
-  has passed *or* has been explicitly lifted (e.g. Legal Holds).
+  has passed *or* has been explicitly lifted (e.g. legal holds).
 
 For example, consider the following bucket with 
 :ref:`minio-object-locking-governance` locking enabled by default for 45 days:
@@ -306,7 +306,7 @@ preferred SDK.
 Enable Legal Hold Retention
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can enable or disable indefinite Legal Hold retention for an object using the MinIO Console, the MinIO :mc:`mc` CLI, or using an S3-compatible SDK. 
+You can enable or disable indefinite legal hold retention for an object using the MinIO Console, the MinIO :mc:`mc` CLI, or using an S3-compatible SDK. 
 
 You can place a legal hold on an object already held under a :ref:`COMPLIANCE <minio-object-locking-compliance>` or :ref:`GOVERNANCE <minio-object-locking-governance>` lock. 
 The object remains WORM locked under the legal hold even when the retention lock expires. 
@@ -333,7 +333,7 @@ You or another user with the necessary permissions must explicitly lift the lega
          :align: center
 
       Browse to the object and select it to open the object details view. 
-      Select the :guilabel:`Legal Hold` button to toggle the Legal Hold status of the object.
+      Select the :guilabel:`Legal Hold` button to toggle the legal hold status of the object.
 
    .. tab-item:: MinIO CLI
       :sync: cli
@@ -426,11 +426,14 @@ The MinIO ``COMPLIANCE`` lock is functionally identical to the
 Legal Hold
 ----------
 
-An object under Legal Hold is protected from write operations by *all* 
+An object under legal hold is protected from write operations by *all* 
 users, including the :ref:`MinIO root <minio-users-root>` user. 
 
-Legal Holds are indefinite and enforce complete immutability for locked objects.
-Only privileged users with the :policy-action:`s3:PutObjectLegalHold` permission can set or lift the Legal Hold.
+Legal holds are indefinite and enforce complete immutability for locked objects.
+Only privileged users with the :policy-action:`s3:PutObjectLegalHold` permission can set or lift the legal hold.
+
+Legal holds apply at the object level.
+If you enable legal hold for a group of objects, such as the contents of a bucket, subsequently created objects in that bucket are not affected.
 
 Legal holds are complementary to both :ref:`minio-object-locking-governance` and :ref:`minio-object-locking-compliance` retention settings. 
 An object held under both legal hold *and* a ``GOVERNANCE/COMPLIANCE`` retention rule remains WORM locked until the legal hold is lifted *and* the rule expires.

--- a/source/includes/facts-versioning.rst
+++ b/source/includes/facts-versioning.rst
@@ -28,7 +28,7 @@ that supports :ref:`minio-bucket-versioning`. For MinIO deployments, use
 
 .. start-version-id-desc
 
-*Optional* Directs |command| to operate only on the specified object version.
+Directs |command| to operate only on the specified object version.
 
 |versionid| requires that the specified |alias| be an S3-compatible service
 that supports :ref:`minio-bucket-versioning`. For MinIO deployments, use

--- a/source/operations/data-recovery/recover-after-site-failure.rst
+++ b/source/operations/data-recovery/recover-after-site-failure.rst
@@ -13,7 +13,7 @@ Site Failure Recovery
 MinIO can make the loss of an entire site, while significant, a relatively minor incident.
 Site recovery depends on the replication option you use for the site.
 
-.. list-table:: 
+.. list-table::
    :widths: 25 75
    :width: 100%
 
@@ -28,7 +28,7 @@ Site replication healing automatically adds IAM settings, buckets, bucket config
 
 You cannot configure site replication if any bucket replication rules remain in place on other healthy sites.
 Bucket replication is mutually exclusive with site replication.
-  
+
 If you are switching from using bucket replication to using site replication, you must first remove all bucket replication rules from the healthy site prior to setting up site replication.
 
 Restore an Unhealthy Peer to Site Replication
@@ -47,8 +47,8 @@ If a peer site fails, such as due to a major disaster or long power outage, you 
 The following procedure can restore data in scenarios where :ref:`site replication <minio-site-replication-overview>` was active prior to the site loss.
 This procedure assumes a *total loss* of one or more peer sites versus replication lag or delays due to latency or transient deployment downtime.
 
-1. Remove the failed site from the MinIO site replication configuration using the :mc-cmd:`mc admin replicate rm` command with the ``--force`` option. 
-   
+#. Remove the failed site from the MinIO site replication configuration using the :mc-cmd:`mc admin replicate rm` command with the ``--force`` option. 
+
    The following command force-removes an unhealthy peer site from the replication configuration:
 
    .. code-block:: shell
@@ -63,7 +63,7 @@ This procedure assumes a *total loss* of one or more peer sites versus replicati
    All healthy peers in the site replication configuration update to remove the unhealthy peer automatically.
    You can use the :mc-cmd:`mc admin replicate info` command to verify the new site replication configuration.
 
-2. Deploy a new MinIO site following the :ref:`site replication requirements <minio-expand-site-replication>`.
+#. Deploy a new MinIO site following the :ref:`site replication requirements <minio-expand-site-replication>`.
 
    - Do not upload any data or otherwise configure the deployment beyond the stated requirements.
    - Validate that the new MinIO deployment functions normally and has bidirectional connectivity to the other peer sites.
@@ -76,7 +76,7 @@ This procedure assumes a *total loss* of one or more peer sites versus replicati
 
       If you plan to re-use the hardware for the site replication configuration, you **must** completely wipe the drives for the deployment before re-initializing MinIO and adding the site back to the replication configuration.
 
-3. :ref:`Add the replacement peer site <minio-expand-site-replication>` to the replication configuration.
+#. :ref:`Add the replacement peer site <minio-expand-site-replication>` to the replication configuration.
 
    Use the :mc-cmd:`mc admin replicate add` command to update the replication configuration with the new site:
 
@@ -92,7 +92,19 @@ This procedure assumes a *total loss* of one or more peer sites versus replicati
    All healthy peers in the site replication configuration update for the new peer automatically.
    You can use the :mc-cmd:`mc admin replicate info` command to verify the new site replication configuration.
 
-4. Validate the replication status.
+#. Resynchronize the new peer with :mc:`mc admin replicate resync`.
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc admin replicate resync start HEALTHY_PEER NEW_PEER
+
+   - Replace ``HEALTHY_PEER`` with the :ref:`alias <alias>` of any healthy peer in the replication configuration
+
+   - Replace ``NEW_PEER`` with the alias of the new peer
+
+
+#. Validate the replication status.
 
    Use the following commands to track the replication status:
 
@@ -105,13 +117,13 @@ Active Bucket Replication Resynchronization
 For scenarios where :ref:`bucket replication <minio-bucket-replication>` was in place prior to the failure, you can use :mc:`mc replicate resync` to restore data to a new site.
 Create a new site to replace the failed deployment, then synchronize the data from an existing, healthy, bucket replication-enabled deployment to the new site.
 
-1. Deploy a new MinIO site
-2. Set up IAM and users as needed
-3. On the site with data, create a new ``remote target`` using the :mc-cmd:`mc admin bucket remote add` command and record the ARN from the output
-4. From the site with the data, use the :mc-cmd:`mc replicate resync start` command with the ARN from the previous command to rebuild the bucket on the new site
-5. Wait for re-synchronization to complete (us :mc-cmd:`mc replicate resync status` to check)
-6. Set up bucket replication rule(s) from the new MinIO site to the existing target bucket(s)
-7. `(Optional)` Delete the bucket replication rules from the target deployment(s) to restore an active-passive replication scenario
+#. Deploy a new MinIO site.
+#. Set up IAM and users as needed.
+#. On the site with data, create a new ``remote target`` using the :mc-cmd:`mc admin bucket remote add` command and record the ARN from the output.
+#. From the site with the data, use the :mc-cmd:`mc replicate resync start` command with the ARN from the previous command to rebuild the bucket on the new site.
+#. Wait for re-synchronization to complete (use :mc-cmd:`mc replicate resync status` to check).
+#. Set up bucket replication rule(s) from the new MinIO site to the existing target bucket(s).
+#. `(Optional)` Delete the bucket replication rules from the target deployment(s) to restore an active-passive replication scenario.
 
 Passive Bucket Replication Resynchronization
 --------------------------------------------
@@ -126,12 +138,12 @@ For recovery procedures with stricter SLA/SLO, use the active bucket replication
 Bucket replication rules copy the object, its version ID, versions, and other metadata to the target bucket.
 MinIO can restore the object with all of these attributes to a new MinIO site if bucket replication had already been in use prior to the site loss.
 
-1. Deploy a new MinIO site
-2. Set up IAM and users as needed
-3. On the remaining target bucket deployment(s), create bucket replication rule(s) for each bucket to the new MinIO site
-4. Wait for replication to complete
-5. Set up bucket replication rule(s) from the new MinIO site to the existing target bucket(s)
-6. `(Optional)` Delete the bucket replication rules from the target deployment(s) to restore an active-passive replication scenario
+#. Deploy a new MinIO site.
+#. Set up IAM and users as needed.
+#. On the remaining target bucket deployment(s), create bucket replication rule(s) for each bucket to the new MinIO site.
+#. Wait for replication to complete.
+#. Set up bucket replication rule(s) from the new MinIO site to the existing target bucket(s).
+#. `(Optional)` Delete the bucket replication rules from the target deployment(s) to restore an active-passive replication scenario.
 
    Do not delete the bucket replication rules from the deployments used to recover data if you prefer to keep an active-active replication between the buckets.
    In active-active replication, changes to the objects at either location affect the objects at the other location.
@@ -147,7 +159,7 @@ You cannot restore those attributes with this method.
 Use :mc:`mc mirror` in situations where you need to restore only the latest version of an object. 
 Use bucket replication or site replication where those methods were already in use if you are copying from another MinIO deployment and wish to restore the object's version history and version metadata.
 
-1. Deploy a new MinIO site
-2. Set up IAM and users as needed
-3. Create buckets on the new site
-4. Use the :mc:`mc cp` CLI command to copy the contents from the mirror location to the new MinIO site
+#. Deploy a new MinIO site.
+#. Set up IAM and users as needed.
+#. Create buckets on the new site.
+#. Use the :mc:`mc cp` CLI command to copy the contents from the mirror location to the new MinIO site.

--- a/source/reference/minio-mc/mc-cat.rst
+++ b/source/reference/minio-mc/mc-cat.rst
@@ -68,8 +68,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The :ref:`alias <alias>` of a MinIO deployment and the full
+   The :ref:`alias <alias>` of a MinIO deployment and the full
    path to the object. For example:
 
    .. code-block:: shell
@@ -98,14 +99,14 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc
       :end-before: end-version-id-desc
 
 .. mc-cmd:: --encrypt-key
-   
+   :optional:
 
    Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.

--- a/source/reference/minio-mc/mc-cp.rst
+++ b/source/reference/minio-mc/mc-cp.rst
@@ -255,7 +255,7 @@ Parameters
       :start-after: start-rewind-desc
       :end-before: end-rewind-desc
 
-.. mc-cmd:: storage-class, sc
+.. mc-cmd:: --storage-class, sc
    :optional:
 
    Set the storage class for the new object(s) on the :mc-cmd:`~mc cp TARGET`. 
@@ -273,7 +273,7 @@ Parameters
    assign to the objects.
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-cp.rst
+++ b/source/reference/minio-mc/mc-cp.rst
@@ -185,7 +185,7 @@ Parameters
 .. mc-cmd:: --legal-hold
    :optional:
 
-   Enables indefinite :ref:`Legal Hold <minio-object-locking-legalhold>` object locking on the copied objects.
+   Enables indefinite :ref:`legal hold <minio-object-locking-legalhold>` object locking on the copied objects.
 
    Specify ``on``.
 

--- a/source/reference/minio-mc/mc-head.rst
+++ b/source/reference/minio-mc/mc-head.rst
@@ -67,8 +67,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The object or objects to print. 
+   The object or objects to print. 
    
    For an object on MinIO, specify the :ref:`alias <alias>` and the full path to
    that object (e.g. bucket and path to object). For example:
@@ -92,16 +93,16 @@ Parameters
       mc head ~/mydata/object.txt
 
 .. mc-cmd:: --lines, n
-   
+   :optional:
 
-   *Optional* The number of lines to print.
+   The number of lines to print.
 
    Defaults to ``10``.
 
 .. mc-cmd:: --encrypt-key
-   
+   :optional:
 
-   *Optional*  Encrypt or decrypt objects using server-side encryption with
+   Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
    
    - Each ``KEY`` represents a bucket or object. 
@@ -123,7 +124,7 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-legalhold-clear.rst
+++ b/source/reference/minio-mc/mc-legalhold-clear.rst
@@ -66,8 +66,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The MinIO :ref:`alias <alias>` and path to the object or
+   The MinIO :ref:`alias <alias>` and path to the object or
    objects on which to remove the legal hold. For example:
 
    .. code-block:: shell
@@ -75,7 +76,7 @@ Parameters
       mc legalhold clear play/mybucket/myobjects/objects.txt
 
 .. mc-cmd:: --recursive, r
-   
+   :optional:
 
    Removes the legal hold on all objects in the 
    :mc-cmd:`~mc legalhold clear ALIAS` bucket or bucket prefix.
@@ -88,7 +89,7 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-legalhold-info.rst
+++ b/source/reference/minio-mc/mc-legalhold-info.rst
@@ -65,8 +65,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The MinIO :ref:`alias <alias>` and path to the object or
+   The MinIO :ref:`alias <alias>` and path to the object or
    objects on which to enable the legal hold. For example:
 
    .. code-block:: shell
@@ -74,7 +75,7 @@ Parameters
       mc legalhold info play/mybucket/myobjects/objects.txt
 
 .. mc-cmd:: --recursive, r
-   
+   :optional:
 
    Returns the legal hold status of all objects in the 
    :mc-cmd:`~mc legalhold info ALIAS` bucket or bucket prefix.
@@ -87,7 +88,7 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-legalhold-set.rst
+++ b/source/reference/minio-mc/mc-legalhold-set.rst
@@ -37,7 +37,7 @@ documentation on creating buckets with object locking enabled.
 
    .. tab-item:: EXAMPLE
 
-      The following command enables legalhold WORM locking on all objects
+      The following command enables legalhold WORM locking on all existing objects
       in the ``mydata`` bucket on the ``myminio`` MinIO deployment:
 
       .. code-block:: shell
@@ -66,8 +66,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The MinIO :ref:`alias <alias>` and path to the object or
+   The MinIO :ref:`alias <alias>` and path to the object or
    objects on which to enable the legal hold. For example:
 
    .. code-block:: shell
@@ -75,10 +76,15 @@ Parameters
       mc legalhold set play/mybucket/myobjects/objects.txt
 
 .. mc-cmd:: --recursive, r
-   
+   :optional:
 
-   *Optional* Applies the legal hold to all objects in the 
+   Applies the legal hold to all existing objects in the 
    :mc-cmd:`~mc legalhold set ALIAS` bucket or bucket prefix.
+
+   .. admonition:: ``--recursive`` only applies to existing objects
+      :class: note
+
+      To enable legal hold for future objects, periodically repeat the :mc:`mc legalhold` command as new objects are created.
 
 .. mc-cmd:: --rewind
    :optional:
@@ -125,9 +131,9 @@ Behavior
 Legal Holds Require Explicit Removal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Legal Holds are indefinite and enforce complete immutability for locked objects.
+Legal holds are indefinite and enforce complete immutability for locked objects.
 Only privileged users with the :policy-action:`s3:PutObjectLegalHold` can set or
-lift the Legal Hold.
+lift the legal hold.
 
 Legal Holds Complement Other Retention Modes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-legalhold-set.rst
+++ b/source/reference/minio-mc/mc-legalhold-set.rst
@@ -94,7 +94,7 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-legalhold.rst
+++ b/source/reference/minio-mc/mc-legalhold.rst
@@ -16,7 +16,7 @@ Description
 
 .. start-mc-legalhold-desc
 
-The :mc:`mc legalhold` command sets, removes, or retrieves the :ref:`Object Legal Hold (WORM) <minio-object-locking-legalhold>` settings for object(s).
+The :mc:`mc legalhold` command sets, removes, or retrieves the :ref:`object legal hold (WORM) <minio-object-locking-legalhold>` settings for object(s).
 
 .. end-mc-legalhold-desc
 

--- a/source/reference/minio-mc/mc-retention-clear.rst
+++ b/source/reference/minio-mc/mc-retention-clear.rst
@@ -71,8 +71,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The full path to the object or objects for which to clear
+   The full path to the object or objects for which to clear
    the object lock configuration. Specify the :mc-cmd:`alias <mc alias>` of a
    configured S3-compatible service as the prefix to the ``ALIAS`` bucket
    path. For example:
@@ -92,18 +93,18 @@ Parameters
       settings for a specific version or for all versions of the object.
 
 .. mc-cmd:: --default
-   
+   :optional:
 
-   *Optional* Clears the default object lock settings for the bucket specified
+   Clears the default object lock settings for the bucket specified
    to :mc-cmd:`~mc retention clear ALIAS`.
    
    If specifying :mc-cmd:`~mc retention clear --default`, 
    :mc:`mc retention clear` ignores all other flags.
 
 .. mc-cmd:: --recursive, r
-   
+   :optional:
 
-   *Optional* Recursively clears the object lock settings for all objects in the
+   Recursively clears the object lock settings for all objects in the
    specified :mc-cmd:`~mc retention clear ALIAS` path.
 
    Mutually exclusive with :mc-cmd:`~mc retention clear --version-id`.
@@ -116,7 +117,7 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-retention-info.rst
+++ b/source/reference/minio-mc/mc-retention-info.rst
@@ -75,9 +75,8 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* 
-   
    The full path to the object for which to retrieve
    the object lock configuration. Specify the :ref:`alias <alias>` of a
    configured S3-compatible service as the prefix to the ``ALIAS`` bucket
@@ -99,18 +98,18 @@ Parameters
 
 
 .. mc-cmd:: --default
-   
+   :optional:
 
-   *Optional* Returns the default object lock settings for the bucket specified
+   Returns the default object lock settings for the bucket specified
    to :mc-cmd:`~mc retention info ALIAS`.
 
    If specifying :mc-cmd:`~mc retention info --default`, 
    :mc:`mc retention info` ignores all other flags.
 
 .. mc-cmd:: --recursive, r
-   
+   :optional:
 
-   *Optional* Recursively returns the object lock settings for all objects in the
+   Recursively returns the object lock settings for all objects in the
    specified :mc-cmd:`~mc retention info ALIAS` path.
 
    Mutually exclusive with :mc-cmd:`~mc retention info --version-id`.
@@ -123,7 +122,7 @@ Parameters
       :end-before: end-rewind-desc
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-retention-set.rst
+++ b/source/reference/minio-mc/mc-retention-set.rst
@@ -84,6 +84,7 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: MODE
+   :required:
 
    Sets the locking mode for the :mc-cmd:`~mc retention set ALIAS`. 
    Specify one of the following supported values:
@@ -98,6 +99,7 @@ Parameters
    Requires specifying :mc-cmd:`~mc retention set VALIDITY`.
 
 .. mc-cmd:: VALIDITY
+   :required:
 
    The duration which objects remain in the specified
    :mc-cmd:`~mc retention set MODE` after creation.
@@ -109,8 +111,7 @@ Parameters
       ``1y`` for 1 year after object creation.
 
 .. mc-cmd:: ALIAS
-
-   *Required* 
+   :required:
    
    The full path to the object or objects for which to set object lock
    configuration. Specify the :ref:`alias <alias>` for the MinIO or
@@ -132,16 +133,16 @@ Parameters
      respectively.
 
 .. mc-cmd:: --bypass
-   
+   :optional:
 
-   *Optional* Allows a user with the ``s3:BypassGovernanceRetention`` permission
+   Allows a user with the ``s3:BypassGovernanceRetention`` permission
    to modify the object. Requires the ``governance`` retention 
    :mc-cmd:`~mc retention set MODE`
 
 .. mc-cmd:: --default
-   
+   :optional:
 
-   *Optional* Sets the default object lock settings for the bucket specified to
+   Sets the default object lock settings for the bucket specified to
    :mc-cmd:`~mc retention set ALIAS` using the
    :mc-cmd:`~mc retention set MODE` and :mc-cmd:`~mc retention set VALIDITY`. 
    Any objects created in the bucket inherit the default object lock settings

--- a/source/reference/minio-mc/mc-share-download.rst
+++ b/source/reference/minio-mc/mc-share-download.rst
@@ -66,8 +66,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The :ref:`alias <alias>` of a MinIO deplyment and the full path to
+   The :ref:`alias <alias>` of a MinIO deplyment and the full path to
    the object for which to generate a download URL. For example:
 
    .. code-block:: shell
@@ -92,9 +93,9 @@ Parameters
       mc share download --recursive play/mybucket/myprefix/
 
 .. mc-cmd:: --expire, E
-   
+   :optional:
 
-   *Optional* Set the expiration time limit for all generated URLs.
+   Set the expiration time limit for all generated URLs.
    
    Specify a string with format ``##h##m##s`` format. For example:
    ``12h34m56s`` for an expiry of 12 hours, 34 minutes, and 56 seconds
@@ -103,15 +104,15 @@ Parameters
    Defaults to ``168h`` or 168 hours (7 days).
 
 .. mc-cmd:: --recursive, r
+   :optional:
    
-   
-   *Optional* Recursively generate URLs for all objects in a 
+   Recursively generate URLs for all objects in a 
    :mc-cmd:`mc share download ALIAS` bucket or bucket prefix. 
       
    Required if any ``ALIAS`` specifies a path to a bucket or bucket prefix.
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-stat.rst
+++ b/source/reference/minio-mc/mc-stat.rst
@@ -68,6 +68,7 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
    The :ref:`alias <alias>` of a MinIO deployment and the full path to the
    object for which to retrieve detailed information. For example:
@@ -97,9 +98,9 @@ Parameters
       mc stat ~/data/myobject.txt
 
 .. mc-cmd:: --encrypt-key
-   
+   :optional:
 
-   *Optional* Encrypt or decrypt objects using server-side encryption with
+   Encrypt or decrypt objects using server-side encryption with
    client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
    
    - Each ``KEY`` represents a bucket or object. 
@@ -114,9 +115,9 @@ Parameters
    as an alternative to specifying them on the command line.
 
 .. mc-cmd:: --recursive, r
-   
+   :optional:
 
-   *Optional* Recursively :mc:`mc stat` the contents of the MinIO bucket
+   Recursively :mc:`mc stat` the contents of the MinIO bucket
    specified to :mc-cmd:`~mc stat ALIAS`.
 
 .. mc-cmd:: --rewind
@@ -138,7 +139,7 @@ Parameters
    versions which existed at a specific point in time.
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-tag-list.rst
+++ b/source/reference/minio-mc/mc-tag-list.rst
@@ -63,8 +63,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The :ref:`alias <alias>` for a MinIO deployment and the
+   The :ref:`alias <alias>` for a MinIO deployment and the
    full path to the object for which to list all tags (e.g. bucket and path to
    object). For example:
 
@@ -98,7 +99,7 @@ Parameters
    object versions which existed at a specific point in time.
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-tag-remove.rst
+++ b/source/reference/minio-mc/mc-tag-remove.rst
@@ -62,8 +62,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The :ref:`alias <alias>` for a MinIO deployment and the
+   The :ref:`alias <alias>` for a MinIO deployment and the
    full path to the object on which to remove all tags (e.g. bucket and path to
    object). For example:
 
@@ -97,7 +98,7 @@ Parameters
    object versions which existed at a specific point in time.
 
 .. mc-cmd:: --version-id, vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc

--- a/source/reference/minio-mc/mc-tag-set.rst
+++ b/source/reference/minio-mc/mc-tag-set.rst
@@ -129,7 +129,7 @@ Parameters
    versions which existed at a specific point in time.
 
 .. mc-cmd:: --version-id, --vid
-   
+   :optional:
 
    .. include:: /includes/facts-versioning.rst
       :start-after: start-version-id-desc


### PR DESCRIPTION
Many small fixes:
- Clarify that `mc legalhold set --recursive` applies to current objects only. Go back and do it again if you want it to apply to newly created objects.
- Clean up inconsistent capitalization of "legal hold."
- Fix a bunch more `:required:` and `:optional:`
- Add a resync step to the restore site replication instructions

Staged:
http://192.241.195.202:9000/staging/small-clarifications/linux/index.html