### PR TITLE
DOCS-1159: RELEASE.2024-03-15T01-07-19Z

### DIFF
--- a/source/operations/concepts/thresholds.rst
+++ b/source/operations/concepts/thresholds.rst
@@ -59,7 +59,7 @@ S3 API Limits
    * - Maximum length for each ``/`` separated object name segment
      - 255
 
-   * - Maximum number of object verions for a unique object
+   * - Maximum number of object versions for a unique object
      - 10000 (Configurable)
 
 Erasure Code Limits

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -20,8 +20,8 @@ This page covers settings that control core behavior of the MinIO process.
    :start-after: start-minio-settings-test-before-prod
    :end-before: end-minio-settings-test-before-prod
 
-MinIO Options
-~~~~~~~~~~~~~
+MinIO Server CLI Options
+------------------------
 
 .. tab-set::
 
@@ -47,11 +47,8 @@ For example, to set up ftp access, you could set the variable to something like 
 
 On Unix-like systems, you can save a file with the environment variable to ``/etc/defaults/minio`` instead of setting the variable manually.
 
-Common Settings
+Storage Volumes
 ---------------
-
-Volumes
-~~~~~~~
 
 .. tab-set::
 
@@ -71,7 +68,7 @@ Volumes
          :end-before: end-minio-settings-no-config-option
 
 Environment Variable File Path
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 .. tab-set::
 
@@ -90,7 +87,7 @@ Environment Variable File Path
          :end-before: end-minio-settings-no-config-option
       
 Workers for Expiration
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 .. tab-set::
 
@@ -110,7 +107,7 @@ Workers for Expiration
          :end-before: end-minio-settings-no-config-option
 
 Domain
-~~~~~~
+------
 
 .. tab-set::
 
@@ -145,7 +142,7 @@ Domain
 .. _minio-scanner-speed-options:
 
 Scanner Speed
-~~~~~~~~~~~~~
+-------------
 
 .. tab-set::
 
@@ -196,6 +193,29 @@ All of the settings in this section fall under the following top-level key:
 
 .. mc-conf:: compression
 
+Enable Compression
+~~~~~~~~~~~~~~~~~~
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_COMPRESSION_ENABLE
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+  
+      .. mc-conf:: compression enable
+         :delimiter: " "
+
+*Optional*
+
+Set to ``on`` to enable data compression for new objects.
+Defaults to ``off``.
+
+Enabling or disabling data compression does not change existing objects.
+
 Allow Encryption
 ~~~~~~~~~~~~~~~~
 
@@ -223,48 +243,6 @@ Defaults to ``off``.
    MinIO strongly recommends against encrypting compressed objects.
    If you require encryption, carefully evaluate the risk of potentially leaking information about the contents of encrypted objects.
 
-Enable Compression
-~~~~~~~~~~~~~~~~~~
-
-.. tab-set::
-
-   .. tab-item:: Environment Variable
-      :sync: envvar
-
-      .. envvar:: MINIO_COMPRESSION_ENABLE
-
-   .. tab-item:: Configuration Setting
-      :sync: config
-  
-      .. mc-conf:: compression enable
-         :delimiter: " "
-
-*Optional*
-
-Set to ``on`` to enable data compression for new objects.
-Defaults to ``off``.
-
-Enabling or disabling data compression does not change existing objects.
-
-Comments
-~~~~~~~~
-
-.. tab-set::
-
-   .. tab-item:: Environment Variable
-
-      This setting does not have an environment variable option.
-      Use the configuration variable instead.
-
-   .. tab-item:: Configuration Setting
-      :selected:
-
-      .. envvar:: compression comment
-
-*Optional*
-
-Specify a comment to associate with the data compression configuration.
-
 Compression Extensions
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -287,12 +265,11 @@ Comma-separated list of the file extensions to compress.
 Setting a new list of file extensions replaces the previously configured list.
 Defaults to ``".txt, .log, .csv, .json, .tar, .xml, .bin"``.
 
-.. admonition:: Default excluded files
-   :class: note
+.. versionchanged:: RELEASE.2024-03-15T01-07-19Z
 
-   Some types of files cannot be significantly reduced in size.
-   MinIO will *not* compress these, even if specified in an :mc-conf:`~compression.extensions` argument.
-   See :ref:`Excluded types <minio-data-compression-excluded-types>` for details.
+   Specify ``"*"`` to direct MinIO to compress all supported file types.
+   
+MinIO does not support compressing file types on the :ref:`Excluded File Types <minio-data-compression-excluded-types>` list, even if explicitly specified in this argument.
 
 Compression MIME Types
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -323,8 +300,27 @@ Defaults to ``"text/*, application/json, application/xml, binary/octet-stream"``
    MinIO will *not* compress these, even if specified in an :mc-conf:`~compression.mime_types` argument.
    See :ref:`Excluded types <minio-data-compression-excluded-types>` for details.
 
+Comments
+~~~~~~~~
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+
+      This setting does not have an environment variable option.
+      Use the configuration variable instead.
+
+   .. tab-item:: Configuration Setting
+      :selected:
+
+      .. envvar:: compression comment
+
+*Optional*
+
+Specify a comment to associate with the data compression configuration.
+
 Erasure Stripe Size
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 .. tab-set:: 
 
@@ -356,6 +352,31 @@ The selected stripe size is **immutable** after the cluster has been initialized
    Changes to stripe size have significant impact to deployment functionality, availability, performance, and behavior.
    MinIO's stripe selection algorithms set appropriate defaults for the majority of workloads.
    Changing the stripe size from this default is unusual and generally not necessary or advised.
+
+Maximum Object Versions
+-----------------------
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_API_OBJECT_MAX_VERSIONS
+
+   .. tab-item:: Configuration Variable
+      :sync: config
+
+      .. mc-conf:: api object_max_versions
+         :delimiter: " "
+
+*Optional*
+
+Overrides the default maximum version per object limit of ``10000`` with the user specified value.
+
+.. important::
+
+   The default limit of 10,000 provides a safety valve against incorrect or inefficient application behavior in versioned buckets.
+   Lifting this limit without first ensuring application's are designed for versioned operations may result in a negative performance impact over time.
 
 
    

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -308,7 +308,7 @@ Comments
    .. tab-item:: Environment Variable
 
       This setting does not have an environment variable option.
-      Use the configuration variable instead.
+      Use the configuration setting instead.
 
    .. tab-item:: Configuration Setting
       :selected:
@@ -363,7 +363,7 @@ Maximum Object Versions
 
       .. envvar:: MINIO_API_OBJECT_MAX_VERSIONS
 
-   .. tab-item:: Configuration Variable
+   .. tab-item:: Configuration Setting
       :sync: config
 
       .. mc-conf:: api object_max_versions
@@ -376,7 +376,7 @@ Overrides the default maximum version per object limit of ``10000`` with the use
 .. important::
 
    The default limit of 10,000 provides a safety valve against incorrect or inefficient application behavior in versioned buckets.
-   Lifting this limit without first ensuring application's are designed for versioned operations may result in a negative performance impact over time.
+   Lifting this limit without first ensuring your applications are designed for versioned operations may result in a negative performance impact over time.
 
 
    

--- a/source/reference/minio-server/settings/storage-class.rst
+++ b/source/reference/minio-server/settings/storage-class.rst
@@ -14,6 +14,17 @@ Erasure Code Settings
 This page covers settings that configure the :ref:`Erasure Code <minio-erasure-coding>` :ref:`parity <minio-ec-parity>` to use for objects written to the MinIO cluster.
 This impacts how MinIO uses the space on the drive(s) and how MinIO can recover objects stored on lost drives or similar issues.
 
+.. include:: /includes/common-mc-admin-config.rst
+   :start-after: start-minio-settings-defined
+   :end-before: end-minio-settings-defined
+
+.. include:: /includes/common-mc-admin-config.rst
+   :start-after: start-minio-settings-test-before-prod
+   :end-before: end-minio-settings-test-before-prod
+
+Standard Storage Class
+----------------------
+
 .. note::
 
    *MinIO Storage Classes* are distinct from *AWS Storage Classes*.
@@ -23,80 +34,140 @@ This impacts how MinIO uses the space on the drive(s) and how MinIO can recover 
 
    For tiering from one type of storage to another, such as for cost management purposes, see :ref:`minio-lifecycle-management-tiering`.
 
-Define any of these environment variables in the host system prior to starting or restarting the MinIO process.
-Refer to your operating system's documentation for how to define an environment variable.
+.. tab-set::
 
-.. include:: /includes/common-mc-admin-config.rst
-   :start-after: start-minio-settings-test-before-prod
-   :end-before: end-minio-settings-test-before-prod
+   .. tab-item:: Environment Variable
+      :sync: envvar
 
-Environment Variables
----------------------
+      .. envvar:: MINIO_STORAGE_CLASS_STANDARD
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+The :ref:`parity level <minio-ec-parity>` for the deployment.
+MinIO shards objects written with the default ``STANDARD`` storage class using this parity value.
+
+MinIO references the ``x-amz-storage-class`` header in request metadata for determining which storage class to assign an object. 
+The specific syntax or method for setting headers depends on your preferred method for interfacing with the MinIO server.
+
+Specify the value using ``EC:M`` notation, where ``M`` refers to the number of parity blocks to create for the object.
+
+The following table lists the default values based on the :ref:`erasure set size <minio-ec-erasure-set>` of the initial server pool in the deployment:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   :width: 100%
+
+   * - Erasure Set Size
+     - Default Parity (EC:N)
+
+   * - 1
+     - EC:0
+
+   * - 2-3
+     - EC:1
+
+   * - 4-5
+     - EC:2
+
+   * - 6 - 7
+     - EC:3
+
+   * - 8 - 16
+     - EC:4
+
+The minimum supported value is ``0``, which indicates no erasure coding protections.
+These deployments rely entirely on the storage controller or resource for availability / resiliency. 
+
+The maximum value depends on the erasure set size of the initial server pool in the deployment, where the upper bound is  :math:`\frac{\text{ERASURE_SET_SIZE}}{\text{2}}`.
+For example, a deployment with erasure set stripe size of 16 has a maximum standard parity of 8.
+
+You can change this value after startup to any value between ``0`` and the upper bound for the erasure set size.
+MinIO only applies the changed parity to newly written objects.
+Existing objects retain the parity value in place at the time of their creation.
+
+Reduced Redundancy Storage Class
+--------------------------------
 
 .. note::
 
-   These settings do not have configuration setting options for use with :mc:`mc admin config set`.
+   *MinIO Storage Classes* are distinct from *AWS Storage Classes*.
 
-.. envvar:: MINIO_STORAGE_CLASS_STANDARD
+   AWS Storage Classes refer to the specific storage tier on which to store a given object, such as ``hot`` or ``glacier`` storage.
+   MinIO Storage Classes affect the erasure code parity setting used and relate to :ref:`minio-availability-resiliency` of objects.
 
-   The :ref:`parity level <minio-ec-parity>` for the deployment.
-   MinIO shards objects written with the default ``STANDARD`` storage class using this parity value.
+   For tiering from one type of storage to another, such as for cost management purposes, see :ref:`minio-lifecycle-management-tiering`.
 
-   MinIO references the ``x-amz-storage-class`` header in request metadata for determining which storage class to assign an object. 
-   The specific syntax or method for setting headers depends on your preferred method for interfacing with the MinIO server.
+.. tab-set::
 
-   Specify the value using ``EC:M`` notation, where ``M`` refers to the number of parity blocks to create for the object.
+   .. tab-item:: Environment Variable
+      :sync: envvar
 
-   The following table lists the default values based on the :ref:`erasure set size <minio-ec-erasure-set>` of the initial server pool in the deployment:
+      .. envvar:: MINIO_STORAGE_CLASS_RRS
 
-   .. list-table::
-      :header-rows: 1
-      :widths: 30 70
-      :width: 100%
+   .. tab-item:: Configuration Setting
+      :sync: config
 
-      * - Erasure Set Size
-        - Default Parity (EC:N)
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
 
-      * - 1
-        - EC:0
+The :ref:`parity level <minio-ec-parity>` for objects written with the ``REDUCED`` storage class.
 
-      * - 2-3
-        - EC:1
+MinIO references the ``x-amz-storage-class`` header in request metadata for determining which storage class to assign an object. 
+The specific syntax or method for setting headers depends on your preferred method for interfacing with the MinIO server.
 
-      * - 4-5
-        - EC:2
+Specify the value using ``EC:M`` notation, where ``M`` refers to the number of parity blocks to create for the object.
 
-      * - 6 - 7
-        - EC:3
+This value **must be** less than or equal to :envvar:`MINIO_STORAGE_CLASS_STANDARD`.
 
-      * - 8 - 16
-        - EC:4
+You cannot set this value for deployments with an erasure set size less than 2.
+Defaults to ``EC:1`` for deployments with erasure set size greater than 1.
+Defaults to ``EC:0`` for deployments of erasure set size of 1.
 
-   The minimum supported value is ``0``, which indicates no erasure coding protections.
-   These deployments rely entirely on the storage controller or resource for availability / resiliency. 
-   
-   The maximum value depends on the erasure set size of the initial server pool in the deployment, where the upper bound is  :math:`\frac{\text{ERASURE_SET_SIZE}}{\text{2}}`.
-   For example, a deployment with erasure set stripe size of 16 has a maximum standard parity of 8.
+Parity Retention Optimization
+-----------------------------
 
-   You can change this value after startup to any value between ``0`` and the upper bound for the erasure set size.
-   MinIO only applies the changed parity to newly written objects.
-   Existing objects retain the parity value in place at the time of their creation.
 
-.. envvar:: MINIO_STORAGE_CLASS_RRS
+.. tab-set::
 
-   The :ref:`parity level <minio-ec-parity>` for objects written with the ``REDUCED`` storage class.
+   .. tab-item:: Environment Variable
+      :sync: envvar
 
-   MinIO references the ``x-amz-storage-class`` header in request metadata for determining which storage class to assign an object. 
-   The specific syntax or method for setting headers depends on your preferred method for interfacing with the MinIO server.
+      .. envvar:: MINIO_STORAGE_CLASS_OPTIMIZE
 
-   Specify the value using ``EC:M`` notation, where ``M`` refers to the number of parity blocks to create for the object.
+   .. tab-item:: Configuration Setting
+      :sync: config
 
-   This value **must be** less than or equal to :envvar:`MINIO_STORAGE_CLASS_STANDARD`.
+      .. mc-conf:: storage_class optimize
+         :delimiter: " "
 
-   You cannot set this value for deployments with an erasure set size less than 2.
-   Defaults to ``EC:1`` for deployments with erasure set size greater than 1.
-   Defaults to ``EC:0`` for deployments of erasure set size of 1.
+MinIO by default automatically "upgrades" parity for an object if the destination erasure set maintains write quorum *but* has one or more drives offline.
+This behavior helps ensure that the given object maintains the same availability as objects written to the healthy erasure set.
 
-.. envvar:: MINIO_STORAGE_CLASS_COMMENT
+Specify ``capacity`` to this setting to direct MinIO to not create any additional parity for the object.
+This prioritizes the overall capacity of the cluster at the cost of potentially reduced object availability in the event more drives in that erasure set fail.
 
-   Adds a comment to the storage class settings.
+Comment
+-------
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_STORAGE_CLASS_COMMENT
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. include:: /includes/common-mc-admin-config.rst
+         :start-after: start-minio-settings-no-config-option
+         :end-before: end-minio-settings-no-config-option
+
+Adds a comment to the storage class settings.


### PR DESCRIPTION
Partially addresses #1159 

Excluding Metrics v3 since that work is ongoing, and it's not fully baked as of yet.

All changes are effectively config level.

Also fixed up some format/hierarchy issues while I was at it.

Staged:

- http://192.241.195.202:9000/staging/DOCS-1159/linux/reference/minio-server/settings/core.html
- http://192.241.195.202:9000/staging/DOCS-1159/linux/reference/minio-server/settings/core.html#compression-extensions
- http://192.241.195.202:9000/staging/DOCS-1159/linux/reference/minio-server/settings/core.html#maximum-object-versions
- http://192.241.195.202:9000/staging/DOCS-1159/linux/reference/minio-server/settings/storage-class.html#parity-retention-optimization