### PR TITLE
Clarify pool ordering for add after decom

### DIFF
--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -260,3 +260,28 @@ As such the restart procedure is non-disruptive to applications and ongoing oper
 Do **not** perform "rolling" (e.g. one node at a time) restarts.
 
 .. end-nondisruptive-upgrade-desc
+
+.. start-pool-order-must-not-change
+
+.. admonition:: Maintain pool order when decommissioning and then adding
+   :class: note
+
+   If you decommission one pool in a multiple pool deployment, you cannot use the same node sequence for a new pool.
+   For example, consider a deployment with the following pools:
+
+   .. code-block::
+
+      https://minio-{1...4}.example.net/mnt/drive-{1...4}
+      https://minio-{5...8}.example.net/mnt/drive-{1...4}
+      https://minio-{9...12}.example.net/mnt/drive-{1...4}
+
+   If you decommission the ``minio-{5...8}`` pool, you cannot add a new pool with the same node numbering.
+   You must add the new pool *after* ``minio-{9...12}``:
+
+   .. code-block::
+
+      https://minio-{1...4}.example.net/mnt/drive-{1...4}
+      https://minio-{9...12}.example.net/mnt/drive-{1...4}
+      https://minio-{13...16}.example.net/mnt/drive-{1...4}
+
+.. end-pool-order-must-not-change

--- a/source/operations/concepts.rst
+++ b/source/operations/concepts.rst
@@ -121,6 +121,10 @@ For deployments which have multiple server pools, you can :ref:`decommission <mi
 Once started, decommissioning cannot be stopped.
 MinIO intends decommissioning for use with removing older pools with aged hardware, and not as an operation performed regularly within any deployment.
 
+.. include:: /includes/common-installation.rst
+   :start-after: start-pool-order-must-not-change
+   :end-before: end-pool-order-must-not-change
+
 How do I manage one or more MinIO instances or clusters?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/operations/install-deploy-manage/modify-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/modify-minio-tenant.rst
@@ -90,3 +90,7 @@ Decommission a Tenant Server Pool
 MinIO Operator 4.4.13 and later support decommissioning a server pool in a Tenant.
 Specifically, you can follow the :minio-docs:`Decommission a Server pool <minio/linux/operations/install-deploy-manage/decommission-server-pool.html>` procedure to remove the pool from the tenant, then edit the tenant YAML to drop the pool from the StatefulSet.
 When removing the Tenant pool, ensure the ``spec.pools.[n].name`` fields have values for all remaining pools.
+
+.. include:: /includes/common-installation.rst
+   :start-after: start-pool-order-must-not-change
+   :end-before: end-pool-order-must-not-change


### PR DESCRIPTION
If you decommission one pool from a multiple pool deployment, you can't reuse the same node (hostname) sequence for a new pool. If you are using expansion notation to define a set of hostnames for the pool, each new pool must continue the numerical sequence even if some pools were decommissioned along the way.


Staged

linux
http://192.241.195.202:9000/staging/DOCS-1250/linux/operations/concepts.html#can-i-change-the-size-of-an-existing-minio-deployment

k8s
http://192.241.195.202:9000/staging/DOCS-1250/k8s/operations/install-deploy-manage/modify-minio-tenant.html#decommission-a-tenant-server-pool

Fixes https://github.com/minio/docs/issues/1250