### PR TITLE
Doc update for supporting `--endpoint` arg with Azure remote tier

### DIFF
--- a/source/administration/object-management/transition-objects-to-azure.rst
+++ b/source/administration/object-management/transition-objects-to-azure.rst
@@ -138,6 +138,7 @@ Use the :mc:`mc ilm tier add` command to add a new remote storage tier:
       --account-name ACCOUNT \
       --account-key KEY \
       --bucket CONTAINER \
+      --endpoint ENDPOINT \
       --prefix PREFIX \
       --storage-class STORAGE_CLASS
 
@@ -177,6 +178,10 @@ The example above uses the following arguments:
    * - :mc-cmd:`CONTAINER <mc ilm tier add --bucket>`
      - The name of the container on the :abbr:`Azure (Microsoft Azure)` storage
        backend to which MinIO transitions objects.
+
+   * - :mc-cmd:`ENDPOINT <mc ilm tier add --endpoint>`
+     - (Optional) The full URL of the Azure blob storage backend to which MinIO transitions objects.  Defaults
+       to ``https://ACCOUNT.blob.core.windows.net`` if not specified.
 
    * - :mc-cmd:`PREFIX <mc ilm tier add --prefix>`
      - The optional container prefix within which MinIO transitions objects.

--- a/source/reference/minio-mc/mc-ilm-tier-add.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-add.rst
@@ -176,7 +176,7 @@ The command accepts the following arguments:
    The URL endpoint for the S3 or MinIO storage. 
    The URL endpoint **must** resolve to the provider specified to :mc-cmd:`~mc ilm tier add TIER_TYPE`. 
 
-   Required for ``s3`` or ``minio`` tier types.
+   Required for ``s3`` or ``minio`` tier types, optional for ``azure``.
    This option has no effect for any other value of ``TIER_TYPE``.
 
 .. mc-cmd:: --access-key


### PR DESCRIPTION
This is the documentation update associated with PR https://github.com/minio/minio/pull/19188 that adds the support for expressing the `--endpoint` arg for a custom Azure blog storage backend. This is useful for targeting Azure Gov Cloud, which has a different URL.

See https://github.com/minio/minio/pull/19188