### PR TITLE
Mention Invalid Login error on MINIO_SERVER_URL

### DIFF
--- a/source/reference/minio-server/settings/deprecated.rst
+++ b/source/reference/minio-server/settings/deprecated.rst
@@ -79,10 +79,9 @@ They are listed here for historical reference only.
 
    For the Console to function correctly, the MinIO server URL *must* be the FQDN of the host, resolveable, and reachable.
 
-   If the :envvar:`MINIO_SERVER_URL` can't be accessed, the MinIO Console won't be able to perform logins, it will hang for about 10 seconds and will return ``Invalid Login``.
-   There won't be any explicit mention about the lack of connectivity between the MinIO Console and the the MinIO server. If you are having trouble login to
-   the MinIO try removing this.
-
+   If the specified value does not resolve to the MinIO server, logins via the MinIO Console fail and returns a network error after a wait period.
+   Older versions of the Console may return a generic 'Invalid Login' error instead.
+   Unset the value *or* address the FQDN resolution issue to allow Console logins to proceed.
    This setting may be required if:
 
    - The MinIO Server uses a TLS certificate that does not include the host local IP(s) in the certificate Subject Alternative Name (SAN).

--- a/source/reference/minio-server/settings/deprecated.rst
+++ b/source/reference/minio-server/settings/deprecated.rst
@@ -79,7 +79,7 @@ They are listed here for historical reference only.
 
    For the Console to function correctly, the MinIO server URL *must* be the FQDN of the host, resolveable, and reachable.
 
-   If the specified value does not resolve to the MinIO server, logins via the MinIO Console fail and returns a network error after a wait period.
+   If the specified value does not resolve to the MinIO server, logins via the MinIO Console fail and return a network error after a wait period.
    Older versions of the Console may return a generic 'Invalid Login' error instead.
    Unset the value *or* address the FQDN resolution issue to allow Console logins to proceed.
    This setting may be required if:

--- a/source/reference/minio-server/settings/deprecated.rst
+++ b/source/reference/minio-server/settings/deprecated.rst
@@ -75,14 +75,18 @@ They are listed here for historical reference only.
 
    .. deprecated:: RELEASE.2024-05-10T01-41-38Z
 
-   The `fully qualified domain name <https://en.wikipedia.org/wiki/Fully_qualified_domain_name>`__ (FQDN) the MinIO Console uses for connecting to the MinIO Server. 
-  
+   The `fully qualified domain name <https://en.wikipedia.org/wiki/Fully_qualified_domain_name>`__ (FQDN) the MinIO Console uses for connecting to the MinIO Server.
+
    For the Console to function correctly, the MinIO server URL *must* be the FQDN of the host, resolveable, and reachable.
+
+   If the :envvar:`MINIO_SERVER_URL` can't be accessed, the MinIO Console won't be able to perform logins, it will hang for about 10 seconds and will return ``Invalid Login``.
+   There won't be any explicit mention about the lack of connectivity between the MinIO Console and the the MinIO server. If you are having trouble login to
+   the MinIO try removing this.
 
    This setting may be required if:
 
    - The MinIO Server uses a TLS certificate that does not include the host local IP(s) in the certificate Subject Alternative Name (SAN).
-   
+
    or
 
    - The Console must use a specific hostname to connect or reference the MinIO Server, such as due to a reverse proxy or similar configuration.


### PR DESCRIPTION
The MinIO Console currently does not warn the user if the MinIO server is not reachable. MinIO Console will just say "Invalid Login" when the MINIO_SERVER_URL is not reachable which is misleading in the sense that will make think most people that the username/password/access key is incorrect  so I think it should be mentioned in the documentation that Invalid Login could be just due to connectivity between console and server. 

Related to https://github.com/minio/console/issues/3428 and https://github.com/minio/console/issues/3427

@marktheunissen 

