### PR TITLE
Typo in deprecated mc ilm import page

### DIFF
--- a/source/reference/deprecated/mc-ilm-import.rst
+++ b/source/reference/deprecated/mc-ilm-import.rst
@@ -42,7 +42,7 @@ input the contents from a ``.json`` file, such as one produced by
       .. code-block:: shell
          :class: copyable
 
-         mc ilm import myminio/mydata <> mydata-lifecycle-config.json
+         mc ilm import myminio/mydata < mydata-lifecycle-config.json
 
    .. tab-item:: SYNTAX
 


### PR DESCRIPTION
Hopefully nobody tries to use this deprecated command anymore, but fix the example typo anyway.