### PR TITLE
Updates for MinIO Server and MC releases on 2024-07-03/04

### DIFF
--- a/source/reference/deprecated/mc-license-update.rst
+++ b/source/reference/deprecated/mc-license-update.rst
@@ -12,6 +12,12 @@
 
 .. important:: 
 
+   This command is no longer maintained in the Open Source MinIO Server or MinIO Client product and has been removed completely as of MinIO Client ``RELEASE.2024-07-03T20-17-25Z``.
+
+   For questions about licensing the MinIO Server, contact sales@min.io.
+
+.. note::
+
    ``mc license update`` requires :ref:`MinIO Client <minio-client>` version ``RELEASE.2023-11-20T16-30-59Z``.
    While not strictly required, best practice keeps the :ref:`MinIO Client version <mc-client-versioning>` in alignment with the MinIO Server version.
    

--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -71,6 +71,10 @@ Table of Deprecated Commands
      - :mc-cmd:`mc replicate backlog`
      - mc RELEASE.2023-07-18T21-05-38Z
 
+   * - ``mc license update``
+     - No replacement
+     - mc RELEASE.2024-07-03T20-17-25Z 
+
 
 Table of Deprecated Admin Commands
 ----------------------------------
@@ -226,6 +230,7 @@ Table of Deprecated Admin Commands
    /reference/deprecated/mc-ilm-import
    /reference/deprecated/mc-ilm-ls
    /reference/deprecated/mc-ilm-rm
+   /reference/deprecated/mc-license-update
    /reference/deprecated/mc-quota
    /reference/deprecated/mc-quota-clear
    /reference/deprecated/mc-quota-info

--- a/source/reference/minio-mc/mc-batch-status.rst
+++ b/source/reference/minio-mc/mc-batch-status.rst
@@ -19,7 +19,11 @@ Syntax
 
 .. start-mc-batch-status-desc
 
-The :mc:`mc batch status` command outputs real-time summaries of job events on a MinIO server.
+The :mc:`mc batch status` command outputs summaries of job events on a MinIO server.
+
+.. versionchanged:: mc RELEASE.2024-07-03T20-17-25Z
+
+   Batch status can display for active, in-progress jobs or any batch job completed in the previous three (3) days.
 
 .. end-mc-batch-status-desc
 
@@ -28,12 +32,12 @@ The :mc:`mc batch status` command outputs real-time summaries of job events on a
 
    .. tab-item:: EXAMPLE
 
-      The following command outputs a list of all jobs currently in progress on the ``myminio`` alias.
+      The following command outputs the status of the specified job with JobID ``KwSysDpxcBU9FNhGkn2dCf`` currently in progress on the ``myminio`` alias.
 
       .. code-block:: shell
          :class: copyable
 
-         mc batch status myminio KwSysDpxcBU9FNhGkn2dCf
+         mc batch status myminio "KwSysDpxcBU9FNhGkn2dCf"
 
    .. tab-item:: SYNTAX
 
@@ -43,7 +47,7 @@ The :mc:`mc batch status` command outputs real-time summaries of job events on a
          :class: copyable
 
          mc [GLOBALFLAGS] batch list TARGET           \
-                                     JOBID
+                                     "JOBID"
 
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
@@ -73,15 +77,15 @@ Global Flags
 Example
 -------
 
-Summary the Events of a Replicate Job
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Summarize the Events of an Active Replicate Job
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following command provides the real-time summary of an active job on the deployment at :mc:`alias <mc alias>` ``myminio``:
 
 .. code-block:: shell
    :class: copyable
 
-   mc batch status myminio KwSysDpxcBU9FNhGkn2dCf
+   mc batch status myminio "KwSysDpxcBU9FNhGkn2dCf"
 
 - Replace ``myminio`` with the :mc:`alias <mc alias>` of the MinIO deployment that should run the job.
 
@@ -90,13 +94,16 @@ The output of the above command is similar to the following:
 .. code-block:: shell
 
    ●∙∙
+   JobType:        replicate
    Objects:        28766
    Versions:       28766
-   Throughput:     3.0 MiB/s
+   FailedObjects:  0
    Transferred:    406 MiB
    Elapsed:        2m14.227222868s
    CurrObjName:    share/doc/xml-core/examples/foo.xmlcatalogs
  
+
+
 S3 Compatibility
 ~~~~~~~~~~~~~~~~
 

--- a/source/reference/minio-mc/mc-batch-status.rst
+++ b/source/reference/minio-mc/mc-batch-status.rst
@@ -23,7 +23,7 @@ The :mc:`mc batch status` command outputs summaries of job events on a MinIO ser
 
 .. versionchanged:: mc RELEASE.2024-07-03T20-17-25Z
 
-   Batch status can display for active, in-progress jobs or any batch job completed in the previous three (3) days.
+   Batch status displays summaries for active, in-progress jobs or any batch job completed in the previous three (3) days.
 
 .. end-mc-batch-status-desc
 
@@ -47,7 +47,7 @@ The :mc:`mc batch status` command outputs summaries of job events on a MinIO ser
          :class: copyable
 
          mc [GLOBALFLAGS] batch list TARGET           \
-                                     "JOBID"
+                                     ["JOBID"]
 
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
@@ -67,6 +67,8 @@ Parameters
    The unique identifier of a job to summarize.
    To find the ID of a job, use :mc:`mc batch list`.
    
+   If not specified, the command returns a summary for the current active batch job.
+
 Global Flags
 ~~~~~~~~~~~~
 

--- a/source/reference/minio-mc/mc-ilm-tier-add.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-add.rst
@@ -320,7 +320,7 @@ The command accepts the following arguments:
 
    Tenant ID for the `service principal account <https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1>`__ to use to log in to Azure storage.
 
-   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using an service principal identity.
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using a service principal identity.
    This option has no effect for any other value of ``TIER_TYPE``.
 
 .. mc-cmd:: --azure-sp-client-id
@@ -328,7 +328,7 @@ The command accepts the following arguments:
 
    Client ID for the `service principal account <https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1>`__ to use to log in to Azure storage.
 
-   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using an service principal identity.
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using a service principal identity.
    This option has no effect for any other value of ``TIER_TYPE``.
 
 .. mc-cmd:: --azure-sp-client-secret
@@ -336,7 +336,7 @@ The command accepts the following arguments:
 
    The client secret for the `service principal account <https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1>`__ to use to log in to Azure storage.
 
-   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using an service principal identity.
+   This option only applies if :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure`` and you log in using a service principal identity.
    This option has no effect for any other value of ``TIER_TYPE``.
 
 Global Flags

--- a/source/reference/minio-mc/mc-ilm-tier-update.rst
+++ b/source/reference/minio-mc/mc-ilm-tier-update.rst
@@ -114,12 +114,15 @@ Syntax
       .. code-block:: shell
          :class: copyable
 
-         mc ilm tier update TARGET                       \
-                            TIER_NAME                    \
-                            [--access-key value]         \
-                            [--secret-key value]         \
-                            [--use-aws-role]             \
-                            [--account-key value]        \
+         mc ilm tier update TARGET                         \
+                            TIER_NAME                      \
+                            [--account-key value]          \
+                            [--access-key value]           \
+                            [--az-sp-tenant-id value]      \
+                            [--az-sp-client-id value]      \
+                            [--az-sp-client-secret value]  \
+                            [--secret-key value]           \
+                            [--use-aws-role]               \
                             [--credentials-file value] 
 
       .. include:: /includes/common-minio-mc.rst
@@ -177,7 +180,41 @@ The command accepts the following arguments:
    Use this option to rotate the credentials for the :mc-cmd:`~mc ilm tier add --account-name` associated to the remote tier.
 
    This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
-   This option has no effect for any other ``TIER_TYPE``.
+   This option has no effect for any other type of login.
+
+.. mc-cmd:: --az-sp-tenant-id
+   :optional:
+
+   .. versionadded:: mc RELEASE.2024-07-03T20-17-25Z 
+
+   Directory ID for the Azure service principal account.
+
+   This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
+   This option has no effect for any other type of login.
+
+.. mc-cmd:: --az-sp-client-id
+   :optional:
+
+   .. versionadded:: mc RELEASE.2024-07-03T20-17-25Z 
+
+   Client ID of the Azure service principal account.
+
+   Requires :mc-cmd:`~mc ilm tier update --az-sp-client-secret`.
+
+   This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
+   This option has no effect for any other type of login.
+
+.. mc-cmd:: --az-sp-client-secret
+   :optional:
+
+   .. versionadded:: mc RELEASE.2024-07-03T20-17-25Z 
+
+   The secret for the Azure service principal account.
+
+   Requires :mc-cmd:`~mc ilm tier update --az-sp-client-id`.
+
+   This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``azure``. 
+   This option has no effect for any other type of login.
 
 .. mc-cmd:: --credentials-file
    :optional:
@@ -188,7 +225,7 @@ The command accepts the following arguments:
    The user must have permission to perform read/write/list/delete operations on the remote bucket or bucket prefix.
       
    This option only applies to remote storage tiers with :mc-cmd:`~mc ilm tier add TIER_TYPE` is ``gcs``. 
-   This option has no effect for any other ``TIER_TYPE``.
+   This option has no effect for any other type of login.
    
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-license.rst
+++ b/source/reference/minio-mc/mc-license.rst
@@ -44,10 +44,6 @@ Subcommands
           :start-after: start-mc-license-register-desc
           :end-before: end-mc-license-register-desc
 
-   * - :mc:`~mc license update`
-     - .. include:: /reference/minio-mc/mc-license-update.rst
-          :start-after: start-mc-license-update-desc
-          :end-before: end-mc-license-update-desc
 
 .. toctree::
    :titlesonly:
@@ -55,4 +51,3 @@ Subcommands
    
    /reference/minio-mc/mc-license-info
    /reference/minio-mc/mc-license-register
-   /reference/minio-mc/mc-license-update


### PR DESCRIPTION
- Adds info about tracking batch job status for completed jobs
- Deprecates `mc license update`
- Adds flags for updating Azure credentials in `mc ilm tier update`

Closes #1260

Staged:

- [mc license update](http://192.241.195.202:9000/staging/2024-07-04/linux/reference/deprecated/mc-license-update.html) moved to deprecated commands with a new admonition
- [mc batch status](http://192.241.195.202:9000/staging/2024-07-04/linux/reference/minio-mc/mc-batch-status.html)
- [mc ilm tier update](http://192.241.195.202:9000/staging/2024-07-04/linux/reference/minio-mc/mc-ilm-tier-update.html#mc.ilm.tier.update.-az-sp-tenant-id)