### PR TITLE
MinIO Erasure Stripe Size

### DIFF
--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -295,3 +295,45 @@ Defaults to ``"text/*, application/json, application/xml, binary/octet-stream"``
    Some	types of files cannot be significantly reduced in size.
    MinIO will *not* compress these, even if specified in an :mc-conf:`~compression.mime_types` argument.
    See :ref:`Excluded types <minio-data-compression-excluded-types>` for details.
+
+Erasure Stripe Size
+~~~~~~~~~~~~~~~~~~~
+
+.. tab-set:: 
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_ERASURE_SET_DRIVE_COUNT
+
+   .. tab-item:: Configuration Variable
+      :sync: config
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+*Optional*
+
+The :ref:`erasure set size <minio-ec-basics>` to apply for all drives in a given :term:`server pool`.
+
+You **must** set this value before you first start the server pool nodes.
+The stripe size selected for the first server pool becomes a baseline minimum for any additional server pools.
+
+You **cannot** change the erasure set stripe size once the deployment starts.
+
+**Do not** deploy custom stripe sizes into production without first validating in lower environments using a mix of performance, stress, and real-workload tests.
+
+.. important::
+
+   Stripe size impacts multiple areas of functionality, including:
+
+   - Storage Capacity
+   - Failure Tolerance
+   - Parity Configuration
+   - Workload Efficiency
+
+   MinIO provides the `Erasure Code Calculator <https://min.io/product/erasure-code-calculator?jmp=docs>`__ to provide a baseline of potential configurations for your deployments.
+   |subnet| users should log in and open an issue to discuss stripe size settings prior to implementing them in testing or production workloads.
+
+   MinIO's default stripe selection algorithms are typically sufficient for the majority of workloads.

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -317,26 +317,17 @@ Erasure Stripe Size
 
 The :ref:`erasure set size <minio-ec-basics>` to apply for all drives in a given :term:`server pool`.
 
-You **must** set this value before you first start the server pool nodes.
-The stripe size selected for the first server pool becomes a baseline minimum for any additional server pools.
+You **must** set this value before you initialize the cluster.
+The selected stripe size is **immutable** after the cluster has been initialized and affects any future server pools added to the cluster.
 
-You **cannot** change the erasure set stripe size after the cluster has been initialized.
-
-**Do not** deploy custom stripe sizes into production without first validating in lower environments using a mix of performance, stress, and real-workload tests.
+|subnet| users should log in and open an issue to discuss stripe size settings prior to implementing them in any environment.
 
 .. important::
 
-   Stripe size impacts multiple areas of functionality, including:
-
-   - Storage Capacity
-   - Failure Tolerance
-   - Parity Configuration
-   - Workload Efficiency
-
+   **Do not** change the stripe size setting unless directed to by MinIO engineering.
+   
+   Changes to stripe size have significant impact to deployment functionality, availability, performance, and behavior.
    MinIO's default stripe selection algorithms are typically sufficient for the majority of workloads.
 
-   **Do not** change the stripe size setting unless directed to by MinIO engineering.
-   Changes to stripe size have significant impact to deployment functionality, availability, performance, and behavior and **cannot be reversed**.
-   |subnet| users should log in and open an issue to discuss stripe size settings prior to implementing them in testing or production workloads.
 
    

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -317,7 +317,7 @@ Erasure Stripe Size
 
 The :ref:`erasure set size <minio-ec-basics>` to apply for all drives in a given :term:`server pool`.
 
-You **must** set this value before you initialize the cluster.
+If you set this value, you **must** do so *before* you initialize the cluster
 The selected stripe size is **immutable** after the cluster has been initialized and affects any future server pools added to the cluster.
 
 |subnet| users should log in and open an issue to discuss stripe size settings prior to implementing them in any environment.
@@ -327,7 +327,8 @@ The selected stripe size is **immutable** after the cluster has been initialized
    **Do not** change the stripe size setting unless directed to by MinIO engineering.
    
    Changes to stripe size have significant impact to deployment functionality, availability, performance, and behavior.
-   MinIO's default stripe selection algorithms are typically sufficient for the majority of workloads.
+   MinIO's stripe selection algorithms set appropriate defaults for the majority of workloads.
+   Changing the stripe size from this default is unusual and generally not necessary or advised.
 
 
    

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -320,7 +320,7 @@ The :ref:`erasure set size <minio-ec-basics>` to apply for all drives in a given
 You **must** set this value before you first start the server pool nodes.
 The stripe size selected for the first server pool becomes a baseline minimum for any additional server pools.
 
-You **cannot** change the erasure set stripe size once the deployment starts.
+You **cannot** change the erasure set stripe size after the cluster has been initialized.
 
 **Do not** deploy custom stripe sizes into production without first validating in lower environments using a mix of performance, stress, and real-workload tests.
 

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -333,7 +333,10 @@ You **cannot** change the erasure set stripe size after the cluster has been ini
    - Parity Configuration
    - Workload Efficiency
 
-   MinIO provides the `Erasure Code Calculator <https://min.io/product/erasure-code-calculator?jmp=docs>`__ to provide a baseline of potential configurations for your deployments.
+   MinIO's default stripe selection algorithms are typically sufficient for the majority of workloads.
+
+   **Do not** change the stripe size setting unless directed to by MinIO engineering.
+   Changes to stripe size have significant impact to deployment functionality, availability, performance, and behavior and **cannot be reversed**.
    |subnet| users should log in and open an issue to discuss stripe size settings prior to implementing them in testing or production workloads.
 
-   MinIO's default stripe selection algorithms are typically sufficient for the majority of workloads.
+   


### PR DESCRIPTION
Staged: http://192.241.195.202:9000/staging/ERASURE_STRIPE_SIZE/linux/reference/minio-server/settings/core.html#erasure-stripe-size

# Overview

We get somewhat frequent inquiries on how to set a stripe size.

We're going to document the option, but heavily emphasize how carefully this needs to be handled

The defaults are *almost always* the best choice.

We are not going to provide any additional guidance here.