### PR TITLE
Changes for MinIO Server RELEASE.2024-08-03T04-33-23Z

### DIFF
--- a/source/administration/batch-framework-job-replicate.rst
+++ b/source/administration/batch-framework-job-replicate.rst
@@ -98,7 +98,22 @@ Optionally, the YAML can also define flags to filter which objects replicate, se
 
 .. versionchanged:: MinIO RELEASE.2024-08-03T04-33-23Z
 
-   v2 of the Batch Job Replicate API allows you to list multiple prefixes on the source to replicate from.
+   This release introduces a new version of the Batch Job Replicate API, ``v2``.
+   The updated API allows you to list multiple prefixes on the source to replicate from.
+   To replicate multiple prefixes from a source, specify ``replicate.apiVersion`` as ``v2``.
+
+   .. code-block::
+      :class: copyable
+
+      replicate:
+        apiVersion: v2
+        source:
+          type: minio
+          bucket: mybucket
+          prefix:
+            - prefix1
+            - prefix2
+      ...
 
 For the **source deployment**
 
@@ -122,6 +137,7 @@ For the **source deployment**
      * - ``prefix:`` 
        - | The prefix on the object(s) that should replicate.
          | Beginning with MinIO Server ``RELEASE.2024-08-03T04-33-23Z``, v2 of the Batch Job Replicate API allows you to list multiple prefixes.
+         | Specify ``replicate.apiVersion`` as ``v2`` to replicate from multiple prefixes.
 
      * - ``endpoint:`` 
        - | Location of the deployment to use for either the source or the target of a replication batch job. 

--- a/source/administration/batch-framework-job-replicate.rst
+++ b/source/administration/batch-framework-job-replicate.rst
@@ -96,6 +96,10 @@ Optionally, the YAML can also define flags to filter which objects replicate, se
 
    You can replicate from a remote MinIO deployment to the local deployment that runs the batch job.
 
+.. vershionchanged:: MinIO RELEASE.2024-08-03T04-33-23Z
+
+   v2 of the Batch Job Replicate API allows you to list multiple prefixes on the source to replicate from.
+
 For the **source deployment**
 
 - Required information
@@ -116,7 +120,8 @@ For the **source deployment**
      :width: 100%
 
      * - ``prefix:`` 
-       - The prefix on the object(s) that should replicate.
+       - | The prefix on the object(s) that should replicate.
+         | Beginning with MinIO Server ``RELEASE.2024-08-03T04-33-23Z``, v2 of the Batch Job Replicate API allows you to list multiple prefixes.
 
      * - ``endpoint:`` 
        - | Location of the deployment to use for either the source or the target of a replication batch job. 

--- a/source/administration/batch-framework-job-replicate.rst
+++ b/source/administration/batch-framework-job-replicate.rst
@@ -96,7 +96,7 @@ Optionally, the YAML can also define flags to filter which objects replicate, se
 
    You can replicate from a remote MinIO deployment to the local deployment that runs the batch job.
 
-.. vershionchanged:: MinIO RELEASE.2024-08-03T04-33-23Z
+.. versionchanged:: MinIO RELEASE.2024-08-03T04-33-23Z
 
    v2 of the Batch Job Replicate API allows you to list multiple prefixes on the source to replicate from.
 


### PR DESCRIPTION
MinIO Server [RELEASE.2024-08-03T04-33-23Z](https://github.com/minio/minio/releases/tag/RELEASE.2024-08-03T04-33-23Z) adds a v2 for the batch job replicate API.

This new version supports including multiple prefixes on the source for replication.

Not linked to a docs issue.

Staged:

- [Replicate batch job reference](http://192.241.195.202:9000/staging/2024-08-03/linux/administration/batch-framework-job-replicate.html#replicate-batch-job-reference)