### PR TITLE
Fixes variable placeholders "ACCESS_KEY", "SECRET_KEY", and "SESSION_TOKEN" to consistently use underscore separator.

### DIFF
--- a/source/includes/code/replicate.yaml
+++ b/source/includes/code/replicate.yaml
@@ -9,9 +9,9 @@ replicate:
     # endpoint: ENDPOINT
     # path: "on|off|auto"
     # credentials:
-    #   accessKey: ACCESS-KEY
-    #   secretKey: SECRET-KEY
-    #   sessionToken: SESSION-TOKEN # Available when rotating credentials are used
+    #   accessKey: ACCESS_KEY
+    #   secretKey: SECRET_KEY
+    #   sessionToken: SESSION_TOKEN # Available when rotating credentials are used
     # snowball:
     #   disable: true|false
     #   batch: 100
@@ -28,9 +28,9 @@ replicate:
     # endpoint: ENDPOINT
     # path: "on|off|auto"
     # credentials:
-    #   accessKey: ACCESS-KEY
-    #   secretKey: SECRET-KEY
-    #   sessionToken: SESSION-TOKEN # Available when rotating credentials are used
+    #   accessKey: ACCESS_KEY
+    #   secretKey: SECRET_KEY
+    #   sessionToken: SESSION_TOKEN # Available when rotating credentials are used
 
   # optional flags based filtering criteria
   # for all source objects

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -113,21 +113,21 @@ Each of the following tabs contains a provider-specific example:
       .. code-block:: shell
          :class: copyable
 
-         mc alias set myminio https://minioserver.example.net ACCESS_KEY SECRET KEY
+         mc alias set myminio https://minioserver.example.net ACCESS_KEY SECRET_KEY
 
    .. tab-item:: AWS S3 Storage
 
       .. code-block:: shell
          :class: copyable
 
-         mc alias set myS3 https://s3.amazon.com/endpoint ACCESS_KEY SECRET KEY
+         mc alias set myS3 https://s3.amazon.com/endpoint ACCESS_KEY SECRET_KEY
 
    .. tab-item:: Google Cloud Storage
 
       .. code-block:: shell
          :class: copyable
 
-         mc alias set myGCS https://storage.googleapis.com/endpoint ACCESS_KEY SECRET KEY
+         mc alias set myGCS https://storage.googleapis.com/endpoint ACCESS_KEY SECRET_KEY
 
 3) Test the Connection
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-ilm-tier-update.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-update.rst
@@ -102,7 +102,7 @@ Syntax
       .. code-block:: shell
          :class: copyable
 
-          mc ilm tier update myminio S3TIER --access-key ACCESS-KEY --secret-key SECRET-KEY  
+          mc ilm tier update myminio S3TIER --access-key ACCESS_KEY --secret-key SECRET_KEY  
 
       After running this command, lifecycle management rules on the ``myminio`` deployment use the tier's new credentials to transition objects into the remote location.
       Options not modified in the command maintain their existing configurations.
@@ -208,11 +208,11 @@ The following example updates the credentials for an S3 remote tier called ``S3T
 .. code-block:: shell
    :class: copyable
 
-   mc ilm tier update myminio S3TIER --access-key ACCESS-KEY --secret-key SECRET-KEY   
+   mc ilm tier update myminio S3TIER --access-key ACCESS_KEY --secret-key SECRET_KEY   
 
 - Replace ``S3TIER`` with the name for your Amazon Simple Storage Solution tier.
-- Replace ``ACCESS-KEY`` with the updated access key for your S3 storage.
-- Replace ``SECRET-KEY`` with the updated secret key for the access key provided.
+- Replace ``ACCESS_KEY`` with the updated access key for your S3 storage.
+- Replace ``SECRET_KEY`` with the updated secret key for the access key provided.
 
 Rotate Credentials for an Azure Blob Storage Remote Tier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
1. Fixes typo of variable placeholder as "SECRET KEY" to "SECRET_KEY"
2. Changes all uses of variable placeholders "ACCESS_KEY", "SECRET_KEY", and "SESSION_TOKEN" to consistently use underscore separator.