### PR TITLE
Changes for two mc releases

### DIFF
--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -627,6 +627,8 @@ You can also define some of these options using :ref:`Environment Variables <min
 
 .. option:: --resolve
 
+   .. versionadded:: mc RELEASE.2024-08-13T05-33-17Z
+
    Creates a custom DNS mapping to resolve a HOST to a specified IP address.
 
    Use the following syntax:

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -560,6 +560,14 @@ Global Options
 All :ref:`commands <minio-mc-commands>` support the following global options.
 You can also define some of these options using :ref:`Environment Variables <minio-server-envvar-mc>`.
 
+.. option:: --config-dir
+
+   The path to a ``JSON`` formatted configuration file that
+   :program:`mc` uses for storing data. See :ref:`mc-configuration` for
+   more information on how :program:`mc` uses the configuration file.
+
+   Alternatively, set the environment variable :envvar:`MC_CONFIG_DIR`.
+
 .. option:: --debug
 
    Enables verbose output to the console.
@@ -574,20 +582,20 @@ You can also define some of these options using :ref:`Environment Variables <min
 
    Alternatively, set the environment variable :envvar:`MC_DEBUG`.
 
-.. option:: --config-dir
-
-   The path to a ``JSON`` formatted configuration file that
-   :program:`mc` uses for storing data. See :ref:`mc-configuration` for
-   more information on how :program:`mc` uses the configuration file.
-
-   Alternatively, set the environment variable :envvar:`MC_CONFIG_DIR`.
-
 .. option:: --disable-pager, --dp
 
    .. versionadded:: mc RELEASE.2024-04-29T09-56-05Z
 
    Disable the pager functionality of the MinIO Client in the CLI.
    When used, output prints to raw ``STDOUT`` instead.
+
+.. option:: --insecure
+
+   Disables TLS/SSL certificate verification. Allows TLS connectivity to 
+   servers with invalid certificates. Exercise caution when using this
+   option against untrusted S3 hosts.
+
+   Alternatively, set the environment variable :envvar:`MC_INSECURE`.
 
 .. option:: --json
 
@@ -617,13 +625,24 @@ You can also define some of these options using :ref:`Environment Variables <min
 
    Alternatively, set the environment variable :envvar:`MC_QUIET`.
 
-.. option:: --insecure
+.. option:: --resolve
 
-   Disables TLS/SSL certificate verification. Allows TLS connectivity to 
-   servers with invalid certificates. Exercise caution when using this
-   option against untrusted S3 hosts.
+   Creates a custom DNS mapping to resolve a HOST to a specified IP address.
 
-   Alternatively, set the environment variable :envvar:`MC_INSECURE`.
+   Use the following syntax:
+
+   .. code-block:: text
+
+      --resolve HOST[:PORT]=IP 
+
+   For example:
+
+   .. code-block:: shell
+      :class: copyable
+
+      mc alias set --resolve myminio.example.com:9000=192.168.188.118 'myminio' 'https://myminio.example.com:9000' 'miniouser' 'miniosecret'
+
+   Repeat the flag multiple times to add additional custom DNS mappings.
 
 .. option:: --version
 

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
@@ -50,11 +50,13 @@ The :mc:`mc idp ldap accesskey ls` displays a list of LDAP access key pairs.
       .. code-block:: shell
          :class: copyable
 
-         mc [GLOBALFLAGS] idp ldap accesskey ls              \
-                                          ALIAS              \
+         mc [GLOBALFLAGS] idp ldap accesskey ls           \
+                                          ALIAS           \
+                                          [--all]         \
+                                          [--self]        \
                                           [--svcacc-only] \
-                                          [--temp-only]      \
-                                          [--users-only]     \
+                                          [--temp-only]   \
+                                          [--users-only]  \
                                           [DN] ...
 
 
@@ -80,6 +82,20 @@ Parameters
    .. code-block:: none
 
          mc idp ldap accesskey ls minio
+
+.. mc-cmd:: --all
+   :optional:
+
+   .. versionadded:: mc RELEASE.2024-07-31T15-58-33Z
+
+   List all access keys for all LDAP users.
+
+.. mc-cmd:: --self
+   :optional:
+
+   .. versionadded:: mc RELEASE.2024-07-31T15-58-33Z
+      
+   List access keys for the currently authenticated user.
 
 .. mc-cmd:: --svcacc-only
    :optional:

--- a/source/reference/minio-mc/mc-stat.rst
+++ b/source/reference/minio-mc/mc-stat.rst
@@ -80,7 +80,7 @@ Parameters
 
       mc stat myminio/mybucket/myobject.txt myminio/mybucket/myobject.txt
 
-   If specifying the path to a bucket or bucket prefixy, you **must** include the :mc-cmd:`mc stat --recursive` flag:
+   If specifying the path to a bucket or bucket prefix, you **must** include the :mc-cmd:`mc stat --recursive` flag:
 
    .. code-block:: shell
 
@@ -103,7 +103,7 @@ Parameters
 .. mc-cmd:: --no-list
    :optional:
 
-   Disable all ``LIST`` operations if an object does not exist.
+   Disable all ``LIST`` operations if the target does not exist.
 
 .. mc-cmd:: --recursive, r
    :optional:

--- a/source/reference/minio-mc/mc-stat.rst
+++ b/source/reference/minio-mc/mc-stat.rst
@@ -47,7 +47,8 @@ You can also use :mc:`mc stat` against the local filesystem to produce similar r
          :class: copyable
 
          mc [GLOBALFLAGS] stat                      \
-                          [--encrypt-key "value"]   \
+                          [--enc-c "value"]         \
+                          [--no-list]               \
                           [--recursive]             \
                           [--rewind "string"]       \
                           [--versions]              \
@@ -91,17 +92,18 @@ Parameters
 
       mc stat ~/data/myobject.txt
 
-.. mc-cmd:: --encrypt-key
+.. mc-cmd:: --enc-c
    :optional:
 
-   Encrypt or decrypt objects using server-side encryption with client-specified keys. Specify key-value pairs as ``KEY=VALUE``.
-   
-   - Each ``KEY`` represents a bucket or object. 
-   - Each ``VALUE`` represents the data key to use for encrypting object(s).
+   Encrypt or decrypt objects using client provided keys.
+   Repeat the flag to pass multiple keys.
 
-   Enclose the entire list of key-value pairs passed to :mc-cmd:`~mc stat --encrypt-key` in double quotes ``"``.
+   Keys must be in either Raw Base64 or Hex format.
 
-   :mc-cmd:`~mc stat --encrypt-key` can use the ``MC_ENCRYPT_KEY`` environment variable for retrieving a list of encryption key-value pairs as an alternative to specifying them on the command line.
+.. mc-cmd:: --no-list
+   :optional:
+
+   Disable all ``LIST`` operations if an object does not exist.
 
 .. mc-cmd:: --recursive, r
    :optional:


### PR DESCRIPTION
[`RELEASE.2024-07-31T15-58-33Z`](https://github.com/minio/mc/releases/tag/RELEASE.2024-07-31T15-58-33Z)

- adds new flags to `mc idp ldap accesskey list`

[`RELEASE.2024-08-13T05-33-17Z`](https://github.com/minio/mc/releases/tag/RELEASE.2024-08-13T05-33-17Z)

- adds new flags to `mc stat`
- adds new global flag for custom DNS mapping

Does not track an outstanding docs issue.

Staged:
- [--resolve flag](http://192.241.195.202:9000/staging/mc-08-08-24/linux/reference/minio-mc.html#cmdoption-mc-resolve)
- [mc stat](http://192.241.195.202:9000/staging/mc-08-08-24/linux/reference/minio-mc/mc-stat.html#mc.stat.-enc-c)
- [mc idp ldap accesskey ls](http://192.241.195.202:9000/staging/mc-08-08-24/linux/reference/minio-mc/mc-idp-ldap-accesskey-ls.html#parameters)