### PR TITLE
Update minio-mc.rst the error parameters, uppercase JSON is not avail…

### DIFF
--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -530,7 +530,7 @@ You can also define some of these options using :ref:`Environment Variables <min
 
    Alternatively, set the environment variable :envvar:`MC_CONFIG_DIR`.
 
-.. option:: --JSON
+.. option:: --json
 
    Enables `JSON lines <http://jsonlines.org/>`_ formatted output to the
    console.
@@ -541,7 +541,7 @@ You can also define some of these options using :ref:`Environment Variables <min
    .. code-block:: shell
       :class: copyable
 
-      mc --JSON ls play 
+      mc --json ls play 
 
    Alternatively, set the environment variable :envvar:`MC_JSON`.
 


### PR DESCRIPTION
Update minio-mc.rst the error parameters, uppercase JSON is not available。

![image](https://github.com/minio/docs/assets/112474703/893cc68e-8a57-4687-97f1-5de2c1857e6d)
