### PR TITLE
Release work for two server releases

### DIFF
--- a/source/includes/common/common-deploy.rst
+++ b/source/includes/common/common-deploy.rst
@@ -32,7 +32,25 @@ The following example provides a starting environment file:
 
    #MINIO_SERVER_URL="http://minio.example.net:9000"
 
-Include any other environment variables as required for your local deployment.
+Include any other environment variables as required for your deployment.
+
+.. versionadded:: Server RELEASE.2024-03-03T17-50-39Z
+
+   You can have MinIO automatically generate root credentials if all of the following are true:
+
+   - :kes-docs:`KES <tutorials/getting-started/>` Release 2024-03-01T18-06-46Z or later running
+   - **Have not** defined:
+     - ``MINIO_ROOT_USER`` variable 
+     - ``MINIO_ROOT_PASSWORD`` variable 
+  
+   - **Have**:
+     - set up KES with a :kes-docs:`supported KMS target <#supported-kms-targets>`
+     - disabled root access with the :ref:`MinIO environment variable <minio-disable-root-access>`
+
+   When those conditions are met at startup, MinIO uses the KMS to generate unique root credentials for the deployment using a `hash-based message authentication code (HMAC) <https://en.wikipedia.org/wiki/HMAC>`__.
+
+   If MinIO generates such credentials, the key used to generate the credentials **must** remain the same *and* continue to exist.
+   All data on the deployment is encrypted with this key!
 
 .. end-common-deploy-create-environment-file-single-drive
 

--- a/source/includes/common/common-deploy.rst
+++ b/source/includes/common/common-deploy.rst
@@ -34,9 +34,13 @@ The following example provides a starting environment file:
 
 Include any other environment variables as required for your deployment.
 
+.. end-common-deploy-create-environment-file-single-drive
+
+.. start-common-deploy-create-unique-root-credentials
+
 .. versionadded:: Server RELEASE.2024-03-03T17-50-39Z
 
-   You can have MinIO automatically generate root credentials if all of the following are true:
+   MinIO automatically generates unique root credentials if all of the following conditions are true:
 
    - :kes-docs:`KES <tutorials/getting-started/>` Release 2024-03-01T18-06-46Z or later running
    - **Have not** defined:
@@ -52,7 +56,9 @@ Include any other environment variables as required for your deployment.
    If MinIO generates such credentials, the key used to generate the credentials **must** remain the same *and* continue to exist.
    All data on the deployment is encrypted with this key!
 
-.. end-common-deploy-create-environment-file-single-drive
+   To rotate the generated root credentials, generate a new key in the KMS, then update the value of the :envvar:`MINIO_KMS_KES_KEY_NAME` with the new key.
+
+.. end-common-deploy-create-unique-root-credentials
 
 .. start-common-deploy-create-environment-file-multi-drive
 

--- a/source/includes/container/steps-deploy-minio-single-node-multi-drive.rst
+++ b/source/includes/container/steps-deploy-minio-single-node-multi-drive.rst
@@ -12,6 +12,10 @@
    :start-after: start-common-deploy-create-environment-file-multi-drive 
    :end-before: end-common-deploy-create-environment-file-multi-drive
 
+.. include:: /includes/common/common-deploy.rst
+   :start-after: start-common-deploy-create-unique-root-credentials 
+   :end-before: end-common-deploy-create-unique-root-credentials
+
 3) Create and Run the Container
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/container/steps-deploy-minio-single-node-single-drive.rst
+++ b/source/includes/container/steps-deploy-minio-single-node-single-drive.rst
@@ -12,6 +12,10 @@
    :start-after: start-common-deploy-create-environment-file-single-drive 
    :end-before: end-common-deploy-create-environment-file-single-drive
 
+.. include:: /includes/common/common-deploy.rst
+   :start-after: start-common-deploy-create-unique-root-credentials 
+   :end-before: end-common-deploy-create-unique-root-credentials
+
 3) Create and Run the Container
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/linux/steps-deploy-minio-single-node-multi-drive.rst
+++ b/source/includes/linux/steps-deploy-minio-single-node-multi-drive.rst
@@ -19,6 +19,10 @@
    :start-after: start-common-deploy-create-environment-file-multi-drive 
    :end-before: end-common-deploy-create-environment-file-multi-drive
 
+.. include:: /includes/common/common-deploy.rst
+   :start-after: start-common-deploy-create-unique-root-credentials 
+   :end-before: end-common-deploy-create-unique-root-credentials
+
 4) Start the MinIO Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/linux/steps-deploy-minio-single-node-single-drive.rst
+++ b/source/includes/linux/steps-deploy-minio-single-node-single-drive.rst
@@ -19,6 +19,10 @@
    :start-after: start-common-deploy-create-environment-file-single-drive
    :end-before: end-common-deploy-create-environment-file-single-drive
 
+.. include:: /includes/common/common-deploy.rst
+   :start-after: start-common-deploy-create-unique-root-credentials 
+   :end-before: end-common-deploy-create-unique-root-credentials
+
 4) Start the MinIO Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/macos/steps-deploy-minio-single-node-multi-drive.rst
+++ b/source/includes/macos/steps-deploy-minio-single-node-multi-drive.rst
@@ -12,6 +12,10 @@
    :start-after: start-common-deploy-create-environment-file-multi-drive 
    :end-before: end-common-deploy-create-environment-file-multi-drive
 
+.. include:: /includes/common/common-deploy.rst
+   :start-after: start-common-deploy-create-unique-root-credentials 
+   :end-before: end-common-deploy-create-unique-root-credentials
+
 3) Start the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/macos/steps-deploy-minio-single-node-single-drive.rst
+++ b/source/includes/macos/steps-deploy-minio-single-node-single-drive.rst
@@ -12,6 +12,10 @@
    :start-after: start-common-deploy-create-environment-file-single-drive
    :end-before: end-common-deploy-create-environment-file-single-drive
 
+.. include:: /includes/common/common-deploy.rst
+   :start-after: start-common-deploy-create-unique-root-credentials 
+   :end-before: end-common-deploy-create-unique-root-credentials
+
 3) Start the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -259,6 +259,7 @@ If you set both a configuration value and the matching environment variable, Min
    /reference/minio-server/settings/metrics-and-logging 
    /reference/minio-server/settings/notifications 
    /reference/minio-server/settings/iam 
+   /reference/minio-server/settings/ilm 
    /reference/minio-server/settings/kes 
    /reference/minio-server/settings/object-lambda
    /reference/minio-server/settings/deprecated

--- a/source/reference/minio-server/settings/ilm.rst
+++ b/source/reference/minio-server/settings/ilm.rst
@@ -1,0 +1,44 @@
+.. _minio-server-envvar-ilm:
+
+============
+ILM Settings
+============
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+This page covers settings that control Information Lifecycle Management (ILM) for the MinIO process. 
+
+.. include:: /includes/common-mc-admin-config.rst
+   :start-after: start-minio-settings-defined
+   :end-before: end-minio-settings-defined
+
+.. include:: /includes/common-mc-admin-config.rst
+   :start-after: start-minio-settings-test-before-prod
+   :end-before: end-minio-settings-test-before-prod
+
+Expiration Workers
+------------------
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_ILM_EXPIRATION_WORKERS
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+  
+      .. mc-conf:: ilm expiration_workers
+         :delimiter: " "
+
+.. versionadded:: MinIO Server RELEASE.2024-03-03T17-50-39Z
+
+Set the number of workers to use for :ref:`expiring objects <minio-lifecycle-management-expiration>`.
+Valid values are ``1`` to ``500``.
+
+The default value is ``100``.

--- a/source/reference/minio-server/settings/metrics-and-logging.rst
+++ b/source/reference/minio-server/settings/metrics-and-logging.rst
@@ -210,6 +210,29 @@ Auth Token
    
          Consult the documentation for the desired service for more details.
 
+Batch Size
+++++++++++
+
+.. versionadded:: MinIO Server RELEASE.2024-03-10T02-53-48Z
+
+*Optional*
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_LOGGER_WEBHOOK_BATCH_SIZE
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: logger_webhook batch_size
+         :delimiter: " "
+
+Collect and send the specified number of events to the webhook as a batch.
+If not set, MinIO sends one event per request.
+
 Client Certificate
 ++++++++++++++++++
 
@@ -499,6 +522,30 @@ Depending on the endpoint, you may need to include additional information.
                   auth_token="ServiceXYZ 1a2b3c4f5e"
 
 Consult the documentation for the desired service for more details.
+
+Batch Size
+++++++++++
+
+.. versionadded:: MinIO Server RELEASE.2024-03-10T02-53-48Z
+
+*Optional*
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_AUDIT_WEBHOOK_BATCH_SIZE
+
+  
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: audit_webhook batch_size
+         :delimiter: " "
+
+Collect and send the specified number of events to the webhook as a batch.
+If not set, MinIO sends one event per request.
 
 Client Certificate
 ++++++++++++++++++

--- a/source/reference/minio-server/settings/notifications/nats.rst
+++ b/source/reference/minio-server/settings/notifications/nats.rst
@@ -222,6 +222,26 @@ Specify the token for connecting to the NATS service endpoint.
 
    MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
 
+User Credentials File
+~~~~~~~~~~~~~~~~~~~~~
+
+*Optional*
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_NOTIFY_NATS_USER_CREDENTIALS
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: notify_nats user_credentials
+         :delimiter: " "
+
+Specify the to the `user credentials file <https://docs.nats.io/using-nats/developer/connecting/creds>` to use to connect to the NATS service endpoint.
+
 TLS
 ~~~
 

--- a/source/reference/minio-server/settings/root-credentials.rst
+++ b/source/reference/minio-server/settings/root-credentials.rst
@@ -70,6 +70,8 @@ Root Password
       This setting does not have a configuration variable setting.
       Use the Environment Variable instead.
 
+.. _minio-disable-root-access:
+
 Root Access
 -----------
 

--- a/source/reference/minio-server/settings/root-credentials.rst
+++ b/source/reference/minio-server/settings/root-credentials.rst
@@ -101,3 +101,10 @@ You can use this variable to temporarily override the configuration setting and 
 
 To reset after an unintentional lock, set :envvar:`MINIO_API_ROOT_ACCESS` ``on`` to override this setting and temporarily re-enable the root account.
 You can then change this setting to ``on`` *or* make the necessary user/policy changes to ensure normal administrative access through other non-root accounts.
+
+Unique Root Credentials
+-----------------------
+
+.. include:: /includes/common/common-deploy.rst
+   :start-after: start-common-deploy-create-unique-root-credentials 
+   :end-before: end-common-deploy-create-unique-root-credentials

--- a/source/url-excludes.yaml
+++ b/source/url-excludes.yaml
@@ -27,6 +27,7 @@ excludes:
 - 'reference/operator-crd.rst'
 - 'reference/operator-chart-values.rst'
 - 'reference/operator-environment-variables.rst'
+- 'reference/tenant-chart-values.rst'
 ---
 tag: macos
 excludes:
@@ -50,6 +51,7 @@ excludes:
 - 'reference/operator-crd.rst'
 - 'reference/operator-chart-values.rst'
 - 'reference/operator-environment-variables.rst'
+- 'reference/tenant-chart-values.rst'
 - 'developers/*'
 - 'integrations/*'
 ---
@@ -80,6 +82,7 @@ excludes:
 - 'reference/operator-crd.rst'
 - 'reference/operator-chart-values.rst'
 - 'reference/operator-environment-variables.rst'
+- 'reference/tenant-chart-values.rst'
 - 'developers/*'
 - 'integrations/*'
 ---
@@ -106,6 +109,7 @@ excludes:
 - 'reference/operator-crd.rst'
 - 'reference/operator-chart-values.rst'
 - 'reference/operator-environment-variables.rst'
+- 'reference/tenant-chart-values.rst'
 - 'developers/*'
 - 'integrations/*'
 ---


### PR DESCRIPTION
Release work for Server RELEASE.2024-03-03T17-50-39Z
    
- Adds new NATS config
- Adds new ilm configs
- Adds info on having a KMS auto generate root credentials
 
Closes #1144

Release work for Server RELEASE.2024-03-10T02-53-48Z
    
- Corrects a missing URL excludes line for some builds
- Adds new webhook options
    
Closes #1155

Staged:
- [Webhook config](http://192.241.195.202:9000/staging/release-work/linux/reference/minio-server/settings/metrics-and-logging.html#envvar.MINIO_AUDIT_WEBHOOK_BATCH_SIZE)
- [NATS config](http://192.241.195.202:9000/staging/release-work/linux/reference/minio-server/settings/notifications/nats.html#user-credentials-file)
- [Root credentials](http://192.241.195.202:9000/staging/release-work/linux/operations/install-deploy-manage/deploy-minio-single-node-single-drive.html#create-the-environment-variable-file)
- [ILM config](http://192.241.195.202:9000/staging/release-work/linux/reference/minio-server/settings/ilm.html)