### PR TITLE
Custom deployments are required to edit YAML manually

### DIFF
--- a/source/includes/common/common-install-operator-kubectl-plugin.rst
+++ b/source/includes/common/common-install-operator-kubectl-plugin.rst
@@ -27,7 +27,13 @@ The command initializes the MinIO Operator with the following default settings:
   different :kube-docs:`cluster domain 
   <tasks/administer-cluster/dns-custom-nameservers/>` value.
 
-- Note that custom deployments are required to edit YAML manually to fulfill certain requirements or limitations such as those on resource requests.
+
+The Operator deploys with certain default settings and resource requests.
+To modify these settings, do the following:
+
+1. Append the ``kubectl minio init -o > operator.yaml`` to save the YAML configuration to file
+2. Modify settings as-needed to fit your deployment
+3. Run ``kubectl apply -f operator.yaml`` to apply the customized Operator deployment.
 
 .. important::
 

--- a/source/includes/common/common-install-operator-kubectl-plugin.rst
+++ b/source/includes/common/common-install-operator-kubectl-plugin.rst
@@ -27,6 +27,8 @@ The command initializes the MinIO Operator with the following default settings:
   different :kube-docs:`cluster domain 
   <tasks/administer-cluster/dns-custom-nameservers/>` value.
 
+- Note that custom deployments are required to edit YAML manually to fulfill certain requirements or limitations such as those on resource requests.
+
 .. important::
 
    Document all arguments used when initializing the MinIO Operator.


### PR DESCRIPTION
Custom deployments are required to edit YAML manually to fulfill certain requirements or limitations such as those on resource requests.

Fixes https://github.com/minio/operator/issues/1204