### PR TITLE
Deprecates the long-dead mc admin console command

### DIFF
--- a/source/administration/monitoring.rst
+++ b/source/administration/monitoring.rst
@@ -44,7 +44,7 @@ Server Logs
 
 MinIO provides the following interfaces for remotely reading server logs:
 
-- The :mc:`mc admin console` command returns the specified server's console output.
+- The :mc:`mc admin logs` command returns the specified server's console output.
 - MinIO supports pushing server logs to an HTTP webhook for further ingestion. 
   See :ref:`minio-logging-publish-server-logs` for more information.
 

--- a/source/reference/deprecated/mc-admin-console.rst
+++ b/source/reference/deprecated/mc-admin-console.rst
@@ -10,6 +10,12 @@
 
 .. mc:: mc admin console
 
+.. important::
+
+   This command has been replaced by :mc:`mc admin logs` in `mc RELEASE.2022-12-02T23-48-47Z <https://github.com/minio/mc/releases/tag/RELEASE.2022-12-02T23-48-47Z>`__.
+
+   The command was previously replaced by ``mc support logs show`` in `mc RELEASE.2022-06-26T18-51-48Z <https://github.com/minio/mc/tree/RELEASE.2022-06-26T18-51-48Z>`__.
+
 Description
 -----------
 

--- a/source/reference/deprecated/mc-admin-console.rst
+++ b/source/reference/deprecated/mc-admin-console.rst
@@ -19,12 +19,8 @@
 Description
 -----------
 
-.. start-mc-admin-console-desc
-
 The :mc:`mc admin console` command returns server log entries for each
 MinIO server in the deployment.
-
-.. end-mc-admin-console-desc
 
 .. admonition:: Use ``mc admin`` on MinIO Deployments Only
    :class: note

--- a/source/reference/minio-mc-admin.rst
+++ b/source/reference/minio-mc-admin.rst
@@ -50,11 +50,6 @@ The following table lists :mc:`mc admin` commands:
           :start-after: start-mc-admin-cluster-iam-desc
           :end-before: end-mc-admin-cluster-iam-desc
 
-   * - :mc-cmd:`mc admin console`
-     - .. include:: /reference/minio-mc-admin/mc-admin-console.rst
-          :start-after: start-mc-admin-console-desc
-          :end-before: end-mc-admin-console-desc
-
    * - :mc-cmd:`mc admin decommission`
      - .. include:: /reference/minio-mc-admin/mc-admin-decommission.rst
           :start-after: start-mc-admin-decommission-desc
@@ -183,7 +178,6 @@ See :ref:`minio-mc-global-options`.
    /reference/minio-mc-admin/mc-admin-cluster-bucket
    /reference/minio-mc-admin/mc-admin-cluster-iam
    /reference/minio-mc-admin/mc-admin-config
-   /reference/minio-mc-admin/mc-admin-console
    /reference/minio-mc-admin/mc-admin-decommission
    /reference/minio-mc-admin/mc-admin-group
    /reference/minio-mc-admin/mc-admin-heal

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -88,6 +88,10 @@ Table of Deprecated Admin Commands
      - :mc-cmd:`mc quota clear`, :mc-cmd:`mc quota info`, :mc-cmd:`mc quota set`
      - mc RELEASE.2022-12-13T00-23-28Z
 
+   * - ``mc admin console``
+     - :mc-cmd:`mc admin logs`
+     - mc RELEASE.2022-06-26T18-51-48Z
+
    * - ``mc admin idp ldap add``
      - :mc-cmd:`mc idp ldap add`
      - mc RELEASE.2023-05-26T23-31-54Z
@@ -207,6 +211,7 @@ Table of Deprecated Admin Commands
    /reference/deprecated/mc-ilm-ls
    /reference/deprecated/mc-ilm-rm
    /reference/deprecated/mc-admin-bucket-quota
+   /reference/deprecated/mc-admin-console
    /reference/deprecated/mc-admin-idp-ldap
    /reference/deprecated/mc-admin-idp-ldap-policy
    /reference/deprecated/mc-admin-idp-openid


### PR DESCRIPTION
Corrects most references to point to the current command.

Additional references to deprecated command fixed by PR #1198 .
We should merge 1198 at the same time we merge this one.

Staged:
- http://192.241.195.202:9000/staging/admin-logs/linux/reference/deprecated/mc-admin-console.html
