### PR TITLE
Add Docsearch facet attribute for search feature

### DIFF
--- a/source/_templates/head.html
+++ b/source/_templates/head.html
@@ -1,4 +1,5 @@
 <!-- Algolia meta attrs -->
+<meta name="docsearch:site" content="docs"/>
 <meta name="docsearch:platform" content="{{ doc_platform }}"/>
 <meta name="docsearch:version" content="{{ doc_platform }}"/>
 <meta name="pagename" content="{{ pagename }}"/>


### PR DESCRIPTION
We're exploring the possibility of adding a global search feature (including docs, blog, etc.) on the main min.io website. As part of this, we are adding a higher-level facet to filter results based on the given site. This is for experimental purposes. If it doesn't work as expected, we will send a PR in the future to remove this meta attribute.

Part of https://github.com/miniohq/min.io/issues/2136