### PR TITLE
Fix build warnings for Operator pages

### DIFF
--- a/source/includes/aks/deploy-minio-on-azure-kubernetes-service.rst
+++ b/source/includes/aks/deploy-minio-on-azure-kubernetes-service.rst
@@ -15,7 +15,7 @@ Overview
 --------
 
 `Azure Kubernetes Engine <https://azure.microsoft.com/en-us/products/kubernetes-service/#overview>`__ (AKS) is a highly available, secure, and fully managed Kubernetes service from Microsoft Azure.
-The MinIO Kubernetes Operator supports deploying MinIO Tenants onto AKS infrastructure using the MinIO Operator Console, the :mc:`kubectl minio` CLI tool, or `kustomize <https://kustomize.io/>`__ for :minio-git:`YAML-defined deployments <operator/tree/master/examples/kustomization>`.
+The MinIO Kubernetes Operator supports deploying MinIO Tenants onto AKS infrastructure using the MinIO Operator Console or `kustomize <https://kustomize.io/>`__ for :minio-git:`YAML-defined deployments <operator/tree/master/examples/kustomization>`.
 
 :minio-web:`Through the AKS Marketplace <product/multicloud-azure-kubernetes-service>`
    MinIO maintains an `AKS Marketplace listing <https://azuremarketplace.microsoft.com/en-us/marketplace/apps/minio.minio-object-storage_v1dot1>`__ through which you can register your AKS cluster with |subnet|.

--- a/source/includes/k8s/deploy-operator.rst
+++ b/source/includes/k8s/deploy-operator.rst
@@ -1,4 +1,6 @@
+.. _minio-operator-installation:
 .. _minio-operator-installation-kustomize:
+.. _deploy-operator-kubernetes:
 .. _deploy-operator-kubernetes-kustomize:
 
 =========================

--- a/source/includes/k8s/steps-configure-ad-ldap-external-identity-management.rst
+++ b/source/includes/k8s/steps-configure-ad-ldap-external-identity-management.rst
@@ -84,7 +84,7 @@ See :ref:`minio-external-identity-management-ad-ldap-access-control` for more in
 
 The MinIO Console supports the full workflow of authenticating to the AD/LDAP provider, generating temporary credentials using the MinIO :ref:`minio-sts-assumerolewithldapidentity` Security Token Service (STS) endpoint, and logging the user into the MinIO deployment.
 
-See the :ref:`Deploy MinIO Tenant: Access the Tenant's MinIO Console <create-tenant-cli-access-tenant-console>` for instructions on accessing the Tenant Console.
+See :ref:`Deploy MinIO Tenant: Connect to the Tenant <create-tenant-connect-tenant>` for additonal information about accessing the Tenant Console.
 
 If the AD/LDAP configuration succeeded, the Console displays a button to login with AD/LDAP credentials.
 

--- a/source/includes/k8s/steps-configure-openid-external-identity-management.rst
+++ b/source/includes/k8s/steps-configure-openid-external-identity-management.rst
@@ -102,7 +102,7 @@ See :ref:`minio-external-identity-management-openid-access-control` for more inf
 
 The MinIO Console supports the full workflow of authenticating to the OIDC provider, generating temporary credentials using the MinIO :ref:`minio-sts-assumerolewithldapidentity` Security Token Service (STS) endpoint, and logging the user into the MinIO deployment.
 
-See the :ref:`Deploy MinIO Tenant: Access the Tenant's MinIO Console <create-tenant-cli-access-tenant-console>` for instructions on accessing the Tenant Console.
+See :ref:`Deploy MinIO Tenant: Connect to the Tenant <create-tenant-connect-tenant>` for additonal information about accessing the Tenant Console.
 
 If the OIDC configuration succeeded, the Console displays a button to login with OIDC credentials.
 

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -36,7 +36,7 @@ Deploy a MinIO Tenant
    :alt: MinIO Operator Console
 
 
-The MinIO Operator Console is designed with deploying multi-node distributed MinIO Deployments.
+The MinIO Operator Console is designed for deploying multi-node distributed MinIO Deployments.
 
 Deploying Single-Node topologies requires additional configurations not covered in this documentation.
 You can alternatively use a simple Kubernetes YAML object to describe a Single-Node topology for local testing and evaluation as necessary.


### PR DESCRIPTION
Fix build warnings from https://github.com/minio/docs/pull/1219 

Some are broken refs that need to point elsewhere.

Some are because `openshift`, `eks`, `gke`, `aks` can't see a target that's on a `k8s` page, apparently due to how `operations/installation.rst` is structured. These we are still investigating. 