### PR TITLE
Adding info about the MINIO_OPTS envvar

### DIFF
--- a/source/reference/minio-server/minio-server.rst
+++ b/source/reference/minio-server/minio-server.rst
@@ -25,6 +25,8 @@ For examples of deploying :mc:`minio server` on a bare metal environment, see :r
 For examples of deploying :mc:`minio server` on a Kubernetes environment, see :ref:`Deploying a MinIO Tenant <minio-k8s-deploy-minio-tenant>`.
 
 
+.. _minio-server-parameters:
+
 Syntax
 ~~~~~~
 
@@ -231,10 +233,15 @@ The command accepts the following arguments:
 
    Outputs server logs and startup information in ``JSON`` format.
 
+.. note::
+
+   You can define any of the ``minio`` parameters above by setting them in the :envvar:`MINIO_OPTS` environment variable.
+   This variable takes as its value a single string that contains any of the above parameters and their values that you want to set when starting the MinIO Server.
+
 Settings
 --------
 
-You can perform additional customizations to the MinIO Server process by defining :ref:`Configuration Values <minio-server-configuration-options>` or :ref:`Environment Variables <minio-server-environment-variables>`.
+You can perform other customizations to the MinIO Server process by defining additional :ref:`Configuration Values <minio-server-configuration-options>` or :ref:`Environment Variables <minio-server-environment-variables>`.
 
 Many configuration values and environment variables define the same value.
 If you set both a configuration value and the matching environment variable, MinIO uses the value from the environment variable.

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -20,6 +20,33 @@ This page covers settings that control core behavior of the MinIO process.
    :start-after: start-minio-settings-test-before-prod
    :end-before: end-minio-settings-test-before-prod
 
+MinIO Options
+~~~~~~~~~~~~~
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_OPTS
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+  
+      There is no configuration setting for this variable, as these settings apply at server startup.
+
+*Optional*
+
+Set a string of :ref:`parameters <minio-server-parameters>` to use when starting the MinIO Server.
+For example, to set up ftp access, you could set the variable to something like the following:
+
+.. code-block:: shell
+   :class: copyable
+
+   export MINIO_OPTS=' "--console-address="9001" --ftp="address=:8021" --ftp="passive-port-range=30000-40000" '
+
+On Unix-like systems, you can save a file with the environment variable to ``/etc/defaults/minio`` instead of setting the variable manually.
+
 Common Settings
 ---------------
 


### PR DESCRIPTION
We didn't discuss `MINIO_OPTS` anywhere.
This adds it.

Staged:
- [MinIO Server overview page](http://192.241.195.202:9000/staging/opts/linux/reference/minio-server/minio-server.html#settings)
- [Core settings page](http://192.241.195.202:9000/staging/opts/linux/reference/minio-server/settings/core.html#envvar.MINIO_OPTS)