### PR TITLE
Remove deprecated heal options, add two trace call types

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -63,40 +63,6 @@ Syntax
    the command returns the status of that scan.
 
 
-++++++++++++++++++++
-
-
-.. dropdown:: Deprecated Arguments
-
-   The following command flags have been deprecated and should only be used under guidance from MinIO Engineers in association with a SUBNET ticket.
-
-   - ``--scan`` 
-     
-     The type of scan to perform. Specify one of the following supported scan modes:
-
-       - ``normal`` (default)
-       - ``deep``
-
-   - ``--recursive, r`` 
-     
-     Recursively scans for objects in the specified bucket or bucket prefix.
-
-   - ``--dry-run`` 
-     
-     Inspects the :mc-cmd:`~mc admin heal TARGET` bucket or bucket prefix, but does *not* perform any object healing.
-
-   - ``--force-start, f`` 
-     
-     Force starts the healing process.
-
-   - ``--force-stop, s`` 
-     
-     Force stops the healing sequence.
-
-   - ``--remove`` 
-     
-     Removes dangling objects and data directories in the healing process not referenced by the metadata on a per-drive basis.
-
 Healing Colors
 --------------
 

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -122,11 +122,13 @@ Syntax
 
    Valid call types include:
 
+   - ``batch-keyrotation``
    - ``batch-replication``
    - ``bootstrap``
    - ``decommission``
    - ``ftp``
    - ``healing``
+   - ``ilm``
    - ``internal``
    - ``os``
    - ``rebalance``


### PR DESCRIPTION
Remove several `mc admin heal` options from the reference docs. These were previously deprecated and are now hidden.

Also add two `mc admin trace` call types from the same PR, noted in the relevant GitHub docs: `batch-keyrotation` and `ilm`.

Staged
http://192.241.195.202:9000/staging/DOCS-1029/linux/reference/minio-mc-admin/mc-admin-heal.html
http://192.241.195.202:9000/staging/DOCS-1029/linux/reference/minio-mc-admin/mc-admin-trace.html#mc.admin.trace.-call

Fixes https://github.com/minio/docs/issues/1029