### PR TITLE
Glossary typo

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -243,7 +243,7 @@ Glossary
    pool
      A set of ``minio server`` nodes which combine their drives and resources to support object storage and retrieval requests.
     
-    For more information, see :ref:`minio-intro-server-pool`.
+     For more information, see :ref:`minio-intro-server-pool`.
 
    service account
      Renamed to :term:`access keys`.


### PR DESCRIPTION
Fix server pool entry. Incorrect indentation truncates first char of second paragraph.