### PR TITLE
Note that mc support perf suspends other S3 API calls for testing

### DIFF
--- a/source/reference/minio-mc/mc-support-perf.rst
+++ b/source/reference/minio-mc/mc-support-perf.rst
@@ -28,8 +28,16 @@ Use the :mc:`mc support perf` command to review the performance of the S3 API (r
 .. end-mc-support-perf-desc
 
 The resulting tests can provide general guidance of deployment performance under S3 ``GET`` and ``PUT`` requests and identify any potential bottlenecks.
+
+.. admonition:: Other S3 API calls suspended during testing
+   :class: note
+
+   For S3 testing, :mc:`mc support perf` temporarily suspends S3 API calls during a test.
+   They are automatically restarted after the test is complete or if the command is cancelled.
+
 For more complete performance testing, consider using a combination of load-testing using your staging application environments and the MinIO `WARP <https://github.com/minio/warp>`_ S3 benchmarking tool.
-   
+
+
 :mc:`mc support perf` has the following subcommands
 
 #. :mc-cmd:`~mc support perf drive`

--- a/source/reference/minio-mc/mc-support-perf.rst
+++ b/source/reference/minio-mc/mc-support-perf.rst
@@ -29,12 +29,6 @@ Use the :mc:`mc support perf` command to review the performance of the S3 API (r
 
 The resulting tests can provide general guidance of deployment performance under S3 ``GET`` and ``PUT`` requests and identify any potential bottlenecks.
 
-.. admonition:: Other S3 API calls suspended during testing
-   :class: note
-
-   For S3 testing, :mc:`mc support perf` temporarily suspends S3 API calls during a test.
-   They are automatically restarted after the test is complete or if the command is cancelled.
-
 For more complete performance testing, consider using a combination of load-testing using your staging application environments and the MinIO `WARP <https://github.com/minio/warp>`_ S3 benchmarking tool.
 
 
@@ -44,6 +38,9 @@ For more complete performance testing, consider using a combination of load-test
 
    Measure the speed of drives in a MinIO deployment.
 
+   :mc-cmd:`mc support perf drive` temporarily suspends S3 API calls during the test.
+   Incoming requests are queued until the test is complete or the command is cancelled.
+
 #. :mc-cmd:`~mc support perf object`
       
    Measure the speed of reading and writing objects in a cluster.
@@ -51,6 +48,9 @@ For more complete performance testing, consider using a combination of load-test
 #. :mc-cmd:`~mc support perf net`
 
    Measure the network throughput of all nodes.
+
+   :mc-cmd:`mc support perf net` temporarily suspends S3 API calls during the test.
+   Incoming requests are queued until the test is complete or the command is cancelled.
 
 #. :mc-cmd:`~mc support perf client`
 

--- a/source/reference/minio-mc/mc-support-perf.rst
+++ b/source/reference/minio-mc/mc-support-perf.rst
@@ -28,9 +28,7 @@ Use the :mc:`mc support perf` command to review the performance of the S3 API (r
 .. end-mc-support-perf-desc
 
 The resulting tests can provide general guidance of deployment performance under S3 ``GET`` and ``PUT`` requests and identify any potential bottlenecks.
-
 For more complete performance testing, consider using a combination of load-testing using your staging application environments and the MinIO `WARP <https://github.com/minio/warp>`_ S3 benchmarking tool.
-
 
 :mc:`mc support perf` has the following subcommands
 

--- a/source/reference/minio-mc/mc-support-perf.rst
+++ b/source/reference/minio-mc/mc-support-perf.rst
@@ -37,7 +37,8 @@ For more complete performance testing, consider using a combination of load-test
    Measure the speed of drives in a MinIO deployment.
 
    :mc-cmd:`mc support perf drive` temporarily suspends S3 API calls during the test.
-   Incoming requests are queued until the test is complete or the command is cancelled.
+   Incoming requests are held in a queue while the command runs.
+   When the command completes or ends, MinIO processes the queued requests and resumes normal operations.
 
 #. :mc-cmd:`~mc support perf object`
       
@@ -48,7 +49,8 @@ For more complete performance testing, consider using a combination of load-test
    Measure the network throughput of all nodes.
 
    :mc-cmd:`mc support perf net` temporarily suspends S3 API calls during the test.
-   Incoming requests are queued until the test is complete or the command is cancelled.
+   Incoming requests are held in a queue while the command runs.
+   When the command completes or ends, MinIO processes the queued requests and resumes normal operations.
 
 #. :mc-cmd:`~mc support perf client`
 


### PR DESCRIPTION
Add information about queuing requests for `drive` and `net` options.

See https://github.com/minio/minio/pull/19634

Staged:
http://192.241.195.202:9000/staging/mc-support-perf-s3-api/linux/reference/minio-mc/mc-support-perf.html#description