### PR TITLE
Splits the helm chart reference page

### DIFF
--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -332,6 +332,9 @@ rst_prolog = """
 .. |SNMD| replace:: :abbr:`SNMD (Single-Node Multi-Drive)`
 .. |MNMD| replace:: :abbr:`MNMD (Multi-Node Multi-Drive)`
 .. |operator-version-stable| replace:: OPERATOR
+.. |helm-charts| replace:: `Helm Charts <https://github.com/minio/operator/tree/vOPERATOR/helm>`__
+.. |helm-operator-chart| replace:: `Helm Operator Charts <https://github.com/minio/operator/blob/vOPERATOR/helm/operator>`__
+.. |helm-tenant-chart| replace:: `Helm Tenant Charts <https://github.com/minio/operator/tree/vOPERATOR/helm/tenant>`__
 
 .. |cpp-sdk-version| replace:: CPPVERSION
 .. |dotnet-sdk-version| replace:: DOTNETVERSION

--- a/source/index.rst
+++ b/source/index.rst
@@ -213,6 +213,7 @@ For more about connecting to ``play``, see :ref:`MinIO Console play Login <minio
       /reference/kubectl-minio-plugin
       /reference/operator-crd
       /reference/operator-chart-values
+      /reference/tenant-chart-values
       /reference/operator-environment-variables
 
 .. toctree::

--- a/source/operations/install-deploy-manage/deploy-minio-tenant-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant-helm.rst
@@ -25,11 +25,11 @@ You cannot use the MinIO Operator Tenant chart to deploy a Tenant independent of
 
    The MinIO Operator Tenant Chart is *distinct* from the community-managed :minio-git:`MinIO Chart <minio/tree/master/helm/minio>`.
 
-   The Community Helm Chart is community built, maintained, and supported.
+   The Community Helm Chart built, maintained, and supported by the community.
    MinIO does not guarantee support for any given bug, feature request, or update referencing that chart.
 
-   The Operator Tenant Chart is officially maintained and supported by MinIO.
-   MinIO strongly recommends the official Helm Chart for Operator and Tenants for production environments.
+   The :ref:`Operator Tenant Chart <minio-tenant-chart-values>` is officially maintained and supported by MinIO.
+   MinIO strongly recommends the official Helm Chart for :ref:`Operator <minio-operator-chart-values>` and :ref:`Tenants <minio-tenant-chart-values>` for production environments.
 
 Prerequisites
 -------------
@@ -100,6 +100,9 @@ You can modify the Operator deployment after installation.
         --namespace MINIO_TENANT_NAMESPACE \
         --create-namespace \ 
         MINIO_TENANT_NAME minio-operator/tenant
+
+   For details on the options available in the MinIO Tenant ``values.yaml``, see :ref:`minio-tenant-chart-values`.
+
 
 #. Validate the Tenant installation
 
@@ -178,6 +181,7 @@ This method may support easier pre-configuration of the Tenant compared to the :
       curl -O https://raw.githubusercontent.com/minio/operator/master/helm-releases/tenant-|operator-version-stable|.tgz
 
    Each chart contains a ``values.yaml`` file you can customize to suit your needs.
+   For details on the options available in the MinIO Tenant ``values.yaml``, see :ref:`minio-tenant-chart-values`.
    For example, you may wish to change the MinIO root user credentials or the Tenant name.
    For more about customizations, see `Helm Charts <https://helm.sh/docs/topics/charts/>`__.
 

--- a/source/operations/install-deploy-manage/deploy-operator-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-helm.rst
@@ -200,6 +200,8 @@ This method may support easier pre-configuration of the Operator compared to the
       curl -O https://raw.githubusercontent.com/minio/operator/master/helm-releases/operator-|operator-version-stable|.tgz
 
    The chart contains a ``values.yaml`` file you can customize to suit your needs.
+   For details on the options available in the MinIO Operator ``values.yaml``, see :ref:`minio-operator-chart-values`.
+
    For more about customizations, see `Helm Charts <https://helm.sh/docs/topics/charts/>`__.
   
 #. Deploy Operator

--- a/source/reference/operator-chart-values.rst
+++ b/source/reference/operator-chart-values.rst
@@ -10,10 +10,10 @@ Operator and Tenant Helm Charts
    :local:
    :depth: 1
 
-MinIO publishes `Helm Charts <https://github.com/minio/operator/tree/v5.0.10/helm>`__ for the MinIO Operator and Tenants.
+MinIO publishes `Helm Charts <https://github.com/minio/operator/tree/v|operator-version-stable|/helm>`__ for the MinIO Operator and :ref:`Tenants <minio-tenant-chart-values>`.
 You can use these charts to deploy the MinIO Operator and managed Tenants through Helm.
 
-The following page documents the ``values.yaml`` for each chart.
+The following page documents the ``values.yaml`` chart for the MinIO Operator.
 
 .. _minio-operator-chart-operator-values:
 
@@ -29,18 +29,3 @@ MinIO Operator Chart
    .. tab-item:: YAML
 
       .. literalinclude:: /includes/k8s/operator-values.yaml
-
-.. _minio-operator-chart-tenant-values:
-
-MinIO Tenant Chart
-------------------
-
-.. tab-set::
-
-   .. tab-item:: Reference
-
-      .. autoyaml:: /source/includes/k8s/tenant-values.yaml
-
-   .. tab-item:: YAML
-
-      .. literalinclude:: /includes/k8s/tenant-values.yaml

--- a/source/reference/operator-chart-values.rst
+++ b/source/reference/operator-chart-values.rst
@@ -1,8 +1,8 @@
 .. _minio-operator-chart-values:
 
-===============================
-Operator and Tenant Helm Charts
-===============================
+====================
+Operator Helm Charts
+====================
 
 .. default-domain:: minio
 
@@ -10,10 +10,11 @@ Operator and Tenant Helm Charts
    :local:
    :depth: 1
 
-MinIO publishes `Helm Charts <https://github.com/minio/operator/tree/v|operator-version-stable|/helm>`__ for the MinIO Operator and :ref:`Tenants <minio-tenant-chart-values>`.
+MinIO publishes |helm-charts| for the |helm-operator-chart| and |helm-tenant-chart|.
 You can use these charts to deploy the MinIO Operator and managed Tenants through Helm.
 
 The following page documents the ``values.yaml`` chart for the MinIO Operator.
+For documentation on the chart for a MinIO Tenant, see :ref:`minio-tenant-chart-values`
 
 .. _minio-operator-chart-operator-values:
 

--- a/source/reference/tenant-chart-values.rst
+++ b/source/reference/tenant-chart-values.rst
@@ -1,0 +1,32 @@
+.. _minio-tenant-chart-values:
+
+==================
+Tenant Helm Charts
+==================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+MinIO publishes `Helm Charts <https://github.com/minio/operator/tree/v|operator-version-stable|/helm>`__ for the :ref:`MinIO Operator <minio-operator-chart-values>` and Tenants.
+You can use these charts to deploy the MinIO Operator and managed Tenants through Helm.
+
+The following page documents the ``values.yaml`` chart for a MinIO Tenant.
+
+.. _minio-tenant-chart-operator-values:
+
+
+MinIO Tenant Chart
+------------------
+
+.. tab-set::
+
+   .. tab-item:: Reference
+
+      .. autoyaml:: /source/includes/k8s/tenant-values.yaml
+
+   .. tab-item:: YAML
+
+      .. literalinclude:: /includes/k8s/tenant-values.yaml

--- a/source/reference/tenant-chart-values.rst
+++ b/source/reference/tenant-chart-values.rst
@@ -10,10 +10,11 @@ Tenant Helm Charts
    :local:
    :depth: 1
 
-MinIO publishes `Helm Charts <https://github.com/minio/operator/tree/v|operator-version-stable|/helm>`__ for the :ref:`MinIO Operator <minio-operator-chart-values>` and Tenants.
+MinIO publishes |helm-charts| for the |helm-operator-chart| and |helm-tenant-chart|.
 You can use these charts to deploy the MinIO Operator and managed Tenants through Helm.
 
 The following page documents the ``values.yaml`` chart for a MinIO Tenant.
+For documentation on the chart for a MinIO Operator, see :ref:`minio-operator-chart-values`
 
 .. _minio-tenant-chart-operator-values:
 


### PR DESCRIPTION
Internal request to split the Operator and Tenant helm chart into separate pages.

This adds a replacement link in default-conf to automate updating the operator version in the URL.

Stage:
- http://192.241.195.202:9000/staging/helm-charts/k8s/reference/operator-chart-values.html
- http://192.241.195.202:9000/staging/helm-charts/k8s/reference/tenant-chart-values.html