### PR TITLE
Adds Enterprise docs link to dropdown switcher

### DIFF
--- a/source/default-conf.py
+++ b/source/default-conf.py
@@ -287,6 +287,11 @@ html_context = {
          'current': True
       },
       {
+         'name': 'MinIO Enterprise Object Store Documentation',
+         'url': 'https://min.io/docs/enterprise',
+         'external': True
+      },
+      {
          'name': 'DirectPV Documentation',
          'url': 'https://min.io/docs/directpv',
          'external': True


### PR DESCRIPTION
Hold for launch of Enterprise docs.
Adds a dropdown site switcher to go to the Enterprise docs, once available.