### PR TITLE
DOCS-1291: Removing trailing operator console references, fixing broken refs

### DIFF
--- a/source/administration/console/managing-deployment.rst
+++ b/source/administration/console/managing-deployment.rst
@@ -41,9 +41,8 @@ The Console :guilabel:`Dashboard` section displays metrics for the MinIO deploym
 The default view provides a high-level overview of the deployment status, including the uptime and availability of individual servers and drives.
 
 The Console also supports displaying time-series and historical data by querying a :prometheus-docs:`Prometheus <prometheus/latest/getting_started/>` service configured to scrape data from the MinIO deployment. 
-Specifically, the MinIO Console uses :prometheus-docs:`Prometheus query API <prometheus/latest/querying/api/>` to retrieve stored metrics data and display historical metrics:
-
-See :ref:`minio-console-metrics` for more information on the historical metric visualization.
+Specifically, the MinIO Console uses :prometheus-docs:`Prometheus query API <prometheus/latest/querying/api/>` to retrieve stored metrics data and display historical metrics
+See :ref:`minio-metrics-collect-using-prometheus` for more information on scraping MinIO metrics into Prometheus.
 
 Logs
 ~~~~

--- a/source/administration/console/managing-deployment.rst
+++ b/source/administration/console/managing-deployment.rst
@@ -41,7 +41,7 @@ The Console :guilabel:`Dashboard` section displays metrics for the MinIO deploym
 The default view provides a high-level overview of the deployment status, including the uptime and availability of individual servers and drives.
 
 The Console also supports displaying time-series and historical data by querying a :prometheus-docs:`Prometheus <prometheus/latest/getting_started/>` service configured to scrape data from the MinIO deployment. 
-Specifically, the MinIO Console uses :prometheus-docs:`Prometheus query API <prometheus/latest/querying/api/>` to retrieve stored metrics data and display historical metrics
+Specifically, the MinIO Console uses the :prometheus-docs:`Prometheus query API <prometheus/latest/querying/api/>` to retrieve stored metrics data and display historical metrics
 See :ref:`minio-metrics-collect-using-prometheus` for more information on scraping MinIO metrics into Prometheus.
 
 Logs

--- a/source/includes/common/common-install-operator-kustomize.rst
+++ b/source/includes/common/common-install-operator-kustomize.rst
@@ -15,33 +15,15 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
 
 #. Install the latest version of Operator
 
+   The following command installs the Operator to the ``minio-operator`` namespace:
+
    .. code-block:: shell
       :class: copyable
       :substitutions:
 
       kubectl apply -k "github.com/minio/operator?ref=v|operator-version-stable|"
 
-   The output resembles the following:
-
-   .. code-block:: shell
-
-      namespace/minio-operator created
-      customresourcedefinition.apiextensions.k8s.io/miniojobs.job.min.io created
-      customresourcedefinition.apiextensions.k8s.io/policybindings.sts.min.io created
-      customresourcedefinition.apiextensions.k8s.io/tenants.minio.min.io created
-      serviceaccount/console-sa created
-      serviceaccount/minio-operator created
-      clusterrole.rbac.authorization.k8s.io/console-sa-role created
-      clusterrole.rbac.authorization.k8s.io/minio-operator-role created
-      clusterrolebinding.rbac.authorization.k8s.io/console-sa-binding created
-      clusterrolebinding.rbac.authorization.k8s.io/minio-operator-binding created
-      configmap/console-env created
-      secret/console-sa-secret created
-      service/console created
-      service/operator created
-      service/sts created
-      deployment.apps/console created
-      deployment.apps/minio-operator created
+   The command outputs a list of installed resources.
 
 #. Verify the Operator pods are running:
 
@@ -55,7 +37,6 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
    .. code-block:: shell
 
       NAME                              READY   STATUS              RESTARTS   AGE
-      console-56c7d8bd89-485qh          1/1     Running   0          2m42s
       minio-operator-6c758b8c45-nkhlx   1/1     Running   0          2m42s
       minio-operator-6c758b8c45-dgd8n   1/1     Running   0          2m42s
 
@@ -80,7 +61,6 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
    .. code-block:: shell
 
       NAME                                  READY   STATUS    RESTARTS   AGE
-      pod/console-56c7d8bd89-485qh          1/1     Running   0          5m20s
       pod/minio-operator-6c758b8c45-nkhlx   1/1     Running   0          5m20s
       pod/minio-operator-6c758b8c45-dgd8n   1/1     Running   0          5m20s
 
@@ -89,11 +69,9 @@ The following procedure uses ``kubectl -k`` to install the Operator from the Min
       service/sts        ClusterIP   10.43.117.251   <none>        4223/TCP                        5m20s
 
       NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
-      deployment.apps/console          1/1     1            1           5m20s
       deployment.apps/minio-operator   2/2     2            2           5m20s
 
       NAME                                        DESIRED   CURRENT   READY   AGE
-      replicaset.apps/console-56c7d8bd89          1         1         1       5m20s
       replicaset.apps/minio-operator-6c758b8c45   2         2         2       5m20s
 
 #. Next Steps

--- a/source/operations/install-deploy-manage/deploy-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/deploy-minio-tenant.rst
@@ -200,6 +200,7 @@ Persistent Volumes
    MinIO strongly recommends SSD-backed disk types for best performance.
    For more information on AKS disk types, see :azure-docs:`Azure disk types <virtual-machines/disk-types>`.
 
+.. _minio-k8s-deploy-minio-tenant-security:
 
 Deploy a MinIO Tenant using Kustomize
 -------------------------------------

--- a/source/operations/install-deploy-manage/modify-minio-tenant.rst
+++ b/source/operations/install-deploy-manage/modify-minio-tenant.rst
@@ -1,4 +1,5 @@
 .. _minio-k8s-modify-minio-tenant:
+.. _minio-k8s-modify-minio-tenant-security:
 
 =====================
 Modify a MinIO Tenant

--- a/source/operations/monitoring.rst
+++ b/source/operations/monitoring.rst
@@ -16,9 +16,7 @@ Monitoring and Alerts
 Metrics and Alerts
 ------------------
 
-MinIO provides point-in-time metrics on cluster status and operations.
-The :ref:`MinIO Console <minio-console-metrics>` provides a graphical display of these metrics.
-
+MinIO publishes a metrics endpoint for scraping data on cluster status and operations.
 For historical metrics and analytics, MinIO publishes cluster and node metrics using the :prometheus-docs:`Prometheus Data Model <concepts/data_model/>`.
 You can use any scraping tool which supports that data model to pull metrics data from MinIO for further analysis and alerting.
 

--- a/source/operations/monitoring.rst
+++ b/source/operations/monitoring.rst
@@ -16,7 +16,7 @@ Monitoring and Alerts
 Metrics and Alerts
 ------------------
 
-MinIO publishes a metrics endpoint for scraping data on cluster status and operations.
+MinIO publishes metrics endpoints for scraping data on cluster status and operations.
 For historical metrics and analytics, MinIO publishes cluster and node metrics using the :prometheus-docs:`Prometheus Data Model <concepts/data_model/>`.
 You can use any scraping tool which supports that data model to pull metrics data from MinIO for further analysis and alerting.
 


### PR DESCRIPTION
Closes #1291 

Missed a few log lines referencing Operator Console.

Also cleaning up some broken refs and further simplifying references to the Console when in context of Tenant/MinIO Object Store.