### PR TITLE
Add `MINIO_SERVER_URL` to deprecated command list

### DIFF
--- a/source/reference/minio-server/settings/deprecated.rst
+++ b/source/reference/minio-server/settings/deprecated.rst
@@ -81,6 +81,8 @@ They are listed here for historical reference only.
 
    This setting may be required if:
 
-   - The MinIO Server uses a TLS certificate that does not include the host local IP(s) in the certificate Subject Alternative Name (SAN) *or*
+   - The MinIO Server uses a TLS certificate that does not include the host local IP(s) in the certificate Subject Alternative Name (SAN).
+   
+   or
 
-   - The Console must use a specific hostname to connect or reference the MinIO Server, e.g. due to a reverse proxy or similar configuration.
+   - The Console must use a specific hostname to connect or reference the MinIO Server, such as due to a reverse proxy or similar configuration.

--- a/source/reference/minio-server/settings/deprecated.rst
+++ b/source/reference/minio-server/settings/deprecated.rst
@@ -70,3 +70,17 @@ They are listed here for historical reference only.
    .. deprecated:: RELEASE.2021-04-22T15-44-28Z
 
    To perform root credential rotation, modify the :envvar:`MINIO_ROOT_USER` and :envvar:`MINIO_ROOT_PASSWORD` environment variables.
+
+.. envvar:: MINIO_SERVER_URL
+
+   .. deprecated:: RELEASE.2024-05-10T01-41-38Z
+
+   The `fully qualified domain name <https://en.wikipedia.org/wiki/Fully_qualified_domain_name>`__ (FQDN) the MinIO Console uses for connecting to the MinIO Server. 
+  
+   For the Console to function correctly, the MinIO server URL *must* be the FQDN of the host, resolveable, and reachable.
+
+   This setting may be required if:
+
+   - The MinIO Server uses a TLS certificate that does not include the host local IP(s) in the certificate Subject Alternative Name (SAN) *or*
+
+   - The Console must use a specific hostname to connect or reference the MinIO Server, e.g. due to a reverse proxy or similar configuration.


### PR DESCRIPTION
For reference by support w/ customers running older MinIO versions

Mostly need this because it sometimes comes up via support, and this lets us reference it while also pushing users to upgrade to versions where this kind of behavior is handled automatically.