### PR TITLE
Regenerate sample batch framework config YAML

### DIFF
--- a/source/includes/code/keyrotate.yaml
+++ b/source/includes/code/keyrotate.yaml
@@ -1,23 +1,20 @@
 keyrotate:
   apiVersion: v1
-  bucket: bucket
-  prefix: 
+  bucket: BUCKET
+  prefix: PREFIX
   encryption:
-    type: sse-kms # valid values are sse-s3 and sse-kms
-    
-    # The following encryption values only apply for sse-kms type.
-    # For sse-s3 key types, MinIO uses the key provided by the MINIO_KMS_KES_KEY_FILE environment variable.
-    # The following two values are ignored if type is set to sse-s3.
-    key: my-new-keys2 # valid only for sse-kms
+    type: sse-s3 # valid values are sse-s3 and sse-kms
+    key: <new-kms-key> # valid only for sse-kms
     context: <new-kms-key-context> # valid only for sse-kms
 
   # optional flags based filtering criteria
+  # for all objects
   flags:
     filter:
-      newerThan: "84h" # match objects newer than this value (e.g. 7d10h31s)
-      olderThan: "80h" # match objects older than this value (e.g. 7d10h31s)
-      createdAfter: "2023-03-02T15:04:05Z07:00" # match objects created after "date"
-      createdBefore: "2023-03-02T15:04:05Z07:00" # match objects created before "date"
+      newerThan: "7d" # match objects newer than this value (e.g. 7d10h31s)
+      olderThan: "7d" # match objects older than this value (e.g. 7d10h31s)
+      createdAfter: "date" # match objects created after "date"
+      createdBefore: "date" # match objects created before "date"
       tags:
         - key: "name"
           value: "pick*" # match objects with tag 'name', with all values starting with 'pick'
@@ -25,13 +22,9 @@ keyrotate:
         - key: "content-type"
           value: "image/*" # match objects with 'content-type', with all values starting with 'image/'
       kmskey: "key-id" # match objects with KMS key-id (applicable only for sse-kms)
-  
-  # optional entries to add notifications for the job
-  notify:
-    endpoint: "https://notify.endpoint" # notification endpoint to receive job status events
-    token: "Bearer xxxxx" # optional authentication token for the notification endpoint
-  
-  # optional entries to add retry attempts if the job is interrupted
-  retry:
-    attempts: 10 # number of retries for the job before giving up
-    delay: "500ms" # least amount of delay between each retry
+    notify:
+      endpoint: "https://notify.endpoint" # notification endpoint to receive job status events
+      token: "Bearer xxxxx" # optional authentication token for the notification endpoint
+    retry:
+      attempts: 10 # number of retries for the job before giving up
+      delay: "500ms" # least amount of delay between each retry

--- a/source/includes/code/replicate.yaml
+++ b/source/includes/code/replicate.yaml
@@ -1,39 +1,45 @@
 replicate:
   apiVersion: v1
   # source of the objects to be replicated
-  # if source is not the local deployment for the command, provide the endpoint and credentials
   source:
     type: TYPE # valid values are "s3" or "minio"
     bucket: BUCKET
-    prefix: PREFIX
-    # endpoint: ENDPOINT
-    # path: "on|off|auto"
-    # credentials:
-    #   accessKey: ACCESS_KEY
-    #   secretKey: SECRET_KEY
-    #   sessionToken: SESSION_TOKEN # Available when rotating credentials are used
-    # snowball:
-    #   disable: true|false
-    #   batch: 100
-    #   inmemory: true|false
-    #   compress: true|false
-    #   smallerThan: 5MiB
-    #   skipErrs: true|false
+    prefix: PREFIX # 'PREFIX' is optional
+    # If your source is the 'local' alias specified to 'mc batch start', then the 'endpoint' and 'credentials' fields are optional and can be omitted
+    # Either the 'source' or 'remote' *must* be the "local" deployment
+    endpoint: "http[s]://HOSTNAME:PORT" 
+    # path: "on|off|auto" # "on" enables path-style bucket lookup. "off" enables virtual host (DNS)-style bucket lookup. Defaults to "auto"
+    credentials:
+      accessKey: ACCESS-KEY # Required
+      secretKey: SECRET-KEY # Required
+    # sessionToken: SESSION-TOKEN # Optional only available when rotating credentials are used
+    snowball: # automatically activated if the source is local
+      disable: false # optionally turn-off snowball archive transfer
+      batch: 100 # upto this many objects per archive
+      inmemory: true # indicates if the archive must be staged locally or in-memory
+      compress: false # S2/Snappy compressed archive
+      smallerThan: 5MiB # create archive for all objects smaller than 5MiB
+      skipErrs: false # skips any source side read() errors
+
   # target where the objects must be replicated
-  # if target is not the local deployment for the command, provide the endpoint and credentials
   target:
     type: TYPE # valid values are "s3" or "minio"
     bucket: BUCKET
-    prefix: PREFIX
-    # endpoint: ENDPOINT
-    # path: "on|off|auto"
-    # credentials:
-    #   accessKey: ACCESS_KEY
-    #   secretKey: SECRET_KEY
-    #   sessionToken: SESSION_TOKEN # Available when rotating credentials are used
+    prefix: PREFIX # 'PREFIX' is optional
+    # If your source is the 'local' alias specified to 'mc batch start', then the 'endpoint' and 'credentials' fields are optional and can be omitted
 
-  # optional flags based filtering criteria
-  # for all source objects
+    # Either the 'source' or 'remote' *must* be the "local" deployment
+    endpoint: "http[s]://HOSTNAME:PORT"
+    # path: "on|off|auto" # "on" enables path-style bucket lookup. "off" enables virtual host (DNS)-style bucket lookup. Defaults to "auto"
+    credentials:
+      accessKey: ACCESS-KEY
+      secretKey: SECRET-KEY
+    # sessionToken: SESSION-TOKEN # Optional only available when rotating credentials are used
+
+  # NOTE: All flags are optional
+  # - filtering criteria only applies for all source objects match the criteria
+  # - configurable notification endpoints
+  # - configurable retries for the job (each retry skips successfully previously replaced objects)
   flags:
     filter:
       newerThan: "7d" # match objects newer than this value (e.g. 7d10h31s)
@@ -41,19 +47,19 @@ replicate:
       createdAfter: "date" # match objects created after "date"
       createdBefore: "date" # match objects created before "date"
 
+      ## NOTE: tags are not supported when "source" is remote.
       # tags:
       #   - key: "name"
       #     value: "pick*" # match objects with tag 'name', with all values starting with 'pick'
 
-      ## NOTE: metadata filter not supported when "source" is non MinIO.
       # metadata:
       #   - key: "content-type"
       #     value: "image/*" # match objects with 'content-type', with all values starting with 'image/'
 
-  notify:
-    endpoint: "https://notify.endpoint" # notification endpoint to receive job status events
-    token: "Bearer xxxxx" # optional authentication token for the notification endpoint
+    notify:
+      endpoint: "https://notify.endpoint" # notification endpoint to receive job status events
+      token: "Bearer xxxxx" # optional authentication token for the notification endpoint
 
-  retry:
-    attempts: 10 # number of retries for the job before giving up
-    delay: "500ms" # least amount of delay between each retry
+    retry:
+      attempts: 10 # number of retries for the job before giving up
+      delay: "500ms" # least amount of delay between each retry


### PR DESCRIPTION
Per @shtripat and @vadmeste , the indentation was off. Fixed by generating new examples with
- `mc batch generate play/ replicate`
- `mc batch generate play/ keyrotate`

The `expire` example is identical to current `mc batch generate play/ expire` output.

Error reported by a customer.