### PR TITLE
correct NATS endpoint syntax

### DIFF
--- a/source/administration/monitoring/publish-events-to-nats.rst
+++ b/source/administration/monitoring/publish-events-to-nats.rst
@@ -79,8 +79,8 @@ You can configure a new NATS service endpoint using either environment variables
         If the specified ``<IDENTIFIER>`` matches an existing NATS service endpoint on the MinIO deployment, the new settings *override* any existing settings for that endpoint. 
         Use :mc-cmd:`mc admin config get notify_nats <mc admin config get>` to review the currently configured NATS endpoints on the MinIO deployment.
 
-      - Replace ``<ENDPOINT>`` with the URL of the NATS service endpoint.
-        For example: ``htpps://nats-endpoint.example.com:4222``
+      - Replace ``<ENDPOINT>`` with the hostname and port of the NATS service endpoint.
+        For example: ``nats-endpoint.example.com:4222``
 
       See :ref:`NATS Service for Bucket Notifications <minio-server-envvar-bucket-notification-nats>` for complete documentation on each environment variable.
 
@@ -124,8 +124,8 @@ You can configure a new NATS service endpoint using either environment variables
         If the specified ``IDENTIFIER`` matches an existing NATS service endpoint on the MinIO deployment, the new settings *override* any existing settings for that endpoint. 
         Use :mc-cmd:`mc admin config get notify_nats <mc admin config get>` to review the currently configured NATS endpoints on the MinIO deployment.
 
-      - Replace ``ENDPOINT`` with the URL of the NATS service endpoint.
-        For example: ``htpps://nats-endpoint.example.com:4222``.
+      - Replace ``ENDPOINT`` with the hostname and port of the NATS service endpoint.
+        For example: ``nats-endpoint.example.com:4222``.
 
       See :ref:`NATS Bucket Notification Configuration Settings <minio-server-config-bucket-notification-nats>` for complete       documentation on each setting.
 

--- a/source/reference/minio-server/settings/notifications/nats.rst
+++ b/source/reference/minio-server/settings/notifications/nats.rst
@@ -49,10 +49,10 @@ For example, the following commands set two distinct NATS service endpoints as `
          :class: copyable
       
          set MINIO_NOTIFY_NATS_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_NATS_ADDRESS_PRIMARY="https://nats-endpoint.example.net:4222"
-      
+         set MINIO_NOTIFY_NATS_ADDRESS_PRIMARY="nats-endpoint.example.net:4222"
+
          set MINIO_NOTIFY_NATS_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_NATS_ADDRESS_SECONDARY="https://nats-endpoint.example.net:4222"
+         set MINIO_NOTIFY_NATS_ADDRESS_SECONDARY="nats-endpoint.example.net:4222"
 
       With these settings, :envvar:`MINIO_NOTIFY_NATS_ENABLE_PRIMARY <MINIO_NOTIFY_NATS_ENABLE>` indicates the environment variable is associated to an NATS service endpoint with ID of ``PRIMARY``.
 
@@ -62,12 +62,12 @@ For example, the following commands set two distinct NATS service endpoints as `
       .. code-block:: shell
    
          mc admin config set notify_nats:primary \ 
-            address="https://nats-endpoint.example.com:4222" \
+            address="nats-endpoint.example.com:4222" \
             subject="minioevents" \ 
             [ARGUMENT=VALUE ...]
    
          mc admin config set notify_nats:secondary \
-            address="https://nats-endpoint.example.com:4222" \
+            address="nats-endpoint.example.com:4222" \
             subject="minioevents" \ 
             [ARGUMENT=VALUE ...]
 
@@ -105,10 +105,10 @@ Enable
          :class: copyable
    
          mc admin config set notify_nats \ 
-           address="https://nats-endpoint.example.com:4222" \
+           address="nats-endpoint.example.com:4222" \
            subject="minioevents" \
            [ARGUMENT="VALUE"] ... \
-   
+
 Address
 ~~~~~~~
 
@@ -128,7 +128,7 @@ Address
          :delimiter: " "
 
 Specify the NATS service endpoint to which MinIO publishes bucket events. 
-For example, ``https://nats-endpoint.example.com:4222``.
+For example, ``nats-endpoint.example.com:4222``.
 
 .. include:: /includes/linux/minio-server.rst
    :start-after: start-notify-target-online-desc


### PR DESCRIPTION
NATS endpoints should be specified with hostname and port, not a URL. 

Staged
http://192.241.195.202:9000/staging/nats-endpoint-fix/linux/reference/minio-server/settings/notifications/nats.html
http://192.241.195.202:9000/staging/nats-endpoint-fix/linux/administration/monitoring/publish-events-to-nats.html

Fixes https://github.com/miniohq/engineering/issues/1966