### PR TITLE
Change instances of --JSON flag to --json

### DIFF
--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -330,7 +330,7 @@ You can exclude up to 10 prefixes for each bucket.
 To add or remove prefixes, repeat the :mc:`mc version enable` command with an updated list.
 The new list of prefixes replaces the previous one.
 
-To view the currently excluded prefixes, use :mc:`mc version info` with the ``--JSON`` option:
+To view the currently excluded prefixes, use :mc:`mc version info` with the ``--json`` option:
 
   .. code-block:: shell
      :class: copyable

--- a/source/includes/common-minio-mc.rst
+++ b/source/includes/common-minio-mc.rst
@@ -6,7 +6,7 @@ This command supports any of the :ref:`global flags <minio-mc-global-options>`.
 
 .. start-minio-mc-json-globals
 
-.. mc-cmd:: --JSON
+.. mc-cmd:: --json
    :optional:
 
    Enables `JSON lines <http://jsonlines.org/>`_ formatted output to the
@@ -17,7 +17,7 @@ This command supports any of the :ref:`global flags <minio-mc-global-options>`.
    .. code-block:: shell
       :class: copyable
 
-      mc --JSON COMMAND
+      mc --json COMMAND
 
 .. end-minio-mc-json-globals
 

--- a/source/reference/minio-mc-admin/mc-admin-user-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-user-info.rst
@@ -72,7 +72,7 @@ Global Flags
 
 .. versionchanged:: RELEASE.2023-05-26T23-31-54Z
 
-   ``mc admin user info --JSON`` output includes policies inherited from a user's group memberships in ``memberOf``.
+   ``mc admin user info --json`` output includes policies inherited from a user's group memberships in ``memberOf``.
 
 Examples
 --------
@@ -114,12 +114,12 @@ For a :ref:`third-party <minio-external-identity-management>` identity service s
 View Policies from Group Membership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc-cmd:`mc admin user info` with :std:option:`--JSON <mc.--JSON>` to view the policies inherited from a user's :ref:`group memberships <minio-groups>`:
+Use :mc-cmd:`mc admin user info` with :std:option:`--json <mc.--json>` to view the policies inherited from a user's :ref:`group memberships <minio-groups>`:
 
 .. code-block:: shell
    :class: copyable
 
-   mc admin user info ALIAS USERNAME --JSON
+   mc admin user info ALIAS USERNAME --json
 
 - Replace :mc-cmd:`ALIAS <mc admin user info ALIAS>` with the :mc-cmd:`alias <mc alias>` of the MinIO deployment.
 

--- a/source/reference/minio-mc/mc-ilm-rule-ls.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-ls.rst
@@ -19,7 +19,7 @@
 
 .. versionchanged:: RELEASE.2023-05-26T23-31-54Z
 
-   ``mc ilm rule ls --JSON`` output includes the policy modification time in ``updateAt``.
+   ``mc ilm rule ls --json`` output includes the policy modification time in ``updateAt``.
    
 Syntax
 ------
@@ -148,12 +148,12 @@ Use :mc:`mc ilm rule ls` to list a bucket's lifecycle management rules:
 Show Policy Modification Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use :mc:`mc ilm rule ls` with :std:option:`--JSON <mc.--JSON>` to show the time the policy for a bucket was last updated.
+Use :mc:`mc ilm rule ls` with :std:option:`--json <mc.--json>` to show the time the policy for a bucket was last updated.
 
 .. code-block:: shell
    :class: copyable
 
-   mc ilm rule ls ALIAS/PATH --JSON
+   mc ilm rule ls ALIAS/PATH --json
 
 - Replace :mc-cmd:`ALIAS <mc ilm rule ls ALIAS>` with the :mc:`alias <mc alias>` of the S3-compatible host.
 


### PR DESCRIPTION
Continues the work of #1148 to change all other instances of `--JSON` to `--json`.