### PR TITLE
Updates for mc 2024-06-04 release

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -260,6 +260,9 @@ Syntax
       * - Min Time
         - The minimum time spent for the Call to complete.
 
+      * - Max Time
+        - The maximum time spent for the Call to complete.
+
       * - Avg TTFB
         - .. versionadded:: RELEASE.2023-11-15T22-45-58Z
 
@@ -270,14 +273,19 @@ Syntax
         
           The maximum Time To First Byte for the Call.
 
+      * - Avg Size
+        - Average size of calls.
+
       * - Errors
         - The number of Calls that failed with an error.
 
       * - RX Avg
         - The average number of Bytes Received (RX) for the Call.
+          This stat only displays if not zero (0). 
 
       * - TX AVG
         - The average number of Bytes Sent (TX) for the Call.
+          This stat only displays if not zero (0). 
 
    Accumulate stats, such as name, count, duration, min time, max time, time to first byte, or errors.
    Accumulates up to 15 stat entries.

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -113,8 +113,8 @@ Syntax
 
 .. mc-cmd:: --call
 
-   Traces only matching call types.
-   For example, the following command only traces calls of the type ``scanner``.
+   Traces only matching client operation or call types.
+   For example, the following command only traces operations of the type ``scanner``.
 
    .. code-block:: shell
 
@@ -145,19 +145,19 @@ Syntax
 
 .. mc-cmd:: --filter-request
 
-   Trace calls with request size greater than the specified :mc-cmd:`~mc admin trace --filter-size` value.
+   Trace client operations or calls with request size greater than the specified :mc-cmd:`~mc admin trace --filter-size` value.
 
    Must be used with :mc-cmd:`~mc admin trace --filter-size` flag.
 
 .. mc-cmd:: --filter-response
 
-   Trace calls with response size greater than the specified :mc-cmd:`~mc admin trace --filter-size` value.
+   Trace client operations or calls with response size greater than the specified :mc-cmd:`~mc admin trace --filter-size` value.
 
    Must be used with :mc-cmd:`~mc admin trace --filter-size` flag.
 
 .. mc-cmd:: --filter-size
 
-   Size limit of a filtered call.
+   Size limit of a filtered client operation or call.
 
    Must be used with either :mc-cmd:`~mc admin trace --filter-request` or :mc-cmd:`~mc admin trace --filter-response` flag.
 
@@ -246,45 +246,45 @@ Syntax
       :widths: 30 70
 
       * - Call
-        - The name of the captured function.
+        - The name of the captured client operation or function.
 
       * - Count
-        - The number of times the call occurred.
+        - The number of times the client operation or call occurred.
 
       * - RPM
-        - The Rate Per Minute (RPM) of that call.
+        - The Rate Per Minute (RPM) of the client operation or call.
 
       * - Avg Time
-        - The average time required for the call to complete.
+        - The average time required for the client operation or call to complete.
 
       * - Min Time
-        - The minimum time spent for the call to complete.
+        - The minimum time spent for the client operation or call to complete.
 
       * - Max Time
-        - The maximum time spent for the call to complete.
+        - The maximum time spent for the client operation or call to complete.
 
       * - Avg TTFB
         - .. versionadded:: RELEASE.2023-11-15T22-45-58Z
 
-          The average Time To First Byte (TTFB) for the call.
+          The average Time To First Byte (TTFB) for the client operation or call response.
 
       * - Max TTFB
         - .. versionadded:: RELEASE.2023-11-15T22-45-58Z
         
-          The maximum Time To First Byte for the call.
+          The maximum Time To First Byte for the client operation or call response.
 
       * - Avg Size
-        - Average size of calls.
+        - Average size of client operation or call responses.
 
       * - Errors
-        - The number of calls that failed with an error.
+        - The number of client operations or calls that failed with an error.
 
       * - RX Avg
-        - The average number of Bytes Received (RX) for the call.
+        - The average number of Bytes Received (RX) for the client operation or call.
           This stat only displays if not zero (0). 
 
       * - TX AVG
-        - The average number of Bytes Sent (TX) for the call.
+        - The average number of Bytes Sent (TX) for the client operation or call.
           This stat only displays if not zero (0). 
 
    Accumulate stats, such as name, count, duration, min time, max time, time to first byte, or errors.

--- a/source/reference/minio-mc-admin/mc-admin-trace.rst
+++ b/source/reference/minio-mc-admin/mc-admin-trace.rst
@@ -249,42 +249,42 @@ Syntax
         - The name of the captured function.
 
       * - Count
-        - The number of times the Call occurred.
+        - The number of times the call occurred.
 
       * - RPM
-        - The Rate Per Minute (RPM) of that Call.
+        - The Rate Per Minute (RPM) of that call.
 
       * - Avg Time
-        - The average time required for the Call to complete.
+        - The average time required for the call to complete.
 
       * - Min Time
-        - The minimum time spent for the Call to complete.
+        - The minimum time spent for the call to complete.
 
       * - Max Time
-        - The maximum time spent for the Call to complete.
+        - The maximum time spent for the call to complete.
 
       * - Avg TTFB
         - .. versionadded:: RELEASE.2023-11-15T22-45-58Z
 
-          The average Time To First Byte (TTFB) for the Call.
+          The average Time To First Byte (TTFB) for the call.
 
       * - Max TTFB
         - .. versionadded:: RELEASE.2023-11-15T22-45-58Z
         
-          The maximum Time To First Byte for the Call.
+          The maximum Time To First Byte for the call.
 
       * - Avg Size
         - Average size of calls.
 
       * - Errors
-        - The number of Calls that failed with an error.
+        - The number of calls that failed with an error.
 
       * - RX Avg
-        - The average number of Bytes Received (RX) for the Call.
+        - The average number of Bytes Received (RX) for the call.
           This stat only displays if not zero (0). 
 
       * - TX AVG
-        - The average number of Bytes Sent (TX) for the Call.
+        - The average number of Bytes Sent (TX) for the call.
           This stat only displays if not zero (0). 
 
    Accumulate stats, such as name, count, duration, min time, max time, time to first byte, or errors.

--- a/source/reference/minio-mc/mc-batch-cancel.rst
+++ b/source/reference/minio-mc/mc-batch-cancel.rst
@@ -44,7 +44,7 @@ To find the job ID, use :mc-cmd:`mc batch list`.
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] batch cancel TARGET JOBID
+         mc [GLOBALFLAGS] batch cancel ALIAS JOBID
 
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
@@ -53,7 +53,7 @@ To find the job ID, use :mc-cmd:`mc batch list`.
 Parameters
 ~~~~~~~~~~
 
-.. mc-cmd:: TARGET
+.. mc-cmd:: ALIAS
    :required:
    
    The :ref:`alias <alias>` for the MinIO deployment on which the job is currently running. 

--- a/source/reference/minio-mc/mc-batch-generate.rst
+++ b/source/reference/minio-mc/mc-batch-generate.rst
@@ -37,7 +37,7 @@ See :ref:`job types <minio-batch-job-types>` for the supported jobs you can gene
       .. code-block:: shell
          :class: copyable
 
-         mc batch generate myminio/mybucket replicate
+         mc batch generate myminio replicate
 
    .. tab-item:: SYNTAX
 
@@ -47,7 +47,7 @@ See :ref:`job types <minio-batch-job-types>` for the supported jobs you can gene
          :class: copyable
 
          mc [GLOBALFLAGS] batch generate \
-                                TARGET   \
+                                ALIAS   \
                                 JOBTYPE
 
       .. include:: /includes/common-minio-mc.rst
@@ -57,7 +57,7 @@ See :ref:`job types <minio-batch-job-types>` for the supported jobs you can gene
 Parameters
 ~~~~~~~~~~
 
-.. mc-cmd:: TARGET
+.. mc-cmd:: ALIAS
    :required:
    
    The :ref:`alias <alias>` used to generate the YAML template file.

--- a/source/reference/minio-mc/mc-batch-start.rst
+++ b/source/reference/minio-mc/mc-batch-start.rst
@@ -35,7 +35,7 @@ To run the batch job again after completion, you must start it again.
       .. code-block:: shell
          :class: copyable
 
-         mc batch start myminio/mybucket jobfile.yaml
+         mc batch start myminio jobfile.yaml
 
       The output of the above command is something similar to:
 
@@ -51,7 +51,7 @@ To run the batch job again after completion, you must start it again.
          :class: copyable
 
          mc [GLOBALFLAGS] batch start    \
-                                TARGET   \
+                                ALIAS   \
                                 JOBFILE
 
       .. include:: /includes/common-minio-mc.rst
@@ -61,7 +61,7 @@ To run the batch job again after completion, you must start it again.
 Parameters
 ~~~~~~~~~~
 
-.. mc-cmd:: TARGET
+.. mc-cmd:: ALIAS
    :required:
    
    The :ref:`alias <alias>` on which to start the batch job.


### PR DESCRIPTION
Corrects mc batch examples
Closes #1235

Applies changes to the mc admin trace --stat flag in mc RELEASE.2024-06-05T18-13-30Z. That change has no tracking docs issue.

Staged:
- [mc admin trace --stats](http://192.241.195.202:9000/staging/mc-2024-06-05/linux/reference/minio-mc-admin/mc-admin-trace.html#mc.admin.trace.-stats)
- [mc batch generate](http://192.241.195.202:9000/staging/mc-2024-06-05/linux/reference/minio-mc/mc-batch-generate.html)
- [mc batch start](http://192.241.195.202:9000/staging/mc-2024-06-05/linux/reference/minio-mc/mc-batch-start.html)