### PR TITLE
Pushing pyyaml to 6.0.1 to resolve compat with Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ sphinx_reredirects === 0.1.2
 myst-parser === 1.0.0
 linkify === 1.4
 linkify-it-py === 2.0.0
-pyyaml === 6.0
+pyyaml === 6.0.1


### PR DESCRIPTION
https://github.com/yaml/pyyaml/issues/736

Python 3.12+ is somewhat broken when trying to install fresh.

Bumping PyYaml to 6.0.1 seems to fix it. There are some warnings that we might have to freeze at Python 3.12 until PyYaml updates to fully support it at some indeterminate time in the future.

@djwfyi @feorlen please test w/ a clean venv (e.g. `python -m venv testvenv` or something) and make sure that you can still `pip install -r requirements.txt` and build w/ PyYaml 6.0.1
