### PR TITLE
Kustomize deployment instructions

### DIFF
--- a/source/includes/k8s/deploy-operator.rst
+++ b/source/includes/k8s/deploy-operator.rst
@@ -172,4 +172,5 @@ To install Operator using a Helm chart, see :ref:`Deploy Operator with Helm <min
    :hidden:
 
    /operations/install-deploy-manage/deploy-operator-helm
+   /operations/install-deploy-manage/deploy-operator-kustomize
    

--- a/source/operations/install-deploy-manage/deploy-minio-tenant-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant-helm.rst
@@ -90,7 +90,7 @@ You can modify the Operator deployment after installation.
 
    Use the ``helm install`` command to deploy the Tenant Chart.
 
-   If you need to override values in the default :ref:`values <minio-operator-chart-tenant-values>` file, you can use the ``--set`` operation for any single key-value.
+   If you need to override values in the default :ref:`values <minio-tenant-chart-values>` file, you can use the ``--set`` operation for any single key-value.
    Alternatively, specify your own ``values.yaml`` using the ``--f`` parameter to override multiple values at once:
 
    .. code-block:: shell

--- a/source/operations/install-deploy-manage/deploy-operator-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-helm.rst
@@ -45,8 +45,8 @@ You can modify the Operator deployment after installation.
 
 .. important::
 
-   Do not use ``kubectl krew`` or similar methods to update or manage the MinIO Operator installation.
    If you use Helm charts to install the Operator, you must use Helm to manage that installation.
+   Do not use ``kubectl krew``, Kustomize, or similar methods to update or manage the MinIO Operator installation.
 
 #. Add the MinIO Operator Repo to Helm
 
@@ -120,7 +120,7 @@ You can modify the Operator deployment after installation.
       replicaset.apps/console-68d955874d          1         1         1       25h
       replicaset.apps/minio-operator-699f797b8b   2         2         2       25h
 
-#. (Optional) Enable NodePort Access to the Console
+#. *(Optional)* Enable NodePort Access to the Console
 
    You can enable :kube-docs:`Node Port <concepts/services-networking/service/#type-nodeport>` access to the ``service/console`` service to allow simplified access to the MinIO Operator.
    You can skip this step if you intend to configure the Operator Console service to use a Kubernetes Load Balancer, ingress, or similar control plane component that enables external access.

--- a/source/operations/install-deploy-manage/deploy-operator-helm.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-helm.rst
@@ -122,8 +122,11 @@ You can modify the Operator deployment after installation.
 
 #. *(Optional)* Enable NodePort Access to the Console
 
+   The Operator Console service does not automatically bind or expose itself for external access on the Kubernetes cluster.
+   You must instead configure a network control plane component, such as a load balancer or ingress, to grant that external access.
+
    You can enable :kube-docs:`Node Port <concepts/services-networking/service/#type-nodeport>` access to the ``service/console`` service to allow simplified access to the MinIO Operator.
-   You can skip this step if you intend to configure the Operator Console service to use a Kubernetes Load Balancer, ingress, or similar control plane component that enables external access.
+   You should skip this step if you intend to configure the Operator Console service to use a Kubernetes Load Balancer, ingress, or similar control plane component that enables external access.
 
    Edit the ``service/console`` and set the ``spec.ports[0].nodePort`` and ``spec.type`` fields as follows:
 

--- a/source/operations/install-deploy-manage/deploy-operator-kustomize.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-kustomize.rst
@@ -14,21 +14,20 @@ Deploy Operator With Kustomize
 Overview
 --------
 
-`Kustomize <https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization>`__ is a YAML-based templating tool that allows you to define Operator and Tenant templates using plain Kubernetes YAML reference language.
+`Kustomize <https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization>`__ is a YAML-based templating tool that allows you to define Kubernetes resources in a declarative and repeatable fashion.
 Kustomize is included with the :kube-docs:`kubectl <reference/kubectl>` command line tool.
 
 The `default MinIO Operator Kustomize template <https://github.com/minio/operator/blob/master/kustomization.yaml>`__ provides a starting point for customizing configurations for your local environment.
-You can modify a Kustomize Operator deployment after installation with :kube-docs:`kubectl patches <reference/kubectl/generated/kubectl_patch>`, which are additional YAML configurations applied over the existing base.
+You can modify the default Kustomization file or apply your own `patches <https://datatracker.ietf.org/doc/html/rfc6902>`__ to customize the Operator deployment for your Kubernetes cluster.
 
 
 Prerequisites
 -------------
 
-To install the Operator with Kustomize you will need the following:
+Installing Operator with Kustomize requires the following prerequisites:
 
 * An existing Kubernetes cluster, v1.21 or later.
-* The ``kubectl`` CLI tool on your local host, the same version as the cluster.
-* `Docker <https://docker.com>`__ for your platform.
+* A local ``kubectl`` installation with the same version as the cluster.
 * Access to run ``kubectl`` commands on the cluster from your local host.
 
 For more about Operator installation requirements, including TLS certificates, see the :ref:`Operator deployment prerequisites <minio-operator-prerequisites>`.
@@ -46,8 +45,8 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
 
 .. important::
 
-   If you use Kustomize to install the Operator, you must use Kustomize to manage that installation.
-   Do not use ``kubectl krew``, a Helm chart, or similar methods to update or manage the MinIO Operator installation.
+   If you use Kustomize to install the Operator, you must use Kustomize to manage or update that installation.
+   Do not use ``kubectl krew``, a Helm chart, or similar methods to manage or update the MinIO Operator installation.
 
 #. Install the latest version of Operator
 
@@ -99,12 +98,12 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
    You can modify your Operator deplyoment by applying kubectl patches.
    You can find examples for common configurations in the `Operator GitHub repository <https://github.com/minio/operator/tree/master/examples/kustomization>`__.
 
-#. *(Optional)* Configure access to the Operator Console port
+#. *(Optional)* Configure access to the Operator Console service
 
-   If needed, configure access to the Operator Console port.
-   Depending on your local policies, this could be a Kubernetes load balancer, ingress, or similar control plane component that enables external access.
+   The Operator Console service does not automatically bind or expose itself for external access on the Kubernetes cluster.
+   You must instead configure a network control plane component, such as a load balancer or ingress, to grant that external access.
 
-   For testing purposes, you can access Operator Console by configuring a NodePort using the following patch:
+   For testing purposes or short-term access, expose the Operator Console service through a NodePort using the following patch:
 
    .. code-block:: shell
       :class: copyable
@@ -132,6 +131,7 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
           }
       }'
 
+   You can now access the service through port ``30433`` on any of your Kubernetes worker nodes.
 
 #. Verify the Operator installation
 

--- a/source/operations/install-deploy-manage/deploy-operator-kustomize.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-kustomize.rst
@@ -1,0 +1,214 @@
+.. _minio-k8s-deploy-operator-kustomize:
+
+==============================
+Deploy Operator With Kustomize
+==============================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+Overview
+--------
+
+`Kustomize <https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization>`__ is part of kubectl
+
+
+Prerequisites
+-------------
+
+To install the Operator with Kustomize you will need the following:
+
+* An existing Kubernetes cluster, v1.21 or later.
+* The ``kubectl`` CLI tool on your local host, the same version as the cluster.
+* `Docker <https://docker.com>`__ version something or greater.
+* Access to run ``kubectl`` commands on the cluster from your local host.
+
+For more about Operator installation requirements, including supported Kubernetes versions and TLS certificates, see the :ref:`Operator deployment prerequisites <minio-operator-prerequisites>`.
+
+This procedure assumes familiarity with the referenced Kubernetes concepts and utilities.
+While this documentation may provide guidance for configuring or deploying Kubernetes-related resources on a best-effort basis, it is not a replacement for the official :kube-docs:`Kubernetes Documentation <>`.
+
+.. _minio-k8s-deploy-operator-kustomize-repo:
+
+Install the MinIO Operator using Kustomize
+------------------------------------------
+
+The following procedure installs the Operator from the MinIO Operator GitHub repository using `kubectl kustomize <https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/>__.
+You can modify the Operator deployment after installation.
+
+.. important::
+
+   Do not use ``kubectl krew`` or similar methods to update or manage the MinIO Operator installation.
+   If you use ``kustomize`` to install the Operator, you must use ``kustomize`` to manage that installation.
+
+#. Install the latest version of Operator
+
+   .. code-block:: shell
+      :class: copyable
+
+      kubectl apply -k github.com/minio/operator\?ref=|OPERATOR|
+
+   The output resembles the following:
+
+   .. code-block:: shell
+
+      namespace/minio-operator created
+      customresourcedefinition.apiextensions.k8s.io/miniojobs.job.min.io created
+      customresourcedefinition.apiextensions.k8s.io/policybindings.sts.min.io created
+      customresourcedefinition.apiextensions.k8s.io/tenants.minio.min.io created
+      serviceaccount/console-sa created
+      serviceaccount/minio-operator created
+      clusterrole.rbac.authorization.k8s.io/console-sa-role created
+      clusterrole.rbac.authorization.k8s.io/minio-operator-role created
+      clusterrolebinding.rbac.authorization.k8s.io/console-sa-binding created
+      clusterrolebinding.rbac.authorization.k8s.io/minio-operator-binding created
+      configmap/console-env created
+      secret/console-sa-secret created
+      service/console created
+      service/operator created
+      service/sts created
+      deployment.apps/console created
+      deployment.apps/minio-operator created
+
+   Verify the Operator pods are running:
+
+   .. code-block:: shell
+      :class: copyable
+
+      kubectl get pods -n minio-operator
+
+   The output resembles the following:
+
+   .. code-block:: shell
+
+      NAME                              READY   STATUS    RESTARTS   AGE
+      console-6b6cf8946c-9cj25          1/1     Running   0          99s
+      minio-operator-69fd675557-lsrqg   1/1     Running   0          99s
+
+      The ``minio-operator`` pod is MinIO Operator and the ``console` pod is the Operator Console.
+
+#. (Optional) Configure access to the Operator Console port
+
+   If needed, configure access to the Operator Console port.
+   Depending on your local policies, this could be a Kubernetes load balancer, ingress, or similar control plane component that enables external access.
+
+   For testing purposes, you can access Operator Console by configuring a NodePort with the following Kustomize patch:
+
+   .. code-block:: shell
+      :class: copyable
+
+      kubectl patch service -n minio-operator console -p '
+      {
+          "spec": {
+              "ports": [
+                  {
+                      "name": "http",
+                      "port": 9090,
+                      "protocol": "TCP",
+                      "targetPort": 9090,
+                      "nodePort": 30090
+                  },
+                  {
+                      "name": "https",
+                      "port": 9443,
+                      "protocol": "TCP",
+                      "targetPort": 9443,
+                      "nodePort": 30433
+                  }
+              ],
+              "type": "NodePort"
+          }
+      }'
+
+
+
+#. Retrieve the Operator Console JWT for login
+
+   .. code-block:: shell
+      :class: copyable
+
+      kubectl apply -f - <<EOF
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: console-sa-secret
+        namespace: minio-operator
+        annotations:
+          kubernetes.io/service-account.name: console-sa
+      type: kubernetes.io/service-account-token
+      EOF
+      SA_TOKEN=$(kubectl -n minio-operator  get secret console-sa-secret -o jsonpath="{.data.token}" | base64 --decode)
+      echo $SA_TOKEN
+
+
+#. Verify the Operator installation
+
+   Check the contents of the specified namespace (``minio-operator``) to ensure all pods and services have started successfully.
+
+   .. code-block:: shell
+      :class: copyable
+
+      kubectl get all -n minio-operator
+
+   The response should resemble the following:
+
+   .. code-block:: shell
+
+      NAME                                  READY   STATUS    RESTARTS   AGE
+      pod/console-68d955874d-vxlzm          1/1     Running   0          25h
+      pod/minio-operator-699f797b8b-th5bk   1/1     Running   0          25h
+      pod/minio-operator-699f797b8b-nkrn9   1/1     Running   0          25h
+
+      NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
+      service/console    ClusterIP   10.43.195.224   <none>        9090/TCP,9443/TCP   25h
+      service/operator   ClusterIP   10.43.44.204    <none>        4221/TCP            25h
+      service/sts        ClusterIP   10.43.70.4      <none>        4223/TCP            25h
+
+      NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
+      deployment.apps/console          1/1     1            1           25h
+      deployment.apps/minio-operator   2/2     2            2           25h
+
+      NAME                                        DESIRED   CURRENT   READY   AGE
+      replicaset.apps/console-68d955874d          1         1         1       25h
+      replicaset.apps/minio-operator-699f797b8b   2         2         2       25h
+
+   
+#. Log into the MinIO Operator Console
+
+   If you configured the ``svc/console`` service for access through ingress, a cluster load balancer, you can access the Console using the configured hostname and port.
+
+   If you configured the service for access through NodePorts, specify the hostname of any worker node in the cluster with that port as ``HOSTNAME:NODEPORT`` to access the Console.
+
+
+$ kubectl get nodes -o wide
+NAME                 STATUS   ROLES                  AGE   VERSION        INTERNAL-IP   EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION       CONTAINER-RUNTIME
+k3d-minio-agent-0    Ready    <none>                 15m   v1.28.8+k3s1   172.18.0.3    <none>        K3s v1.28.8+k3s1   5.15.0-102-generic   containerd://1.7.11-k3s2
+k3d-minio-agent-3    Ready    <none>                 15m   v1.28.8+k3s1   172.18.0.5    <none>        K3s v1.28.8+k3s1   5.15.0-102-generic   containerd://1.7.11-k3s2
+k3d-minio-agent-2    Ready    <none>                 15m   v1.28.8+k3s1   172.18.0.6    <none>        K3s v1.28.8+k3s1   5.15.0-102-generic   containerd://1.7.11-k3s2
+k3d-minio-agent-1    Ready    <none>                 15m   v1.28.8+k3s1   172.18.0.4    <none>        K3s v1.28.8+k3s1   5.15.0-102-generic   containerd://1.7.11-k3s2
+k3d-minio-server-0   Ready    control-plane,master   15m   v1.28.8+k3s1   172.18.0.2    <none>        K3s v1.28.8+k3s1   5.15.0-102-generic   containerd://1.7.11-k3s2
+
+
+http://172.18.0.2:30090
+
+
+
+
+
+   
+   Alternatively, you can use ``kubectl port forward`` to temporary forward ports for the Console:
+   
+   .. code-block:: shell
+      :class: copyable
+
+      kubectl port-forward svc/console -n minio-operator 9090:9090
+
+   You can then use ``http://localhost:9090`` to access the MinIO Operator Console.
+
+   Once you access the Console, use the Console JWT to log in.
+
+You can now :ref:`deploy and manage MinIO Tenants using the Operator Console <deploy-minio-distributed>`.

--- a/source/operations/install-deploy-manage/deploy-operator-kustomize.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-kustomize.rst
@@ -96,7 +96,7 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
 
    In this example, the ``minio-operator`` pod is MinIO Operator and the ``console`` pod is the Operator Console.
 
-   You can modify your Operator deplyoment by applying Kustomize patches.
+   You can modify your Operator deplyoment by applying kubectl patches.
    You can find examples for common configurations in the `Operator GitHub repository <https://github.com/minio/operator/tree/master/examples/kustomization>`__.
 
 #. *(Optional)* Configure access to the Operator Console port
@@ -104,7 +104,7 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
    If needed, configure access to the Operator Console port.
    Depending on your local policies, this could be a Kubernetes load balancer, ingress, or similar control plane component that enables external access.
 
-   For testing purposes, you can access Operator Console by configuring a NodePort using the following Kustomize patch:
+   For testing purposes, you can access Operator Console by configuring a NodePort using the following patch:
 
    .. code-block:: shell
       :class: copyable
@@ -190,8 +190,9 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
    .. tab-set::
 
       .. tab-item:: NodePort
+         :selected:
 
-         If you configured the service for access through NodePorts, specify the hostname of any worker node in the cluster with that port as ``HOSTNAME:NODEPORT`` to access the Console.
+         If you configured the service for access through a NodePort, specify the hostname of any worker node in the cluster with that port as ``HOSTNAME:NODEPORT`` to access the Console.
 
          For example, a deployment configured with a NodePort of 30090 and the following ``InternalIP`` addresses can be accessed at ``http://172.18.0.5:30090``.
 
@@ -212,7 +213,7 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
 
       .. tab-item:: Port Forwarding
 
-         Alternatively, you can use ``kubectl port forward`` to temporary forward ports for the Console:
+         You can use ``kubectl port forward`` to temporary forward ports for the Console:
 
          .. code-block:: shell
             :class: copyable

--- a/source/operations/install-deploy-manage/deploy-operator-kustomize.rst
+++ b/source/operations/install-deploy-manage/deploy-operator-kustomize.rst
@@ -15,10 +15,10 @@ Overview
 --------
 
 `Kustomize <https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization>`__ is a YAML-based templating tool that allows you to define Operator and Tenant templates using plain Kubernetes YAML reference language.
-Kustomize is included with the `kubectl <https://kubernetes.io/docs/reference/kubectl/>`__ command line tool.
+Kustomize is included with the :kube-docs:`kubectl <reference/kubectl>` command line tool.
 
 The `default MinIO Operator Kustomize template <https://github.com/minio/operator/blob/master/kustomization.yaml>`__ provides a starting point for customizing configurations for your local environment.
-You can modify a Kustomize Operator deployment after installation with kubectl patches, which are additional YAML configurations applied over the existing base.
+You can modify a Kustomize Operator deployment after installation with :kube-docs:`kubectl patches <reference/kubectl/generated/kubectl_patch>`, which are additional YAML configurations applied over the existing base.
 
 
 Prerequisites


### PR DESCRIPTION
New page with Kustomize Operator deployment instructions, as a sibling to the existing Helm page. Includes some matching updates to the Helm page, for consistency. 

Replacing the Krew instructions (numerous locations) will be a separate PR.

Staged
http://192.241.195.202:9000/staging/DOCS-1125/k8s/operations/install-deploy-manage/deploy-operator-kustomize.html

See also: https://github.com/minio/operator/pull/1947

Fixes https://github.com/minio/docs/issues/1125