### PR TITLE
Discourage rebalance, warn against stopping it

### DIFF
--- a/source/operations/concepts.rst
+++ b/source/operations/concepts.rst
@@ -149,12 +149,14 @@ For more information on write preference calculation logic, see :ref:`Writing Fi
 Rebalancing data across all pools after an expansion is an expensive operation that requires scanning the entire deployment and moving objects between pools.
 This may take a long time to complete depending on the amount of data to move.
 
-Starting with MinIO Client version RELEASE.2022-11-07T23-47-39Z, you can manually initiate a rebalancing operation across all server pools using :mc:`mc admin rebalance`. 
+MinIO does not recommend manual rebalancing.
+If required, you can manually initiate a rebalancing operation across all server pools using :mc:`mc admin rebalance`. 
+MinIO recommends `SUBNET <https://min.io/pricing?jmp=docs>`__ users `log in <https://subnet.min.io/>`__ and create a new issue to discuss appropriate rebalancing strategies for deployments.
 
 Rebalancing does not block ongoing operations and runs in parallel to all other I/O. 
 This can result in reduced performance of regular operations. 
 Consider scheduling rebalancing operations during non-peak periods to avoid impacting production workloads. 
-You can start and stop rebalancing at any time
+
 
 How do I upload objects to MinIO?
 ---------------------------------

--- a/source/operations/install-deploy-manage/expand-minio-deployment.rst
+++ b/source/operations/install-deploy-manage/expand-minio-deployment.rst
@@ -165,7 +165,10 @@ MinIO calculates the probability of a write operation to each of the pools as:
 In addition to the free space calculation, if a write option (with parity) would bring a drive
 usage above 99% or a known free inode count below 1000, MinIO does not write to the pool.
 
-If desired, you can manually initiate a rebalance procedure with :mc:`mc admin rebalance`.
+MinIO does not recommend manual rebalancing.
+If required, you can manually initiate a rebalance procedure with :mc:`mc admin rebalance`.
+MinIO recommends `SUBNET <https://min.io/pricing?jmp=docs>`__ users `log in <https://subnet.min.io/>`__ and create a new issue to discuss appropriate rebalancing strategies for deployments.
+
 For more about how rebalancing works, see :ref:`managing objects across a deployment <minio-rebalance>`.
 
 Likewise, MinIO does not write to pools in a decommissioning process.

--- a/source/reference/minio-mc-admin/mc-admin-rebalance.rst
+++ b/source/reference/minio-mc-admin/mc-admin-rebalance.rst
@@ -22,7 +22,7 @@ Description
 
 .. start-mc-admin-rebalance-desc
 
-The :mc-cmd:`mc admin rebalance` command allows starts, monitors, or stops a rebalancing operation on a MinIO deployment.
+The :mc-cmd:`mc admin rebalance` command allows starts or monitors a rebalancing operation on a MinIO deployment.
 Rebalancing redistributes objects across all pools in the deployment.
 
 .. end-mc-admin-rebalance-desc
@@ -35,7 +35,7 @@ This is an expensive and time consuming operation.
 Consider only running a rebalance procedure during light or no use of the deployment.
 If write operations do occur during a rebalance operation, they process in parallel and write to a pool not actively in rebalancing.
 
-You can stop a rebalance and start it again later as needed.
+`MinIO SUBNET <https://min.io/pricing?jmp=docs>`__ users can `log in <https://subnet.min.io/>`__ and create a new issue to discuss appropriate rebalancing strategies for deployments.
 
 Follow the progress of an ongoing rebalance operation using the following command:
 
@@ -67,8 +67,6 @@ The :mc-cmd:`mc admin rebalance` command has the following subcommands:
    * - :mc-cmd:`mc admin rebalance status`
      - Outputs the current status of an in-progress rebalance operation.
 
-   * - :mc-cmd:`mc admin rebalance stop`
-     - Stops an in-progress rebalance operation.
 
 Syntax
 ------
@@ -135,6 +133,12 @@ Syntax
 
    Ends an in-progress rebalance job on the specified deployment.
 
+   .. admonition:: Stop may cause data loss
+      :class: warning
+
+      At this time, MinIO does not recommend stopping an in-progress rebalance job.
+      Interrupting rebalance may result in data loss.
+      
    .. tab-set::
       
       .. tab-item:: EXAMPLES


### PR DESCRIPTION
Starting point for temporary guidance while we fix issues with stopping a rebalance operation.

Staged

Remove several reference to stop. Option detail remains, with a warning:
- http://192.241.195.202:9000/staging/rebalance-stop-guidance/linux/reference/minio-mc-admin/mc-admin-rebalance.html

Recommend against manual rebalance:
- http://192.241.195.202:9000/staging/rebalance-stop-guidance/linux/operations/install-deploy-manage/expand-minio-deployment.html#writing-files
- http://192.241.195.202:9000/staging/rebalance-stop-guidance/linux/operations/concepts.html#how-do-i-manage-object-distribution-across-a-minio-deployment

cc @kannappanr @harshavardhana @krisis 