### PR TITLE
Updates for several releases and issues

### DIFF
--- a/source/administration/console/managing-deployment.rst
+++ b/source/administration/console/managing-deployment.rst
@@ -81,16 +81,10 @@ Watch
 The :guilabel:`Watch` section displays S3 events as they occur on the selected bucket. 
 This section provides similar functionality to :mc:`mc watch`.
 
-Drives
-~~~~~~
+Encryption
+~~~~~~~~~~
 
-The :guilabel:`Drives` section displays the healing status for a bucket. 
-MinIO automatically heals objects and drives when it detects problems, such as drive-level corruption or a replacement drive.
-
-.. important::
-
-   MinIO does not recommend performing manual healing unless explicitly directed by support. 
-
+The :guilabel:`Encryption` section allows you to view the status and metrics for configured :kes-docs:`Key Encryption Service <>` providers.
 
 .. _minio-console-notifications:
 
@@ -135,8 +129,8 @@ You can use keys created or listed in this view for object encryption operations
 
 .. _minio-console-settings:
 
-Settings
---------
+Configuration
+-------------
 
 The :guilabel:`Settings` section provides an interface for viewing and retrieving :ref:`configuration settings <minio-server-configuration-settings>` for all MinIO Servers in the deployment. 
 Use the buttons to :guilabel:`Export` and :guilabel:`Import` the settings between deployments.

--- a/source/administration/console/managing-objects.rst
+++ b/source/administration/console/managing-objects.rst
@@ -120,7 +120,7 @@ When managing a bucket, your access settings may allow you to view or change any
 Tiers
 -----
 
-The :guilabel:`Tiers` section provides an interface for adding and managing :ref:`remote tiers <minio-lifecycle-management-tiering>` to support lifecycle management transition rules.
+The :guilabel:`Tiering` section provides an interface for adding and managing :ref:`remote tiers <minio-lifecycle-management-tiering>` to support lifecycle management transition rules.
 MinIO tiering supports moving objects from the deployment to the remote storage, but does not support automatically restoring them to the deployment.
 
 The tiering tab allows users with the appropriate permissions to:

--- a/source/administration/console/subnet-registration.rst
+++ b/source/administration/console/subnet-registration.rst
@@ -36,21 +36,8 @@ You should instead rely on your own legal counsel or licensing specialists to au
 MinIO Commercial Licensing is the best option for applications which trigger AGPLv3 obligations (for example, open sourcing your application). 
 Applications using MinIO — or any other OSS-licensed code — without validating their usage do so at their own risk.
 
-Support
--------
-
-Proprietary application stacks that register for a commercial license choose engineering support under either the :guilabel:`Standard` or :guilabel:`Enterprise` License and Support plans.
-Both support plans share the same commercial license to MinIO.
-
-The :guilabel:`Support` section provides an interface for generating health and performance reports.
-Support functionality requires registering your deployment with |subnet|. 
-Unregistered deployments display a :guilabel:`Register Your Cluster` button to register with your |subnet| account.
-See the :guilabel:`License` section in the Console or visit the `MinIO SUBNET <https://min.io/pricing?jmp=docs>` website for more information on registration.
-
-This section contains several subsections.
-
 Health
-~~~~~~
+------
 
 The :guilabel:`Health` section provides an interface for running a health diagnostic for the MinIO Deployment.
 For clusters connected to the Internet, the report uploads automatically to SUBNET.
@@ -61,7 +48,7 @@ Exercise caution before sending a health report to a third party or posting the 
 If desired, you can download the latest report from the page.
 
 Performance
-~~~~~~~~~~~
+-----------
 
 The :guilabel:`Performance` section provides an interface for running a performance test of the deployment.
 The resulting test can provide a general guideline of deployment performance under S3 ``GET`` and ``PUT`` requests.
@@ -69,7 +56,7 @@ The resulting test can provide a general guideline of deployment performance und
 For more complete performance testing, consider using a combination of load-testing using your staging application environments and the MinIO :minio-git:`WARP <warp>` tool.
 
 Profile
-~~~~~~~
+-------
 
 The :guilabel:`Profile` section provides an interface for running system profiling of the deployment.
 The results can provide insight into the MinIO server process running on a given node.
@@ -78,7 +65,7 @@ The resulting report is intended for use by MinIO Engineering via |subnet|.
 Independent or third-party use of these profiles for diagnostics and remediation is done at your own risk.
 
 Inspect
-~~~~~~~
+-------
 
 The :guilabel:`Inspect` section provides an interface for capturing the erasure-coded metadata associated to an object or objects.
 MinIO Engineering may request this output as part of diagnostics in |subnet|.

--- a/source/administration/server-side-encryption/server-side-encryption-sse-c.rst
+++ b/source/administration/server-side-encryption/server-side-encryption-sse-c.rst
@@ -60,7 +60,7 @@ SSE-C with Replication
 
 .. versionchanged:: Server RELEASE.2024-03-30T09-41-56Z
 
-   Objects encrypted with SSE-C can generally now replicate under both site replication or bucket replication.
+   Objects encrypted with SSE-C can replicate through both site replication or bucket replication.
    Previous versions of MinIO Object Store did not replicate SSE-C encrypted objects.
 
 SSE-C encrypted objects that are compressed are not compatible with MinIO :ref:`bucket replication <minio-bucket-replication>` or :ref:`site replication <minio-site-replication-overview>`. 

--- a/source/administration/server-side-encryption/server-side-encryption-sse-c.rst
+++ b/source/administration/server-side-encryption/server-side-encryption-sse-c.rst
@@ -55,14 +55,16 @@ which specified that |EK| when requesting SSE-C encryption.
 Considerations
 --------------
 
-SSE-C is Incompatible with Bucket Replication
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SSE-C with Replication
+~~~~~~~~~~~~~~~~~~~~~~
 
-SSE-C encrypted objects are not compatible with MinIO 
-:ref:`bucket replication <minio-bucket-replication>`. Use
-:ref:`SSE-KMS <minio-encryption-sse-kms>` or
-:ref:`SSE-S3 <minio-encryption-sse-s3>` to ensure encrypted
-objects are compatible with bucket replication.
+.. versionchanged:: Server RELEASE.2024-03-30T09-41-56Z
+
+   Objects encrypted with SSE-C can generally now replicate under both site replication or bucket replication.
+   Previous versions of MinIO Object Store did not replicate SSE-C encrypted objects.
+
+SSE-C encrypted objects that are compressed are not compatible with MinIO :ref:`bucket replication <minio-bucket-replication>` or :ref:`site replication <minio-site-replication-overview>`. 
+Use :ref:`SSE-KMS <minio-encryption-sse-kms>` or :ref:`SSE-S3 <minio-encryption-sse-s3>` to ensure encrypted objects are compatible with replication.
 
 SSE-C Overrides SSE-S3 and SSE-KMS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/operations/install-deploy-manage/minio-operator-console.rst
+++ b/source/operations/install-deploy-manage/minio-operator-console.rst
@@ -94,14 +94,14 @@ On that date, Operator automatically renews the tenant's certificate.
 Operator 4.3.3 to 4.5.3
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Operator version 4.3.3 through 4.5.3 automatically renew tenant certificates after they reach 48 hours before expiration.
+Operator versions 4.3.3 through 4.5.3 automatically renew tenant certificates after they reach 48 hours before expiration.
 
 For a certificate that expires on December 31, 2023, Operator renews the certificate on December 29 or December 30, within 48 of the expiration.
 
 Operator 4.3.2 or earlier
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Older versions of Operator 4.3.2 or before do not automatically renew certificates.
+Operator versions 4.3.2 and earlier do not automatically renew certificates.
 You must renew the tenant certificates on these releases separately.
 
 Review Your MinIO License

--- a/source/operations/install-deploy-manage/minio-operator-console.rst
+++ b/source/operations/install-deploy-manage/minio-operator-console.rst
@@ -79,6 +79,31 @@ Tenant Registration
    
    You can obtain the key from |SUBNET| through the Console by selecting :guilabel:`Get from SUBNET`.
 
+TLS Certificate Renewal
+-----------------------
+
+Operator 4.5.4 or later
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Operator versions 4.5.4 and later automatically renew a tenant's certificates when the duration of the certificate has reached 80% of its life.
+
+For example, a tenant certificate was issued on January 1, 2023, and set to expire on December 31, 2023.
+80% of the 1 year life of the certificate comes on day 292, or October 19, 2023.
+On that date, Operator automatically renews the tenant's certificate.
+
+Operator 4.3.3 to 4.5.3
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Operator version 4.3.3 through 4.5.3 automatically renew tenant certificates after they reach 48 hours before expiration.
+
+For a certificate that expires on December 31, 2023, Operator renews the certificate on December 29 or December 30, within 48 of the expiration.
+
+Operator 4.3.2 or earlier
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Older versions of Operator 4.3.2 or before do not automatically renew certificates.
+You must renew the tenant certificates on these releases separately.
+
 Review Your MinIO License
 -------------------------
 

--- a/source/reference/minio-mc/mc-ilm-restore.rst
+++ b/source/reference/minio-mc/mc-ilm-restore.rst
@@ -29,7 +29,7 @@ tier, while the temporary copy becomes ``HEAD`` for that object.
 .. versionadded:: mc RELEASE.2023-04-12T02-21-51Z
 
    Use :mc:`mc stat` to display whether a restored object reads from the local temporary copy or the remote tier.
-   Restored objects read from the local copy show a status of ``Ongoing : true``.
+   Objects currently in the process of restoration from the remote tier show a status of ``Ongoing : true``.
 
 .. tab-set::
 


### PR DESCRIPTION
Updates for server RELEASE.2024-03-30T09-41-56Z
    
- Adds information that SSE-C encrypted objects can now replicate.
    
Closes #1177

- Adds information on operator renewal of tenant certificates
    
Closes #1167

- Corrects a description for `ilm restore` function
    
Closes #1175

Updates for Console release 0.45.0
    
- Removes healing references
- Updates headings and subheadings for the current Console UI
    
Closes #1107

Staged:
- [SSE-C with replication](http://192.241.195.202:9000/staging/console45/linux/administration/server-side-encryption/server-side-encryption-sse-c.html#sse-c-with-replication)
- [TLS Certificate Renewal in Operator](http://192.241.195.202:9000/staging/console45/k8s/operations/install-deploy-manage/minio-operator-console.html#tls-certificate-renewal)
- [mc ilm restore](http://192.241.195.202:9000/staging/console45/linux/reference/minio-mc/mc-ilm-restore.html)
- [MinIO Console](http://192.241.195.202:9000/staging/console45/linux/administration/minio-console.html) - changes are in the subpages from here