### PR TITLE
Updates for two mc-releases

### DIFF
--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -407,6 +407,7 @@ The following table lists :mc-cmd:`mc` commands:
        | :mc:`mc support top api`
        | :mc:`mc support top disk`
        | :mc:`mc support top locks`
+       | :mc:`mc support upload`
      - .. include:: /reference/minio-mc/mc-support.rst
           :start-after: start-mc-support-desc
           :end-before: end-mc-support-desc

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -392,41 +392,41 @@ For example, refer to the following examples for wildcard uses and their results
 .. list-table::
    :header-rows: 1
    :widths: 40 30 30
-   :width: 100%
+   :width: 70%
 
    * - Pattern
      - Text
      - Match Result
 
-   * - abc*
+   * - ``abc*``
      - ab
      - Match
 
-   * - abc*
+   * - ``abc*``
      - abd
      - Not a match
   
-   * - abc*c
+   * - ``abc*c``
      - abcd
      - Match
 
-   * - ab*??d
+   * - ``ab*??d``
      - abxxc
      - Match
 
-   * - ab*??d
+   * - ``ab*??d``
      - abxc
      - Match
 
-   * - ab??d
+   * - ``ab??d``
      - abxc
      - Match
 
-   * - ab??d
+   * - ``ab??d``
      - abc
      - Match
 
-   * - ab??d
+   * - ``ab??d``
      - abcxdd
      - Not a match
 

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -55,6 +55,7 @@ The :mc:`mc mirror` command synchronizes content to MinIO deployment, similar to
                           [--dry-run]                       \
                           [--encrypt-key "string"]          \
                           [--exclude "string"]              \
+                          [--exclude-bucket "string"]       \
                           [--exclude-storageclass "string"] \
                           [--limit-download string]         \
                           [--limit-upload string]           \
@@ -151,6 +152,14 @@ Parameters
    :optional:
 
    Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified object name pattern.
+
+.. mc-cmd:: --exclude-bucket
+   :optional:
+
+   .. versionadded:: mc RELEASE.2024-03-03T00-13-08Z
+
+   Exclude bucket(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified bucket name pattern.
+
 
 .. mc-cmd:: --exclude-storageclass
    :optional:

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -392,7 +392,7 @@ For example, refer to the following examples for wildcard uses and their results
 .. list-table::
    :header-rows: 1
    :widths: 40 30 30
-   :width: 70%
+   :width: 100%
 
    * - Pattern
      - Text

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -151,15 +151,14 @@ Parameters
 .. mc-cmd:: --exclude
    :optional:
 
-   Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified object name pattern.
+   Exclude object(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified object :ref:`name pattern <minio-wildcard-matching>`.
 
 .. mc-cmd:: --exclude-bucket
    :optional:
 
    .. versionadded:: mc RELEASE.2024-03-03T00-13-08Z
 
-   Exclude bucket(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified bucket name pattern.
-
+   Exclude bucket(s) in the :mc-cmd:`~mc mirror SOURCE` path that match the specified bucket :ref:`name pattern <minio-wildcard-matching>`.
 
 .. mc-cmd:: --exclude-storageclass
    :optional:
@@ -376,6 +375,61 @@ Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --exclude-storageclass` to mirror o
 
 Behavior
 --------
+
+.. _minio-wildcard-matching::
+
+Wildcard Matching
+~~~~~~~~~~~~~~~~~
+
+Some flags allow for name pattern matching.
+When enabled, a pattern can include include either of two wildcards for character replacement.
+   
+- ``*`` to represent a string of characters to match, either in the middle or end.
+- ``?`` to represent a single character.
+
+For example, refer to the following examples for wildcard uses and their results.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 30 30
+   :width: 100%
+
+   * - Pattern
+     - Text
+     - Match Result
+
+   * - abc*
+     - ab
+     - Match
+
+   * - abc*
+     - abd
+     - Not a match
+  
+   * - abc*c
+     - abcd
+     - Match
+
+   * - ab*??d
+     - abxxc
+     - Match
+
+   * - ab*??d
+     - abxc
+     - Match
+
+   * - ab??d
+     - abxc
+     - Match
+
+   * - ab??d
+     - abc
+     - Match
+
+   * - ab??d
+     - abcxdd
+     - Not a match
+
 
 Mirror Continues on Failed Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -376,7 +376,7 @@ Use :mc:`mc mirror` with :mc-cmd:`~mc mirror --exclude-storageclass` to mirror o
 Behavior
 --------
 
-.. _minio-wildcard-matching::
+.. _minio-wildcard-matching:
 
 Wildcard Matching
 ~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -54,6 +54,10 @@ You can optionally configure synchronization of existing objects, delete operati
 
       The replication rule synchronizes versioned delete operations, delete markers, and existing objects to the remote MinIO deployment.
 
+      .. versionchanged:: mc RELEASE.2024-03-03T00-13-08Z
+
+         You can use a configured ALIAS for the ``--remote-bucket`` flag instaed of URL or IP.
+
    .. tab-item:: SYNTAX
 
       The command has the following syntax:
@@ -100,12 +104,23 @@ Parameters
    :required:
 
    Specify the credentials, destination deployment, and bucket of the remote location. 
+   Value may be an alias/bucket, location based (IP or URL), or path based.
 
    For example, a URL based target might look like the following:
 
    .. code-block::
 
       https://user:secret@myminio.cloudprovider.tld:9001/bucket
+
+   .. versionchanged:: mc RELEASE.2024-03-03T00-13-08Z
+
+      The ``--remote-bucket`` value may be an :ref:`alias`.
+
+   An alias based target might look like the following:
+
+   .. code-block::
+
+      minio-target/my-bucket
 
 .. mc-cmd:: --bandwidth
    :optional:

--- a/source/reference/minio-mc/mc-replicate-add.rst
+++ b/source/reference/minio-mc/mc-replicate-add.rst
@@ -56,7 +56,7 @@ You can optionally configure synchronization of existing objects, delete operati
 
       .. versionchanged:: mc RELEASE.2024-03-03T00-13-08Z
 
-         You can use a configured ALIAS for the ``--remote-bucket`` flag instaed of URL or IP.
+         You can use a configured ALIAS to the ``--remote-bucket`` flag.
 
    .. tab-item:: SYNTAX
 
@@ -103,8 +103,12 @@ Parameters
 .. mc-cmd:: --remote-bucket
    :required:
 
+   .. versionchanged:: mc RELEASE.2024-03-03T00-13-08Z
+
+      The ``--remote-bucket`` supports specifying an existing :ref:`alias <alias>`.
+
    Specify the credentials, destination deployment, and bucket of the remote location. 
-   Value may be an alias/bucket, location based (IP or URL), or path based.
+   Value may be an IP address, URL, or :ref:`alias <alias>`/bucket.
 
    For example, a URL based target might look like the following:
 
@@ -112,15 +116,11 @@ Parameters
 
       https://user:secret@myminio.cloudprovider.tld:9001/bucket
 
-   .. versionchanged:: mc RELEASE.2024-03-03T00-13-08Z
-
-      The ``--remote-bucket`` value may be an :ref:`alias`.
-
    An alias based target might look like the following:
 
    .. code-block::
 
-      minio-target/my-bucket
+      --remote-bucket minio-target/my-bucket
 
 .. mc-cmd:: --bandwidth
    :optional:

--- a/source/reference/minio-mc/mc-replicate-update.rst
+++ b/source/reference/minio-mc/mc-replicate-update.rst
@@ -213,13 +213,19 @@ Parameters
    :optional:
 
    Specify the credentials, destination deployment, and bucket of the remote location.
-   Value may be either location based (IP or URL) or path based.
+   Value may be an alias/bucket, location based (IP or URL), or path based.
 
    For example, a URL based target might look like the following:
 
    .. code-block::
 
       https://user:secret@myminio.cloudprovider.tld:9001/bucket
+
+   An alias based target might look like the following:
+
+   .. code-block::
+
+      minio-target/my-bucket
 
 .. mc-cmd:: --replicate
    :optional:

--- a/source/reference/minio-mc/mc-replicate-update.rst
+++ b/source/reference/minio-mc/mc-replicate-update.rst
@@ -213,19 +213,19 @@ Parameters
    :optional:
 
    Specify the credentials, destination deployment, and bucket of the remote location.
-   Value may be an alias/bucket, location based (IP or URL), or path based.
+   Value may be an :ref:`alias <alias>` and bucket, location based (IP or URL), or path based.
 
    For example, a URL based target might look like the following:
 
    .. code-block::
 
-      https://user:secret@myminio.cloudprovider.tld:9001/bucket
+      --remote-bucket https://user:secret@myminio.cloudprovider.tld:9001/bucket
 
    An alias based target might look like the following:
 
    .. code-block::
 
-      minio-target/my-bucket
+      --remote-bucket minio-target/my-bucket
 
 .. mc-cmd:: --replicate
    :optional:

--- a/source/reference/minio-mc/mc-support-profile.rst
+++ b/source/reference/minio-mc/mc-support-profile.rst
@@ -19,7 +19,7 @@ Description
 
 .. start-mc-support-profile-desc
 
-The :mc:`mc support profile` command runs a system profile for your deployment.
+:mc:`mc support profile` runs a system profile for your deployment.
 The results of the profile can provide insight into the MinIO server process running on a given node.
 
 .. end-mc-support-profile-desc

--- a/source/reference/minio-mc/mc-support-upload.rst
+++ b/source/reference/minio-mc/mc-support-upload.rst
@@ -1,0 +1,97 @@
+======================
+``mc support upload``
+======================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 1
+
+.. mc:: mc support upload
+
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-minio-only
+   :end-before: end-minio-only
+
+Description
+-----------
+
+.. start-mc-support-upload-desc
+
+:mc:`mc support upload` copies a file from the local file system to a SUBNET ticket.
+
+.. end-mc-support-upload-desc
+
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-minio-only
+   :end-before: end-minio-only
+
+Syntax
+------
+      
+The :mc:`mc support profile` command has the following syntax:
+
+.. code-block:: shell
+
+   mc [GLOBALFLAGS] support profile     \
+                            ALIAS       \
+                            FILE        \
+                            [--comment] \
+                            [--issue]
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment.
+
+.. mc-cmd:: FILE
+   :required:
+
+   The path to the file to upload to SUBNET.
+
+.. mc-cmd:: --comment
+   :optional:
+
+   Include a message to the issue when uploading the file.
+
+.. mc-cmd:: --issue
+   :optional:
+
+   Specify the issue number to which to add the file.
+   If not specified, the file uploads to the generic issue number ``0``.
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Upload a file to an issue
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This command uploads the file ``./trace.log`` from the local file system to the SUBNET issue number 10001 for the deployment with alias ``minio1``.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support upload --issue 10 myminio ./trace.log 
+
+
+Upload a file to an issue with a comment for MinIO Engineers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This command uploads the file ``./trace.log`` from the local file system to the SUBNET issue number 10001 for the deployment with alias ``minio1``.
+The command also includes a comment available to MinIO Engineers about the file.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc support upload --issue 10 --comment "here is the requested trace log" myminio ./trace.log

--- a/source/reference/minio-mc/mc-support-upload.rst
+++ b/source/reference/minio-mc/mc-support-upload.rst
@@ -10,9 +10,6 @@
 
 .. mc:: mc support upload
 
-.. include:: /includes/common-mc-support.rst
-   :start-after: start-minio-only
-   :end-before: end-minio-only
 
 Description
 -----------
@@ -22,6 +19,10 @@ Description
 :mc:`mc support upload` copies a file from the local file system to a SUBNET ticket.
 
 .. end-mc-support-upload-desc
+
+.. include:: /includes/common-mc-support.rst
+   :start-after: start-minio-only
+   :end-before: end-minio-only
 
 Syntax
 ------

--- a/source/reference/minio-mc/mc-support-upload.rst
+++ b/source/reference/minio-mc/mc-support-upload.rst
@@ -23,10 +23,6 @@ Description
 
 .. end-mc-support-upload-desc
 
-.. include:: /includes/common-mc-support.rst
-   :start-after: start-minio-only
-   :end-before: end-minio-only
-
 Syntax
 ------
       
@@ -82,7 +78,7 @@ This command uploads the file ``./trace.log`` from the local file system to the 
 .. code-block:: shell
    :class: copyable
 
-   mc support upload --issue 10 myminio ./trace.log 
+   mc support upload --issue 10001 minio1 ./trace.log 
 
 
 Upload a file to an issue with a comment for MinIO Engineers
@@ -94,4 +90,4 @@ The command also includes a comment available to MinIO Engineers about the file.
 .. code-block:: shell
    :class: copyable
 
-   mc support upload --issue 10 --comment "here is the requested trace log" myminio ./trace.log
+   mc support upload --issue 10001 --comment "here is the requested trace log" minio1 ./trace.log

--- a/source/reference/minio-mc/mc-support.rst
+++ b/source/reference/minio-mc/mc-support.rst
@@ -87,3 +87,4 @@ Subcommands
    /reference/minio-mc/mc-support-profile
    /reference/minio-mc/mc-support-proxy
    /reference/minio-mc/mc-support-top
+   /reference/minio-mc/mc-support-upload


### PR DESCRIPTION
mc RELEASE.2024-03-07T00-31-49Z

- Adds new mc support upload command.
  
Closes #1152

mc RELEASE.2024-03-03T00-13-08Z

- Adds alias options for replicate add and replicate update
- Adds exclude-bucket flag for mc mirror
    
Closes #1143

Staged:

- [mc mirror --exclude-bucket](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc/mc-mirror.html#mc.mirror.-exclude-bucket)
- [mc support upload](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc/mc-support-upload.html)
- [mc replicate add --remote-bucket](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc/mc-replicate-add.html#mc.replicate.add.-remote-bucket)
- [mc replicate update --remote-bucket](http://192.241.195.202:9000/staging/mc-releases/linux/reference/minio-mc/mc-replicate-update.html#mc.replicate.update.-remote-bucket)