### PR TITLE
Quick Fix: KES Guidance

### DIFF
--- a/source/administration/server-side-encryption.rst
+++ b/source/administration/server-side-encryption.rst
@@ -33,6 +33,9 @@ MinIO SSE is feature and API compatible with :s3-docs:`AWS Server-Side Encryptio
 
       For buckets without automatic SSE-KMS encryption, clients can specify an |EK| as part of the write operation instead.
 
+      MinIO encrypts backend data as part of enabling server-side encryption.
+      You cannot disable SSE-KMS encryption once enabled.
+
       SSE-KMS provides more granular and customizable encryption compared to SSE-S3 and SSE-C and is recommended over the other supported encryption methods.
 
       For a tutorial on enabling SSE-KMS in a local (non-production) MinIO Deployment, see :ref:`minio-encryption-sse-kms-quickstart`. 
@@ -55,6 +58,9 @@ MinIO SSE is feature and API compatible with :s3-docs:`AWS Server-Side Encryptio
 
       For buckets without automatic SSE-S3 encryption, clients can request
       SSE encryption as part of the write operation instead.
+
+      MinIO encrypts backend data as part of enabling server-side encryption.
+      You cannot disable SSE-KMS encryption once enabled.
 
       For a tutorial on enabling SSE-s3 in a local (non-production) MinIO
       Deployment, see :ref:`minio-encryption-sse-s3-quickstart`. For

--- a/source/administration/server-side-encryption/server-side-encryption-sse-kms.rst
+++ b/source/administration/server-side-encryption/server-side-encryption-sse-kms.rst
@@ -64,6 +64,12 @@ MinIO SSE-KMS is functionally compatible with AWS S3 :s3-docs:`Server-Side Encry
 Quickstart
 ----------
 
+.. important::
+
+   .. include:: /includes/common/common-minio-kes.rst
+      :start-after: start-kes-encrypted-backend-desc
+      :end-before: end-kes-encrypted-backend-desc
+
 The following procedure uses the ``play`` MinIO |KES| sandbox for 
 supporting |SSE| with SSE-KMS in evaluation and early development environments.
 

--- a/source/administration/server-side-encryption/server-side-encryption-sse-s3.rst
+++ b/source/administration/server-side-encryption/server-side-encryption-sse-s3.rst
@@ -61,6 +61,12 @@ following KMS providers:
 Quickstart
 ----------
 
+.. important::
+
+   .. include:: /includes/common/common-minio-kes.rst
+      :start-after: start-kes-encrypted-backend-desc
+      :end-before: end-kes-encrypted-backend-desc
+
 The following procedure uses the ``play`` MinIO |KES| sandbox for 
 supporting |SSE| with SSE-S3 in evaluation and early development environments.
 

--- a/source/includes/common/common-minio-kes.rst
+++ b/source/includes/common/common-minio-kes.rst
@@ -5,7 +5,8 @@
 
 Enabling |SSE| on a MinIO deployment automatically encrypts the backend data for that deployment using the default encryption key.
 
-MinIO *requires* access to KES *and* the root KMS to decrypt the backend and start normally.
+MinIO *requires* access to KES and the external KMS to decrypt the backend and start normally.
+The KMS **must** maintain and provide access to the :envvar:`MINIO_KMS_KES_KEY_NAME`.
 You cannot disable KES later or "undo" the |SSE| configuration at a later point.
 
 .. end-kes-encrypted-backend-desc

--- a/source/operations/server-side-encryption.rst
+++ b/source/operations/server-side-encryption.rst
@@ -56,6 +56,9 @@ supports the following encryption strategies:
       For buckets without automatic SSE-KMS encryption, clients can specify
       an |EK| as part of the write operation instead.
 
+      MinIO encrypts backend data as part of enabling server-side encryption.
+      You cannot disable SSE-KMS encryption once enabled.
+
       SSE-KMS provides more granular and customizable encryption compared to
       SSE-S3 and SSE-C and is recommended over the other supported encryption
       methods.
@@ -71,6 +74,9 @@ supports the following encryption strategies:
 
       For buckets without automatic SSE-S3 encryption, clients can request
       SSE encryption as part of the write operation instead.
+
+      MinIO encrypts backend data as part of enabling server-side encryption.
+      You cannot disable SSE-KMS encryption once enabled.
 
       For a tutorial on enabling SSE-s3 in a local (non-production) MinIO Deployment, see :ref:`minio-encryption-sse-s3-quickstart`.
 

--- a/source/reference/minio-server/settings/kes.rst
+++ b/source/reference/minio-server/settings/kes.rst
@@ -60,6 +60,12 @@ Refer to your operating system's documentation for how to define an environment 
 
    - The encryption key for Server-Side Encryption with :ref:`SSE-S3 <minio-encryption-sse-s3>`.
 
+   .. important::
+
+      .. include:: /includes/common/common-minio-kes.rst
+         :start-after: start-kes-encrypted-backend-desc
+         :end-before: end-kes-encrypted-backend-desc
+
 .. envvar:: MINIO_KMS_KES_ENCLAVE
 
    Use this optional environment variable to define the name of a KES enclave.


### PR DESCRIPTION
We already state on one page that you cannot undo KES once configured.

This ensures we make that statement on all other relevant pages.

Staged:

- http://192.241.195.202:9000/staging/QUICKFIX/linux/operations/server-side-encryption.html - SSE-KMS and SSE-S3 tabs
- http://192.241.195.202:9000/staging/QUICKFIX/linux/operations/server-side-encryption/configure-minio-kes.html
- http://192.241.195.202:9000/staging/QUICKFIX/linux/administration/server-side-encryption.html SSE KMS and SSE-S3 Tabs
- http://192.241.195.202:9000/staging/QUICKFIX/linux/administration/server-side-encryption/server-side-encryption-sse-kms.html#quickstart
- http://192.241.195.202:9000/staging/QUICKFIX/linux/administration/server-side-encryption/server-side-encryption-sse-s3.html#quickstart