### PR TITLE
fix ref typos for mc admin prometheus generate

### DIFF
--- a/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
+++ b/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
@@ -38,7 +38,7 @@ Configure Prometheus to Collect and Alert using MinIO Metrics
 1) Generate the Scrape Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the :mc-cmd:`mc admin prometheus generate` command to generate the scrape configuration for use by Prometheus in making scraping requests:
+Use the :mc:`mc admin prometheus generate` command to generate the scrape configuration for use by Prometheus in making scraping requests:
 
 .. tab-set::
 

--- a/source/operations/monitoring/metrics-and-alerts.rst
+++ b/source/operations/monitoring/metrics-and-alerts.rst
@@ -62,7 +62,7 @@ MinIO provides scraping endpoints for the following metric groups:
 
 
 MinIO by default requires authentication for scraping the metrics endpoints.
-Use the :mc-cmd:`mc admin prometheus generate` command to generate the necessary bearer tokens. 
+Use the :mc:`mc admin prometheus generate` command to generate the necessary bearer tokens. 
 You can alternatively disable metrics endpoint authentication by setting :envvar:`MINIO_PROMETHEUS_AUTH_TYPE` to ``public``.
 
 .. _minio-console-metrics:


### PR DESCRIPTION
Fix broken refs that were causing build warnings on some platforms. Not staged.