### PR TITLE
Changes for MinIO Server releases

### DIFF
--- a/source/administration/console/subnet-registration.rst
+++ b/source/administration/console/subnet-registration.rst
@@ -1,8 +1,8 @@
 .. _minio-console-subscription:
 
-===============================
-SUBNET Registration and Support
-===============================
+======
+SUBNET
+======
 
 .. default-domain:: minio
 
@@ -14,17 +14,19 @@ SUBNET Registration and Support
 You can use the MinIO Console to perform several of the license and subscription related functions available in MinIO, such as:
 
 - View the license you are currently using for your MinIO deployment.
-- Subscribe to |SUBNET|.
-- Manage the deployment's SUBNET license.
+- Subscribe to a commercial license, which includes access to |SUBNET|.
+- Manage the deployment's Enterprise license.
 - Access Support tools for sharing with MinIO Engineering.
+- Review differences between license options.
 
 License
 -------
 
-MinIO offers two licensing options: 
+MinIO offers three licensing options: 
 
 #. Open source with the :minio-git:`GNU AGPLv3 license <mc/blob/master/LICENSE>`
-#. Paid commercial license with included support direct from MinIO Engineers
+#. Enterprise Lite, a `commercial license <https://min.io/pricing?ref=docs>`__ with included support direct from MinIO Engineers
+#. Enterprise Plus, a `commercial license <https://min.io/pricing?ref=docs>`__ with included support direct from MinIO Engineers, longer release cycle, shorter SLA, and other benefits
 
 This page shows the current license status of the deployment.
 You can also begin the registration process to sign up for a paid subscription or add the deployment to an existing subscription.
@@ -34,7 +36,7 @@ MinIO cannot make the determination as to whether your application's usage of Mi
 You should instead rely on your own legal counsel or licensing specialists to audit and ensure your application is in compliance with the licenses of MinIO and all other open-source projects with which your application integrates or interacts.
 
 MinIO Commercial Licensing is the best option for applications which trigger AGPLv3 obligations (for example, open sourcing your application). 
-Applications using MinIO — or any other OSS-licensed code — without validating their usage do so at their own risk.
+Applications using MinIO—or any other OSS-licensed code—without validating their usage do so at their own risk.
 
 Health
 ------
@@ -86,7 +88,7 @@ MinIO installs with Call Home options disabled by default.
 
 .. important:: 
 
-   Call Home requires an active SUBNET subscription.
+   Call Home requires an active Enterprise license.
 
 Use the :guilabel:`Call Home` section to enable or disable uploading either once-per-day health diagnostic reports or real-time error logs to SUBNET.
 The health reports and real-time logs are separate functions you can enable or disable separately.

--- a/source/administration/console/subnet-registration.rst
+++ b/source/administration/console/subnet-registration.rst
@@ -28,7 +28,7 @@ MinIO offers three licensing options:
 #. Enterprise Lite, a `commercial license <https://min.io/pricing?ref=docs>`__ with included support direct from MinIO Engineers
 #. Enterprise Plus, a `commercial license <https://min.io/pricing?ref=docs>`__ with included support direct from MinIO Engineers, longer release cycle, shorter SLA, and other benefits
 
-This page shows the current license status of the deployment.
+The :guilabel:`License` page shows the current license status of the deployment.
 You can also begin the registration process to sign up for a paid subscription or add the deployment to an existing subscription.
 
 Deployments licensed under AGPLv3 must comply to the terms of the license.

--- a/source/administration/minio-console.rst
+++ b/source/administration/minio-console.rst
@@ -156,7 +156,7 @@ Once logged in to the MinIO Console, users can perform many kinds of tasks.
 - :ref:`Manage objects <minio-console-managing-objects>` by browsing or uploading objects, managing bucket settings, or creating tiers.
 - :ref:`Review or modify identity and security <minio-console-security-access>` with access keys, policies, and Identity Provider settings.
 - :ref:`Monitor the health and activities <minio-console-managing-deployment>` with metrics, notifications, or site replication
-- :ref:`Manage your deployment's license and SUBNET Subscription <minio-console-subscription>`
+- :ref:`Manage your deployment's license <minio-console-subscription>`
 
 .. toctree::
    :titlesonly:

--- a/source/operations/troubleshooting.rst
+++ b/source/operations/troubleshooting.rst
@@ -287,10 +287,10 @@ Version support varies by the `license <https://min.io/pricing?ref=docs>`_ used 
    * - AGPLv3
      - Most recent release
 
-   * - MinIO Standard
+   * - MinIO Enterprise Lite
      - 1 year long term support of any release
 
-   * - MinIO Enterprise
+   * - MinIO Enterprise Plus
      - 5 year long term support of any release, SUBNET support for upgrade guidance and recommendations
 
 Recommended Upgrade Schedule

--- a/source/reference/minio-mc/mc-idp-ldap-policy-entities.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-policy-entities.rst
@@ -51,9 +51,9 @@ The :mc:`mc idp ldap policy entities` command displays a list of mappings for a 
 
          mc [GLOBALFLAGS] idp ldap policy entities                       \
                                           ALIAS                          \
-                                          [--user `value`, -u `value`]   \
                                           [--group `value`, -g `value`]  \
-                                          [--policy value]
+                                          [--policy value]               \
+                                          [--user `value`, -u `value`]
 
       - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment to configure for AD/LDAP integration.
       - You may use each of the ``--user``, ``--group``, and/or ``--policy`` flags as many times as desired in the command.
@@ -79,6 +79,25 @@ Parameters
 
       mc idp ldap policy entities myminio
 
+.. mc-cmd:: --group
+   :optional:
+
+   Returns a list of users and policies associated with the specified group.
+   Repeat the flag to return a list for multiple groups.
+
+.. mc-cmd:: --policies
+   :optional:
+
+   Returns a list of users and groups associated with the specified policy.
+   Repeat the flag to return a list for multiple policies.
+
+.. mc-cmd:: --user
+   :optional:
+
+   Returns a list of groups to which the user belongs and the policies associated with each group.
+   The output includes only groups assigned to policies.
+
+   Repeat the flag to return a list for multiple users.
 
 Example
 ~~~~~~~

--- a/source/reference/minio-mc/mc-support-diag.rst
+++ b/source/reference/minio-mc/mc-support-diag.rst
@@ -108,7 +108,7 @@ Generate health data for a MinIO cluster and automatically for a MinIO cluster a
 
    mc support diag minio1
 
-The automatic upload of data only occurs for deployments registered with SUBNET using :mc-cmd:`mc license register`.
+The automatic upload of data only occurs for deployments under a Commerical License.
 
 .. _minio-support-diagnostics-airgap:
 

--- a/source/reference/minio-server/settings/iam/openid.rst
+++ b/source/reference/minio-server/settings/iam/openid.rst
@@ -197,6 +197,9 @@ Claim Prefix
 
 *Optional*
 
+This setting is deprecated and has been removed as of :minio-release:`RELEASE.2024-07-13T01-46-15Z`.
+Use :envvar:`MINIO_IDENTITY_OPENID_CLAIM_NAME` instead.
+
 .. tab-set::
 
    .. tab-item:: Environment Variable
@@ -262,6 +265,9 @@ Redirect URI
 ~~~~~~~~~~~~
 
 *Optional*
+
+This setting is deprecated and has been removed as of :minio-release:`RELEASE.2024-07-13T01-46-15Z`.
+Use :envvar:`MINIO_BROWSER_REDIRECT_URL` instead.
 
 .. tab-set:: 
 


### PR DESCRIPTION
- Updates references for licensing to use "Enterprise" branding
- Updates the mc idp ldap policy entities command with flags and changes to groups
- Deprecates OpenID envvar

Closes #1271

Staged:
- [ldap policy entities](http://192.241.195.202:9000/staging/DOCS-1271/linux/reference/minio-mc/mc-idp-ldap-policy-entities.html)
- and some other places you'll have to navigate to from there