### PR TITLE
DOCS-1178: Add S3 API Compatibility List

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -179,6 +179,7 @@ For more about connecting to ``play``, see :ref:`MinIO Console play Login <minio
       File Transfer Protocol <https://min.io/docs/minio/linux/developers/file-transfer-protocol.html?ref=docs>
       MinIO Client <https://min.io/docs/minio/linux/reference/minio-mc.html?ref=docs>
       MinIO Admin Client <https://min.io/docs/minio/linux/reference/minio-mc-admin.html?ref=docs>
+      S3 API Compatibility <https://min.io/docs/minio/linux/reference/s3-api-compatibility.html?ref=docs>
       Integrations <https://min.io/docs/minio/linux/integrations/integrations.html?ref=docs>
 
 .. cond:: linux
@@ -195,6 +196,7 @@ For more about connecting to ``play``, see :ref:`MinIO Console play Login <minio
       /reference/minio-mc-admin
       /reference/minio-mc-deprecated
       /reference/minio-server/minio-server
+      /reference/s3-api-compatibility
       /integrations/integrations
 
 .. cond:: k8s
@@ -209,6 +211,7 @@ For more about connecting to ``play``, see :ref:`MinIO Console play Login <minio
       /developers/file-transfer-protocol
       MinIO Client <https://min.io/docs/minio/linux/reference/minio-mc.html?ref=docs>
       MinIO Admin Client <https://min.io/docs/minio/linux/reference/minio-mc-admin.html?ref=docs>
+      S3 API Compatibility <https://min.io/docs/minio/linux/reference/s3-api-compatibility.html?ref=docs>
       Integrations <https://min.io/docs/minio/linux/integrations/integrations.html?ref=docs>
       /reference/kubectl-minio-plugin
       /reference/operator-crd

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -8,7 +8,7 @@ S3 API Compatibility
    :local:
    :depth: 2
 
-This page documents all S3 APIs supported by MinIO Object Storage.
+This page documents S3 APIs supported by MinIO Object Storage.
 For reference documentation on any given API, see the corresponding documentation for Amazon S3.
 
 .. important::
@@ -55,10 +55,10 @@ Multipart Uploads
 :s3-api:`UploadPart <API_UploadPart.html>`
 :s3-api:`UploadPartCopy <API_UploadPartCopy.html>`
 
-Unsupported API Endpoints
+Unsupported API Object Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: none
+.. code-block:: text
 
    GetObjectTorrent
    GetObjectAcl
@@ -116,7 +116,7 @@ Bucket Policies
 - :s3-api:`PutBucketPolicy <API_PutBucketPolicy.html>`
 - :s3-api:`DeleteBucketPolicy <API_DeleteBucketPolicy.html>`
 
-Unsupported API Endpoints
+Unsupported API Bucket Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: none

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -58,13 +58,12 @@ Multipart Uploads
 Unsupported API Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``GetObjectTorrent``
+.. code-block:: none
 
-- ``GetObjectAcl``
-
-- ``PutObjectAcl``
-
-- ``WriteGetObjectResponse``
+   GetObjectTorrent
+   GetObjectAcl
+   PutObjectAcl
+   WriteGetObjectResponse
 
 Bucket APIs
 -----------
@@ -120,49 +119,37 @@ Bucket Policies
 Unsupported API Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- | ``GetBucketInventoryConfiguration``
-  | ``PutBucketInventoryConfiguration``
-  | ``DeleteBucketInventoryConfiguration``
+.. code-block:: none
 
-- | ``PutBucketCors``
-  | ``DeleteBucketCors``
-
-
-- | ``GetBucketMetricsConfiguration``
-  | ``PutBucketMetricsConfiguration``
-  | ``DeleteBucketMetricsConfiguration``
-
-- | ``PutBucketWebsite``
-
-- | ``GetBucketLogging``
-  | ``PutBucketLogging``
-
-- | ``PutBucketAccelerateConfiguration``
-  | ``DeleteBucketAccelerateConfiguration``
-
-- | ``PutBucketRequestPayment``
-  | ``DeleteBucketRequestPayment``
-
-- | ``PutBucketAcl``
-  | ``HeadBucketAcl``
-
-- | ``GetPublicAccessBlock``
-  | ``PutPublicAccessBlock``
-  | ``DeletePublicAccessBlock``
-
-- | ``GetBucketOwnershipControls``
-  | ``PutBucketOwnershipControls``
-  | ``DeleteBucketOwnershipControls``
-
-- | ``GetBucketIntelligentTieringConfiguration``
-  | ``PutBucketIntelligentTieringConfiguration``
-  | ``ListBucketIntelligentTieringConfigurations``
-  | ``DeleteBucketIntelligentTieringConfiguration``
-
-
-- | ``GetBucketAnalyticsConfiguration``
-  | ``PutBucketAnalyticsConfiguration``
-  | ``ListBucketAnalyticsConfigurations``
-  | ``DeleteBucketAnalyticsConfiguration``
-
-- | ``CreateSession``
+   GetBucketInventoryConfiguration
+   PutBucketInventoryConfiguration
+   DeleteBucketInventoryConfiguration
+   PutBucketCors
+   DeleteBucketCors
+   GetBucketMetricsConfiguration
+   PutBucketMetricsConfiguration
+   DeleteBucketMetricsConfiguration
+   PutBucketWebsite
+   GetBucketLogging
+   PutBucketLogging
+   PutBucketAccelerateConfiguration
+   DeleteBucketAccelerateConfiguration
+   PutBucketRequestPayment
+   DeleteBucketRequestPayment
+   PutBucketAcl
+   HeadBucketAcl
+   GetPublicAccessBlock
+   PutPublicAccessBlock
+   DeletePublicAccessBlock
+   GetBucketOwnershipControls
+   PutBucketOwnershipControls
+   DeleteBucketOwnershipControls
+   GetBucketIntelligentTieringConfiguration
+   PutBucketIntelligentTieringConfiguration
+   ListBucketIntelligentTieringConfigurations
+   DeleteBucketIntelligentTieringConfiguration
+   GetBucketAnalyticsConfiguration
+   PutBucketAnalyticsConfiguration
+   ListBucketAnalyticsConfigurations
+   DeleteBucketAnalyticsConfiguration
+   CreateSession

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -1,0 +1,168 @@
+====================
+S3 API Compatibility
+====================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+This page documents all S3 APIs supported by MinIO Object Storage.
+For reference documentation on any given API, see the corresponding documentation for Amazon S3.
+
+.. important::
+
+   MinIO strongly recommends using an :ref:`S3-Compatible SDK <minio-drivers>` for performing object storage operations.
+
+Object APIs
+-----------
+
+- :s3-api:`CopyObject <API_CopyObject.html>`
+- :s3-api:`DeleteObject <API_DeleteObject.html>`
+- :s3-api:`DeleteObjects <API_DeleteObjects.html>`
+- :s3-api:`DeleteObjectTagging <API_DeleteObjectTagging.html>`
+- :s3-api:`GetObject <API_GetObject.html>`
+- :s3-api:`GetObjectAttributes <API_GetObjectAttributes.html>`
+- :s3-api:`GetObjectTagging <API_GetObjectTagging.html>`
+- :s3-api:`HeadObject <API_HeadObject.html>`
+- :s3-api:`ListObjects <API_ListObjects.html>`
+- :s3-api:`ListObjectsV2 <API_ListObjectsV2.html>`
+- :s3-api:`ListObjectVersions <API_ListObjectVersions.html>`
+- :s3-api:`PutObject <API_PutObject.html>`
+- :s3-api:`PutObjectTagging <API_PutObjectTagging.html>`
+- :s3-api:`RestoreObject <API_RestoreObject.html>`
+- :s3-api:`SelectObjectContent <API_SelectObjectContent.html>`
+
+Object Locking
+~~~~~~~~~~~~~~
+
+- :s3-api:`GetObjectRetention <API_GetObjectRetention.html>`
+- :s3-api:`PutObjectRetention <API_PutObjectRetention.html>`
+- :s3-api:`GetObjectLegalHold <API_GetObjectLegalHold.html>`
+- :s3-api:`PutObjectLegalHold <API_PutObjectLegalHold.html>`
+- :s3-api:`GetObjectLockConfiguration <API_GetObjectLockConfiguration.html>`
+- :s3-api:`PutObjectLockConfiguration <API_PutObjectLockConfiguration.html>`
+
+Multipart Uploads
+~~~~~~~~~~~~~~~~~
+
+:s3-api:`AbortMultipartUpload <API_AbortMultipartUpload.html>`
+:s3-api:`CompleteMultipartUpload <API_CompleteMultipartUpload.html>`
+:s3-api:`CreateMultipartUpload <API_CreateMultipartUpload.html>`
+:s3-api:`ListMultipartUploads <API_ListMultipartUploads.html>`
+:s3-api:`ListParts <API_ListParts.html>`
+:s3-api:`UploadPart <API_UploadPart.html>`
+:s3-api:`UploadPartCopy <API_UploadPartCopy.html>`
+
+Unsupported API Endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``GetObjectTorrent``
+
+- ``GetObjectAcl``
+
+- ``PutObjectAcl``
+
+- ``WriteGetObjectResponse``
+
+Bucket APIs
+-----------
+
+
+- :s3-api:`CreateBucket <API_CreateBucket.html>`
+- :s3-api:`DeleteBucket <API_DeleteBucket.html>`
+- :s3-api:`DeleteBucketEncryption <API_DeleteBucketEncryption.html>`
+- :s3-api:`DeleteBucketTagging <API_DeleteBucketTagging.html>`
+- :s3-api:`GetBucketEncryption <API_GetBucketEncryption.html>`
+- :s3-api:`GetBucketLocation <API_GetBucketLocation.html>`
+- :s3-api:`GetBucketTagging <API_GetBucketTagging.html>`
+- :s3-api:`GetBucketVersioning <API_GetBucketVersioning.html>`
+- :s3-api:`HeadBucket <API_HeadBucket.html>`
+- :s3-api:`ListBuckets <API_ListBuckets.html>`
+- :s3-api:`ListDirectoryBuckets <API_ListDirectoryBuckets.html>`
+- :s3-api:`PutBucketEncryption <API_PutBucketEncryption.html>`
+- :s3-api:`PutBucketTagging <API_PutBucketTagging.html>`
+- :s3-api:`PutBucketVersioning <API_PutBucketVersioning.html>`
+
+Bucket Replication
+~~~~~~~~~~~~~~~~~~
+
+- :s3-api:`GetBucketReplication <API_GetBucketReplication.html>`
+- :s3-api:`PutBucketReplication <API_PutBucketReplication.html>`
+- :s3-api:`DeleteBucketReplication <API_DeleteBucketReplication.html>`
+
+Bucket Lifecycle
+~~~~~~~~~~~~~~~~
+
+- :s3-api:`GetBucketLifecycle <API_GetBucketLifecycle.html>`
+- :s3-api:`GetBucketLifecycleConfiguration <API_GetBucketLifecycleConfiguration.html>`
+- :s3-api:`PutBucketLifecycle <API_PutBucketLifecycle.html>`
+- :s3-api:`PutBucketLifecycleConfiguration <API_PutBucketLifecycleConfiguration.html>`
+- :s3-api:`DeleteBucketLifecycle <API_DeleteBucketLifecycle.html>`
+
+Bucket Notifications
+~~~~~~~~~~~~~~~~~~~~
+
+- :s3-api:`GetBucketNotification <API_GetBucketNotification.html>`
+- :s3-api:`GetBucketNotificationConfiguration <API_GetBucketNotificationConfiguration.html>`
+- :s3-api:`PutBucketNotification <API_PutBucketNotification.html>`
+- :s3-api:`PutBucketNotificationConfiguration <API_PutBucketNotificationConfiguration.html>`
+
+Bucket Policies
+~~~~~~~~~~~~~~~
+
+- :s3-api:`GetBucketPolicy <API_GetBucketPolicy.html>`
+- :s3-api:`GetBucketPolicyStatus <API_GetBucketPolicyStatus.html>`
+- :s3-api:`PutBucketPolicy <API_PutBucketPolicy.html>`
+- :s3-api:`DeleteBucketPolicy <API_DeleteBucketPolicy.html>`
+
+Unsupported API Endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- | ``GetBucketInventoryConfiguration``
+  | ``PutBucketInventoryConfiguration``
+  | ``DeleteBucketInventoryConfiguration``
+
+- | ``PutBucketCors``
+  | ``DeleteBucketCors``
+
+
+- | ``GetBucketMetricsConfiguration``
+  | ``PutBucketMetricsConfiguration``
+  | ``DeleteBucketMetricsConfiguration``
+
+- | ``PutBucketWebsite``
+
+- | ``GetBucketLogging``
+  | ``PutBucketLogging``
+
+- | ``PutBucketAccelerateConfiguration``
+  | ``DeleteBucketAccelerateConfiguration``
+
+- | ``PutBucketRequestPayment``
+  | ``DeleteBucketRequestPayment``
+
+- | ``PutBucketAcl``
+  | ``HeadBucketAcl``
+
+- | ``GetPublicAccessBlock``
+  | ``PutPublicAccessBlock``
+  | ``DeletePublicAccessBlock``
+
+- | ``GetBucketOwnershipControls``
+  | ``PutBucketOwnershipControls``
+  | ``DeleteBucketOwnershipControls``
+
+- | ``GetBucketIntelligentTieringConfiguration``
+  | ``PutBucketIntelligentTieringConfiguration``
+  | ``ListBucketIntelligentTieringConfigurations``
+  | ``DeleteBucketIntelligentTieringConfiguration``
+
+
+- | ``GetBucketAnalyticsConfiguration``
+  | ``PutBucketAnalyticsConfiguration``
+  | ``ListBucketAnalyticsConfigurations``
+  | ``DeleteBucketAnalyticsConfiguration``
+
+- | ``CreateSession``

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -56,7 +56,7 @@ Multipart Uploads
 - :s3-api:`UploadPartCopy <API_UploadPartCopy.html>`
 
 Unsupported API Object Endpoints
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
@@ -117,7 +117,7 @@ Bucket Policies
 - :s3-api:`DeleteBucketPolicy <API_DeleteBucketPolicy.html>`
 
 Unsupported API Bucket Endpoints
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -47,13 +47,13 @@ Object Locking
 Multipart Uploads
 ~~~~~~~~~~~~~~~~~
 
-:s3-api:`AbortMultipartUpload <API_AbortMultipartUpload.html>`
-:s3-api:`CompleteMultipartUpload <API_CompleteMultipartUpload.html>`
-:s3-api:`CreateMultipartUpload <API_CreateMultipartUpload.html>`
-:s3-api:`ListMultipartUploads <API_ListMultipartUploads.html>`
-:s3-api:`ListParts <API_ListParts.html>`
-:s3-api:`UploadPart <API_UploadPart.html>`
-:s3-api:`UploadPartCopy <API_UploadPartCopy.html>`
+- :s3-api:`AbortMultipartUpload <API_AbortMultipartUpload.html>`
+- :s3-api:`CompleteMultipartUpload <API_CompleteMultipartUpload.html>`
+- :s3-api:`CreateMultipartUpload <API_CreateMultipartUpload.html>`
+- :s3-api:`ListMultipartUploads <API_ListMultipartUploads.html>`
+- :s3-api:`ListParts <API_ListParts.html>`
+- :s3-api:`UploadPart <API_UploadPart.html>`
+- :s3-api:`UploadPartCopy <API_UploadPartCopy.html>`
 
 Unsupported API Object Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -119,7 +119,7 @@ Bucket Policies
 Unsupported API Bucket Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: none
+.. code-block:: text
 
    GetBucketInventoryConfiguration
    PutBucketInventoryConfiguration

--- a/source/url-excludes.yaml
+++ b/source/url-excludes.yaml
@@ -52,6 +52,7 @@ excludes:
 - 'reference/operator-chart-values.rst'
 - 'reference/operator-environment-variables.rst'
 - 'reference/tenant-chart-values.rst'
+- 'reference/s3-api-compatibility.rst'
 - 'developers/*'
 - 'integrations/*'
 ---
@@ -83,6 +84,7 @@ excludes:
 - 'reference/operator-chart-values.rst'
 - 'reference/operator-environment-variables.rst'
 - 'reference/tenant-chart-values.rst'
+- 'reference/s3-api-compatibility.rst'
 - 'developers/*'
 - 'integrations/*'
 ---
@@ -106,6 +108,7 @@ excludes:
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
 - 'reference/deprecated/*'
+- 'reference/s3-api-compatibility.rst'
 - 'reference/operator-crd.rst'
 - 'reference/operator-chart-values.rst'
 - 'reference/operator-environment-variables.rst'
@@ -126,7 +129,7 @@ excludes:
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
 - 'reference/deprecated/*'
-- 'reference/deprecated/*'
+- 'reference/s3-api-compatibility.rst'
 - 'developers/dotnet/*'
 - 'developers/go/*'
 - 'developers/haskell/*'
@@ -152,6 +155,7 @@ excludes:
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
 - 'reference/deprecated/*'
+- 'reference/s3-api-compatibility.rst'
 - 'developers/*'
 - 'integrations/*'
 ---
@@ -168,6 +172,7 @@ excludes:
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
 - 'reference/deprecated/*'
+- 'reference/s3-api-compatibility.rst'
 - 'developers/*'
 - 'integrations/*'
 ---
@@ -184,6 +189,7 @@ excludes:
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
 - 'reference/deprecated/*'
+- 'reference/s3-api-compatibility.rst'
 - 'developers/*'
 - 'integrations/*'
 ---
@@ -200,5 +206,6 @@ excludes:
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
 - 'reference/deprecated/*'
+- 'reference/s3-api-compatibility.rst'
 - 'developers/*'
 - 'integrations/*'


### PR DESCRIPTION
Closes #1178 

Staged: http://192.241.195.202:9000/staging/DOCS-1178/linux/reference/s3-api-compatibility.html

Summary:

This covers the S3 APIs which we directly support - reference minio/minio/cmd/api-router.go

Any APIs which are marked as 'dummy' internally are considered 'unsupported'
Admin APIs are out of scope here
MinIO API extensions are out of scope as well

We are not doing any detailed reference - just pointing out to S3