### PR TITLE
Updates for two mc releases

### DIFF
--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -119,6 +119,8 @@ MinIO has two specific default behaviors for versioned buckets:
 
   To expire delete markers when there are no remaining versions for that object, specify the :mc-cmd:`~mc ilm rule add --expire-delete-marker` option when creating the expiration rule.
 
+- To expire all versions of an object after a specified period of days, including the current version *and* all non-current versions, use the :mc-cmd:`~mc ilm rule add --expire-all-object-versions` flag with the :mc-cmd:`~mc ilm rule add --expire-days` flag.
+
 .. _minio-lifecycle-management-scanner:
 
 Lifecycle Management Object Scanner

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -119,7 +119,8 @@ MinIO has two specific default behaviors for versioned buckets:
 
   To expire delete markers when there are no remaining versions for that object, specify the :mc-cmd:`~mc ilm rule add --expire-delete-marker` option when creating the expiration rule.
 
-- To expire all versions of an object after a specified period of days, including the current version *and* all non-current versions, use the :mc-cmd:`~mc ilm rule add --expire-all-object-versions` flag with the :mc-cmd:`~mc ilm rule add --expire-days` flag.
+- To expire *all* versions of an object after a specified period of days, use the :mc-cmd:`~mc ilm rule add --expire-all-object-versions` flag with the :mc-cmd:`~mc ilm rule add --expire-days` flag. 
+  This permits the permanent deletion of the object after the specified number of days pass.
 
 .. _minio-lifecycle-management-scanner:
 

--- a/source/reference/minio-mc-admin/mc-admin-service.rst
+++ b/source/reference/minio-mc-admin/mc-admin-service.rst
@@ -15,15 +15,13 @@ Description
 
 .. start-mc-admin-service-desc
 
-The :mc-cmd:`mc admin service` command can restart or stop MinIO servers.
+The :mc-cmd:`mc admin service` command can restart or unfreeze MinIO servers.
 
 .. end-mc-admin-service-desc
 
 :mc-cmd:`mc admin service` affects *all* MinIO servers in the target deployment
 at the same time. The command interrupts in-progress API operations on
-the MinIO deployment. Exercise caution before issuing an update command on
-production environments.
-
+the MinIO deployment. Use caution when issuing this command to a deployment.
 
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only
    :class: note
@@ -47,8 +45,8 @@ Restart MinIO Servers in Target Deployment
 
    mc admin service restart myminio
 
-Stop MinIO Servers in Target Deployment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Resume S3 Calls on a Target Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/play-alias-available.rst
    :start-after: myminio-alias
@@ -57,7 +55,7 @@ Stop MinIO Servers in Target Deployment
 .. code-block:: shell
    :class: copyable
 
-   mc admin service stop myminio
+   mc admin service unfreeze myminio
 
 Syntax
 ------
@@ -74,30 +72,30 @@ Syntax
 .. mc-cmd:: restart
 
    Restarts MinIO servers.
+   If needed, the command provides some guidance based on status about potential next steps you may need to take on each node.
+   For example, if hard drives are hung, the command may suggest restarting the node's operating system.
 
    :mc-cmd:`mc admin service restart` has the following syntax:
 
    .. code-block:: shell
       :class: copyable
 
-      mc admin service restart TARGET
+      mc admin service restart ALIAS
 
    Specify the :mc-cmd:`alias <mc alias>` of a configured MinIO deployment.
    :mc-cmd:`~mc admin service restart` restarts *all* MinIO servers in the
    deployment.
 
-.. mc-cmd:: stop
+.. mc-cmd:: unfreeze
 
-   Stops MinIO servers.
+   Restart S3 API calls on a MinIO cluster.
 
-   :mc-cmd:`mc admin service stop` has the following syntax:
+   :mc-cmd:`mc admin service unfreeze` has the following syntax:
 
    .. code-block:: shell
       :class: copyable
 
-      mc admin service stop TARGET
+      mc admin service unfreeze ALIAS
 
    Specify the :mc-cmd:`alias <mc alias>` of a configured MinIO deployment.
-   :mc-cmd:`~mc admin service stop` stops *all* MinIO servers in the
-   deployment.
 

--- a/source/reference/minio-mc-admin/mc-admin-service.rst
+++ b/source/reference/minio-mc-admin/mc-admin-service.rst
@@ -72,8 +72,7 @@ Syntax
 .. mc-cmd:: restart
 
    Restarts MinIO servers.
-   If needed, the command provides some guidance based on status about potential next steps you may need to take on each node.
-   For example, if hard drives are hung, the command may suggest restarting the node's operating system.
+   If needed, the command may suggest restarting the node based on the status.
 
    :mc-cmd:`mc admin service restart` has the following syntax:
 

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -242,7 +242,12 @@ The following table lists :mc-cmd:`mc` commands:
      - .. include:: /reference/minio-mc/mc-find.rst
           :start-after: start-mc-find-desc
           :end-before: end-mc-find-desc
-     
+
+   * - :mc:`mc get`
+     - .. include:: /reference/minio-mc/mc-get.rst
+          :start-after: start-mc-get-desc
+          :end-before: end-mc-get-desc  
+
    * - :mc:`mc head`
      - .. include:: /reference/minio-mc/mc-head.rst
           :start-after: start-mc-head-desc
@@ -344,6 +349,11 @@ The following table lists :mc-cmd:`mc` commands:
      - .. include:: /reference/minio-mc/mc-pipe.rst
           :start-after: start-mc-pipe-desc
           :end-before: end-mc-pipe-desc  
+
+   * - :mc:`mc put`
+     - .. include:: /reference/minio-mc/mc-put.rst
+          :start-after: start-mc-put-desc
+          :end-before: end-mc-put-desc  
 
    * - | :mc:`mc quota clear`
        | :mc:`mc quota info`
@@ -590,6 +600,7 @@ You can also define some of these options using :ref:`Environment Variables <min
    /reference/minio-mc/mc-encrypt
    /reference/minio-mc/mc-event
    /reference/minio-mc/mc-find
+   /reference/minio-mc/mc-get
    /reference/minio-mc/mc-head
    /reference/minio-mc/mc-idp-ldap
    /reference/minio-mc/mc-idp-ldap-accesskey
@@ -605,6 +616,7 @@ You can also define some of these options using :ref:`Environment Variables <min
    /reference/minio-mc/mc-od
    /reference/minio-mc/mc-ping
    /reference/minio-mc/mc-pipe
+   /reference/minio-mc/mc-put
    /reference/minio-mc/mc-quota
    /reference/minio-mc/mc-rb
    /reference/minio-mc/mc-replicate

--- a/source/reference/minio-mc/mc-get.rst
+++ b/source/reference/minio-mc/mc-get.rst
@@ -17,12 +17,12 @@ Syntax
 
 .. start-mc-get-desc
 
-The :mc:`mc get` downloads an object from a target S3 deployment to the local file system.
+The :mc:`mc get` command downloads an object from a target S3 deployment to the local file system.
 
 .. end-mc-get-desc
 
-Unlike other commands that can download files, such as :mc:`mc cp` or :mc:`mc mirror`, ``mc get`` is a simpler call.
-``mc get`` only does the one-way function of downloading the file so that it avoids the potential performance costs of other commands.
+``mc get`` provides a simplified interface for downloading files compared to :mc:`mc cp` or :mc:`mc mirror`.
+``mc get`` uses a one-way download function that trades efficiency for the power and complexity of the other commands.
 
 .. tab-set::
 
@@ -59,12 +59,12 @@ Parameters
 .. mc-cmd:: SOURCE
    :required:
 
-   The full path to the :ref:`alias <minio-mc-alias>`, bucket, prefix (if used), and object of the path to download.
+   The full path to the :ref:`alias <minio-mc-alias>`, bucket, prefix (if used), and object to download.
 
 .. mc-cmd:: TARGET
    :required:
 
-   The path on the local file system where the object should download to.
+   The destination path on the local file system where the command should place the downloaded file.
 
 .. mc-cmd:: --encrypt
    :optional:

--- a/source/reference/minio-mc/mc-get.rst
+++ b/source/reference/minio-mc/mc-get.rst
@@ -1,0 +1,92 @@
+==========
+``mc get``
+==========
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc get
+
+.. versionadded:: mc RELEASE.2024-02-24T01-33-20Z
+
+Syntax
+------
+
+.. start-mc-get-desc
+
+The :mc:`mc get` downloads an object from a target S3 deployment to the local file system.
+
+.. end-mc-get-desc
+
+Unlike other commands that can download files, such as :mc:`mc cp` or :mc:`mc mirror`, ``mc get`` is a simpler call.
+``mc get`` only does the one-way function of downloading the file so that it avoids the potential performance costs of other commands.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following downloads the file ``logo.png`` from an s3 source to the local file system at path ``~/images/collateral/``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc get minio/marketing/logo.png ~/images/collateral
+
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] get                      \
+                          SOURCE                   \
+                          TARGET                   \
+                          [--encrypt-key value]    \
+                          [--encrypt value] 
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: SOURCE
+   :required:
+
+   The full path to the :ref:`alias <minio-mc-alias>`, bucket, prefix (if used), and object of the path to download.
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The path on the local file system where the object should download to.
+
+.. mc-cmd:: --encrypt
+   :optional:
+
+   Specify the key to use for decrypting and encrypting the downloaded object.
+
+   Requires that you also specify the key to use with the :mc-cmd:`~mc put --encrypt-key` flag.
+
+   Alternatively, set the :envvar:`MC_ENCRYPT` environment variable.
+
+.. mc-cmd:: --encrypt-key
+   :optional:
+   
+   Specify the key to use for decrypting and encrypting the downloaded object.
+
+   Requires that you also pass the :mc-cmd:`~mc put --encrypt` flag set to ``TRUE``.
+
+   Alternatively, set the :envvar:`MC_ENCRYPT_KEY` environment variable.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals

--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -124,7 +124,7 @@ Parameters
    Expire all current **and** noncurrent versions of an object.
    Use with the :mc-cmd:`~mc ilm rule add --expire-days` option to specify the number of days after which all versions of an object should be deleted by the scanner process.
 
-   After the scanner processes this command, no versions of the object remain on the deployment.
+   After the :ref:`scanner <minio-lifecycle-management-scanner>` processes this command, no versions of the object remain on the deployment.
 
 .. mc-cmd:: --expire-days
    :optional:   

--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -64,6 +64,7 @@ The command supports adding both :ref:`Transition (Tiering) <minio-lifecycle-man
                           [--prefix string]                          \
                           [--tags string]                            \
                           [--expire-days "integer"]                  \
+                          [--expire-all-object-versions]             \
                           [--expire-delete-marker]                   \
                           [--transition-days "string"]               \
                           [--transition-tier "string"]               \
@@ -114,6 +115,16 @@ Parameters
    This option is mutually exclusive with the following option:
 
    - :mc-cmd:`~mc ilm rule add --expire-delete-marker`
+
+.. mc-cmd:: --expire-all-object-versions
+   :optional:   
+
+   .. versionadded:: mc RELEASE.2024-02-24T01-33-20Z
+
+   Expire all current **and** noncurrent versions of an object.
+   Use with the :mc-cmd:`~mc ilm rule add --expire-days` option to specify the number of days after which all versions of an object should be deleted by the scanner process.
+
+   After the scanner processes this command, no versions of the object remain on the deployment.
 
 .. mc-cmd:: --expire-days
    :optional:   

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -254,6 +254,13 @@ Parameters
 
    See the Amazon documentation on :aws-docs:`Storage Classes <AmazonS3/latest/dev/storage-class-intro.html>` for more information on S3 storage classses.
 
+.. mc-cmd:: --skip-errors
+   :optional:
+
+   .. versionadded:: mc RELEASE.2024-01-28T16-23-14Z
+
+   Skip any objects that produce errors while mirroring.
+
 .. mc-cmd:: --summary
    :optional:
 

--- a/source/reference/minio-mc/mc-put.rst
+++ b/source/reference/minio-mc/mc-put.rst
@@ -61,7 +61,7 @@ Parameters
    :required:
 
    The full path to the :ref:`alias <minio-mc-alias>` or prefix where the command should run.
-   The TARGET *must* contain an :mc-ref:`alias <alias>` and ``bucket`` name.
+   The TARGET *must* contain an :ref:`alias <alias>` and ``bucket`` name.
 
    The TARGET may also contain the following optional components:
    - PREFIX where the object should upload to

--- a/source/reference/minio-mc/mc-put.rst
+++ b/source/reference/minio-mc/mc-put.rst
@@ -21,8 +21,9 @@ The :mc:`mc put` uploads an object from the local file system to a bucket on a t
 
 .. end-mc-put-desc
 
-Unlike other commands that can upload files, such as :mc:`mc cp` or :mc:`mc mirror`, ``mc put`` is a simpler call.
-``mc put`` only does the one-way function of uploading the file so that it avoids the potential performance costs of other commands.
+``mc put`` provides a simplified interface for uploading files compared to :mc:`mc cp` or :mc:`mc mirror`.
+``mc put`` uses a one-way upload function that trades efficiency for the power and complexity of the other commands.
+
 
 .. tab-set::
 
@@ -119,17 +120,18 @@ Examples
 Upload a File and Specify the Object Name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following command uploads the file ``logo.png`` from the local file system to the ``business`` bucket on the ``minio`` deployment with the object name of ``company-logo.png``.
+The following command uploads the file ``logo.png`` from the local file system to the ``business`` bucket on the ``minio`` deployment, uploading it on the destination as ``company-logo.png``.
 
 .. code-block:: shell
    :class: copyable
 
    mc put images/collateral/logo.png minio/business/company-logo.png
 
-Upload a File 8 Parts in Parallel with a Specified Part Size
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Upload a Multipart Object in Parallel with a Specified Part Size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following command uploads 8 parts of a file in parallel with parts of 20MiB each.
+The following command uploads a file in chunks of 20MiB each and uploads 8 parts of the file in parallel.
+8 parts are uploaded in succession until all parts of the object have uploaded.
 
 .. code-block:: shell
    :class: copyable

--- a/source/reference/minio-mc/mc-put.rst
+++ b/source/reference/minio-mc/mc-put.rst
@@ -1,0 +1,137 @@
+==========
+``mc put``
+==========
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+.. mc:: mc put
+
+.. versionadded:: mc RELEASE.2024-02-24T01-33-20Z
+
+Syntax
+------
+
+.. start-mc-put-desc
+
+The :mc:`mc put` uploads an object from the local file system to a bucket on a target S3 deployment.
+
+.. end-mc-put-desc
+
+Unlike other commands that can upload files, such as :mc:`mc cp` or :mc:`mc mirror`, ``mc put`` is a simpler call.
+``mc put`` only does the one-way function of uploading the file so that it avoids the potential performance costs of other commands.
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+      The following uploads the file ``logo.png`` from the local file system at path ``~/images/collateral/`` to a bucket called ``marketing`` on the MinIO deployment with the alias of ``minio``.
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc put ~/images/collateral/logo.png minio/marketing
+
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] put                      \
+                          TARGET                   \
+                          [--encrypt-key value]    \
+                          [--encrypt value]        \
+                          [--parallel, -P integer] \
+                          [--part-size, -s string]
+
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+
+   The full path to the :ref:`alias <minio-mc-alias>` or prefix where the command should run.
+   The TARGET *must* contain an :mc-ref:`alias <alias>` and ``bucket`` name.
+
+   The TARGET may also contain the following optional components:
+   - PREFIX where the object should upload to
+   - OBJECT-NAME to use in place of the file names
+
+   Valid TARGETs could take any of the following forms:
+   - ``ALIAS/BUCKET``
+   - ``ALIAS/BUCKET/PREFIX``
+   - ``ALIAS/BUCKET/OBJECT-NAME``
+   - ``ALIAS/BUCKET/PREFIX/OBJECT-NAME``
+
+.. mc-cmd:: --encrypt
+   :optional:
+
+   Specify the key to use for decrypting and encrypting the uploaded object.
+
+   Requires that you also specify the key to use with the :mc-cmd:`~mc put --encrypt-key` flag.
+
+   Alternatively, set the :envvar:`MC_ENCRYPT` environment variable.
+
+.. mc-cmd:: --encrypt-key
+   :optional:
+   
+   Specify the key to use for decrypting and encrypting the uploaded object.
+
+   Requires that you also pass the :mc-cmd:`~mc put --encrypt` flag set to ``TRUE``.
+
+   Alternatively, set the :envvar:`MC_ENCRYPT_KEY` environment variable.
+
+.. mc-cmd:: --parallel, --P
+   :optional:
+
+   For multi-part uploads, specify the number of parts of the object to upload in parallel.
+
+   If not defined, defaults to a value of ``4``.
+
+.. mc-cmd:: --part-size, -s
+   :optional:
+
+   Specify the size to use for each part of a multi-part upload.
+
+   If not defined, defaults to a value of ``16MiB``.
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Upload a File and Specify the Object Name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command uploads the file ``logo.png`` from the local file system to the ``business`` bucket on the ``minio`` deployment with the object name of ``company-logo.png``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc put images/collateral/logo.png minio/business/company-logo.png
+
+Upload a File 8 Parts in Parallel with a Specified Part Size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command uploads 8 parts of a file in parallel with parts of 20MiB each.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc put ~/videos/collateral/splash-page.mp4 minio/business --parallel 8 --part-size 20MiB


### PR DESCRIPTION
Adds updates for mc RELEASE.2024-02-24T01-33-20Z
    
- New `mc put` command
- New `mc get` command
- New `--expire-all-object-versions` flag for the `mc ilm rule add` command
- Adds info to the expiration of objects in versioned buckets on the Object Lifecycle Management page
    
Closes #1140

Adds updates for mc release RELEASE.2024-01-28T16-23-14Z
    
- adds --skip-errors flag to mc mirror
- updates the mc admin service commands
    
Closes #1120

Staged:
- [`mc put`](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc/mc-put.html)
- [`mc get`](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc/mc-get.html)
- [`mc admin service](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc-admin/mc-admin-service.html)
- [`mc ilm rule add --expire-all-object-versions`](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc/mc-ilm-rule-add.html#mc.ilm.rule.add.-expire-all-object-versions)
- [Object Expiration info in lifecycle management doc](http://192.241.195.202:9000/staging/mc-releases/linux/administration/object-management/object-lifecycle-management.html#id1)
- [`mc mirror --skip-errors`](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc/mc-mirror.html#mc.mirror.-skip-errors)