### PR TITLE
Replace mc admin console references with mc admin logs

### DIFF
--- a/source/operations/data-recovery/recover-after-drive-failure.rst
+++ b/source/operations/data-recovery/recover-after-drive-failure.rst
@@ -111,7 +111,7 @@ The command should result in remounting of all of the replaced drives.
 5) Monitor MinIO for Drive Detection and Healing Status
 -------------------------------------------------------
 
-Use :mc:`mc admin console` command *or* ``journalctl -u minio`` for
+Use :mc:`mc admin logs` command *or* ``journalctl -u minio`` for
 ``systemd``-managed installations to monitor the server log output after
 remounting drives. The output should include messages identifying each formatted
 and empty drive.

--- a/source/operations/data-recovery/recover-after-node-failure.rst
+++ b/source/operations/data-recovery/recover-after-node-failure.rst
@@ -73,8 +73,8 @@ in the deployment.
 ------------------------------------
 
 Start the MinIO server process on the node and monitor the process output
-using :mc:`mc admin console` or by monitoring the MinIO service logs
-using ``journalctl -u minio`` for ``systemd`` managed installations.
+using :mc:`mc admin logs` or by monitoring the MinIO service logs using 
+``journalctl -u minio`` for ``systemd`` managed installations.
 
 The server output should indicate that it has detected the other nodes
 in the deployment and begun :ref:`healing operations <minio-concepts-healing>`.

--- a/source/operations/install-deploy-manage/decommission-server-pool.rst
+++ b/source/operations/install-deploy-manage/decommission-server-pool.rst
@@ -310,7 +310,7 @@ the next step once decommissioning is completed.
 
 If :guilabel:`Status` reads as failed, you can re-run the
 :mc-cmd:`mc admin decommission start` command to resume the process. 
-For persistent failures, use :mc:`mc admin console` or review
+For persistent failures, use :mc:`mc admin logs` or review
 the ``systemd`` logs (e.g. ``journalctl -u minio``) to identify more specific
 errors.
 
@@ -505,7 +505,7 @@ The command returns output similar to the following:
 You can move on to the next step once MinIO completes decommissioning for all pools.
 
 If :guilabel:`Status` reads as failed, you can re-run the :mc-cmd:`mc admin decommission start` command to resume the process. 
-For persistent failures, use :mc:`mc admin console` or review the ``systemd`` logs (e.g. ``journalctl -u minio``) to identify more specific errors.
+For persistent failures, use :mc:`mc admin logs` or review the ``systemd`` logs (e.g. ``journalctl -u minio``) to identify more specific errors.
 
 4) Remove the Decommissioned Pools from the Deployment Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
mc admin console command is depreciated, users should start using mc admin logs instead.