### PR TITLE
Updates for server and mc releases on 2024-06-10

### DIFF
--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -99,7 +99,7 @@ Clients therefore drive the overall hierarchy of data within a given bucket or p
 
 .. cond:: windows
 
-   Unlike filenames on a Windows system, object names in MinIO must not include either ``\`` or ``:`` characters in the object name.
+   MinIO does not support the ``\`` or ``:`` characters in object names, regardless of support for those characters in Windows filesystems.
    Use ``/`` as a delimiter in object names to have MinIO automatically create a folder structure using :term:`prefixes <prefix>`.
 
 MinIO has no hard :ref:`thresholds <minio-server-limits>` on the number of buckets, objects, or prefixes on a given deployment.

--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -99,7 +99,7 @@ Clients therefore drive the overall hierarchy of data within a given bucket or p
 
 .. cond:: windows
 
-   Unlike filenames on a Windows system, object names in MinIO cannot have either a ``\`` or ``:`` character in the object name.
+   Unlike filenames on a Windows system, object names in MinIO must not include either ``\`` or ``:`` characters in the object name.
    Use ``/`` as a delimiter in object names to have MinIO automatically create a folder structure using :term:`prefixes <prefix>`.
 
 MinIO has no hard :ref:`thresholds <minio-server-limits>` on the number of buckets, objects, or prefixes on a given deployment.

--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -99,7 +99,7 @@ Clients therefore drive the overall hierarchy of data within a given bucket or p
 
 .. cond:: windows
 
-   Unlike filenames on a Windows system, object names in MinIO cannot have a ``\`` character.
+   Unlike filenames on a Windows system, object names in MinIO cannot have either a ``\`` or ``:`` character in the object name.
    Use ``/`` as a delimiter in object names to have MinIO automatically create a folder structure using :term:`prefixes <prefix>`.
 
 MinIO has no hard :ref:`thresholds <minio-server-limits>` on the number of buckets, objects, or prefixes on a given deployment.

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -38,7 +38,8 @@ MinIO supports any of the following remote tier targets:
 - :ref:`Microsoft Azure Blob Storage 
   <minio-lifecycle-management-transition-to-azure>`
 
-MinIO object transition supports use cases like moving aged data from MinIO clusters in private or public cloud infrastructure to low-cost private or public cloud storage solutions. 
+MinIO object transition supports use cases like moving aged data from MinIO clusters in private or public cloud infrastructure to low-cost private or public cloud storage solutions.
+Directory objects, which are 0-byte objects with a name that ends in a ``/``, do **not** tier.
 MinIO manages retrieving tiered objects on-the-fly without any additional application-side logic. 
 
 Use the :mc:`mc ilm tier add` command to create a remote target for tiering data to that target. 

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -39,7 +39,7 @@ MinIO supports any of the following remote tier targets:
   <minio-lifecycle-management-transition-to-azure>`
 
 MinIO object transition supports use cases like moving aged data from MinIO clusters in private or public cloud infrastructure to low-cost private or public cloud storage solutions.
-Directory objects, which are 0-byte objects with a name that ends in a ``/``, do **not** tier.
+Directory objects, which are 0-byte objects with a name ending in ``/``, do **not** tier.
 MinIO manages retrieving tiered objects on-the-fly without any additional application-side logic. 
 
 Use the :mc:`mc ilm tier add` command to create a remote target for tiering data to that target. 

--- a/source/reference/minio-mc-admin/mc-admin-info.rst
+++ b/source/reference/minio-mc-admin/mc-admin-info.rst
@@ -64,6 +64,20 @@ Syntax
 .. code-block:: shell
    :class: copyable
 
-   mc admin info TARGET
+   mc admin info TARGET      \
+                 [--offline]
 
 Specify the :mc-cmd:`alias <mc alias>` of a configured MinIO deployment as the ``TARGET``.
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: TARGET
+   :required:
+   
+   The :ref:`alias <alias>` about which you want to display information.
+
+.. mc-cmd:: --offline
+   :optional:
+
+   Show only offline drives or nodes.


### PR DESCRIPTION
For mc RELEASE.2024-06-10T16-44-16Z

- Updates `mc admin info` to add the `--offline` flag

For MinIO Server RELEASE.2024-06-11T03-13-30Z

- Adds to note to object management page about avoiding the `:` character on Windows
- Adds info that directory objects (0-byte, end in `/`) do not tier

These releases do not have doc repo issues to track them.

Docs are not staged, but can be if needed.