### PR TITLE
MinIO removed the version limit in a prior version

### DIFF
--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -120,11 +120,6 @@ For a deeper discussion on the benefits of limiting prefix contents, see the art
 Object Versioning
 ----------------- 
 
-.. versionchanged:: RELEASE.2023-08-04T17-40-21Z
-
-   MinIO supports keeping up to 10,000 "versions" of an object in a single bucket. 
-   For workloads that require keeping more than 10K versions per object, please reach out to MinIO by email at hello@min.io.
-
 .. image:: /images/retention/minio-versioning-multiple-versions.svg
    :alt: Object with Multiple Versions
    :align: center

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -29,12 +29,7 @@ For versioned buckets, a write operation that mutates an object results in a new
 MinIO marks the "latest" version of the object that clients retrieve by default. 
 Clients can then explicitly choose to list, retrieve, or remove a specific object version. 
 
-.. versionchanged:: 2023-08-04T17-40-21Z
-
-   MinIO restricts object versioning to no more than 10,000 versions of each object.
-
-   If a write operation would exceed the 10,000 object version limit, MinIO blocks the operation and returns an error.
-   :ref:`Delete one or more <minio-bucket-versioning-delete>` versions to create a new version of the object.
+Define :ref:`object expiration <minio-lifecycle-management-create-expiry-rule>` rules to remove versions of objects no longer needed, such as by the number of versions or the date of versions.
 
 Read Operations on Versioned Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-mb.rst
+++ b/source/reference/minio-mc/mc-mb.rst
@@ -107,7 +107,8 @@ Parameters
    :optional:
 
    Enables :ref:`object versioning <minio-bucket-versioning>` on the new bucket.
-   When enabled, MinIO keeps up to 10,000 versions of each object.
+   When enabled, MinIO keeps a virtually unlimited number of objects.
+   Define :ref:`object expiration <minio-lifecycle-management-create-expiry-rule>` rules to manage noncurrent versions you no longer need to keep by either number of versions or version date.
 
    Versioning is required for :ref:`bucket replication <minio-bucket-replication>` or :ref:`site replication <minio-site-replication-overview>`.
    Versioning does not imply or require object locking.

--- a/source/reference/minio-mc/mc-mb.rst
+++ b/source/reference/minio-mc/mc-mb.rst
@@ -107,8 +107,8 @@ Parameters
    :optional:
 
    Enables :ref:`object versioning <minio-bucket-versioning>` on the new bucket.
-   When enabled, MinIO keeps a virtually unlimited number of objects.
-   Define :ref:`object expiration <minio-lifecycle-management-create-expiry-rule>` rules to manage noncurrent versions you no longer need to keep by either number of versions or version date.
+   When enabled, MinIO keeps a nearly unlimited number of objects.
+   Define :ref:`object expiration <minio-lifecycle-management-create-expiry-rule>` rules to remove versions of objects no longer needed, such as by the number of versions or the date of versions.
 
    Versioning is required for :ref:`bucket replication <minio-bucket-replication>` or :ref:`site replication <minio-site-replication-overview>`.
    Versioning does not imply or require object locking.

--- a/source/reference/minio-mc/mc-mb.rst
+++ b/source/reference/minio-mc/mc-mb.rst
@@ -107,7 +107,7 @@ Parameters
    :optional:
 
    Enables :ref:`object versioning <minio-bucket-versioning>` on the new bucket.
-   When enabled, MinIO keeps a nearly unlimited number of objects.
+   With versioning enabled, by default MinIO allows up to the maximum value of an Int64 versions per object, or over 9.2 quintillion.
    Define :ref:`object expiration <minio-lifecycle-management-create-expiry-rule>` rules to remove versions of objects no longer needed, such as by the number of versions or the date of versions.
 
    Versioning is required for :ref:`bucket replication <minio-bucket-replication>` or :ref:`site replication <minio-site-replication-overview>`.

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -371,12 +371,7 @@ Maximum Object Versions
 
 *Optional*
 
-Overrides the default maximum version per object limit of ``10000`` with the user specified value.
-
-.. important::
-
-   The default limit of 10,000 provides a safety valve against incorrect or inefficient application behavior in versioned buckets.
-   Lifting this limit without first ensuring your applications are designed for versioned operations may result in a negative performance impact over time.
-
-
-   
+Defines the default maximum versions to allow per object.
+If not defined, MinIO allows a practically unlimited number of object versions.
+ 
+The real maximum is up to highest value of ``MaxInt64``, which is over 9.2 quintillion versions per object.

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -383,3 +383,5 @@ By default, MinIO allows up to the maximum value of an Int64 versions per object
 Arbitrarily high versions per objects may cause performance degradation on some operations, such as ``LIST``.
 This is especially true on systems running budget hardware or spinning drives (HDD).
 Applications or workloads which produce thousands or more versions per object may require design or architecture review to mitigate potential performance degradations.
+
+Setting a limit of no more than ``100`` should provide enough versions for most typical use cases.

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -372,6 +372,6 @@ Maximum Object Versions
 *Optional*
 
 Defines the default maximum versions to allow per object.
-If not defined, MinIO allows a practically unlimited number of object versions.
+If not defined, MinIO keeps a nearly unlimited number of object versions.
  
 The real maximum is up to highest value of ``MaxInt64``, which is over 9.2 quintillion versions per object.

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -372,6 +372,14 @@ Maximum Object Versions
 *Optional*
 
 Defines the default maximum versions to allow per object.
-If not defined, MinIO keeps a nearly unlimited number of object versions.
- 
-The real maximum is up to highest value of ``MaxInt64``, which is over 9.2 quintillion versions per object.
+
+By default, MinIO allows up to the maximum value of an Int64 versions per object, or over 9.2 quintillion.
+
+.. note::
+
+   MinIO versions from ``RELEASE.2023-08-04T17-40-21Z``to ``RELEASE.2024-03-26T22-10-45Z`` had a default limit of 10,000 object versions.
+   This setting can be used to override that limit to another value.
+
+Arbitrarily high versions per objects may cause performance degradation on some operations, such as ``LIST``.
+This is especially true on systems running budget hardware or spinning drives (HDD).
+Applications or workloads which produce thousands or more versions per object may require design or architecture review to mitigate potential performance degradations.


### PR DESCRIPTION
This removes references to version limits and suggests using object expiration rules to manage unneeded noncurrent versions.

There is no doc issue to track this.

Staged:
- [Envvar](http://192.241.195.202:9000/staging/version-max/linux/reference/minio-server/settings/core.html#maximum-object-versions)
- [Object versioning](http://192.241.195.202:9000/staging/version-max/linux/administration/object-management/object-versioning.html)
- [mc mb](http://192.241.195.202:9000/staging/version-max/linux/reference/minio-mc/mc-mb.html#mc.mb.-with-versioning)

And a few other files.