### PR TITLE
Updates for mc RELEASE.2024-09-16T17-43-14Z

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-cluster-iam-export.rst
+++ b/source/reference/minio-mc-admin/mc-admin-cluster-iam-export.rst
@@ -39,7 +39,8 @@ The command saves the output as ``ALIAS-iam-metadata.zip``, where ``ALIAS`` is t
       .. code-block:: shell  
          :class: copyable 
   
-         mc [GLOBALFLAGS] admin cluster iam export ALIAS
+         mc [GLOBALFLAGS] admin cluster iam export ALIAS  \
+                          [--output, -o <string>]
                                              
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
@@ -56,9 +57,41 @@ Parameters
 
    The :ref:`alias <alias>` of the MinIO deployment to export IAM metadata for.
 
+
+.. mc-cmd:: --output, --o
+   :optional:
+
+   Specify a custom file and path to use when exporting the IAM data.
+
 Global Flags
 ~~~~~~~~~~~~
 
 .. include:: /includes/common-minio-mc.rst
    :start-after: start-minio-mc-globals
    :end-before: end-minio-mc-globals
+
+Examples
+--------
+
+Download all IAM metadata for a cluster to a ZIP file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command downloads all IAM metadata for the cluster at alias ``myminio``, then stores the metadata to a ZIP file.
+
+.. code-block:: shell
+
+   mc admin cluster iam export myminio
+
+The ZIP file is named ``<alias>-iam-info.zip`` where ``<alias>`` is the alias of the cluster.
+For the above example, the file is named ``myminio-iam-info.zip``.
+
+The file is placed in the current active directory path.
+
+Download all IAM metadata for a cluster and specify the name and path of the ZIP file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command downloads all IAM metadata for the cluster at alias ``myminio``, then stores the metadata to a ZIP file at ``/tmp/myminio-iam.zip``.
+
+.. code-block:: shell
+
+   mc admin cluster iam export myminio --output /tmp/myminio-iam.zip

--- a/source/reference/minio-mc/mc-encrypt-set.rst
+++ b/source/reference/minio-mc/mc-encrypt-set.rst
@@ -143,9 +143,7 @@ encryption state. Specifying default encryption settings which the
 server cannot support may result in undesired behavior.
 
 Setting or modifying the default server-side encryption settings does *not*
-automatically encrypt or decrypt the existing bucket contents. If the bucket
-contents *must* have consistent encryption, use the
-:mc:`mc mv` mc with the :mc-cmd:`~mc mv --encrypt` or
-:mc-cmd:`~mc mv --encrypt-key` arguments to manually modify the
-encryption settings or encrypted state of the bucket contents *before*
-changing the bucket default. 
+automatically encrypt or decrypt the existing bucket contents. 
+If the bucket contents *must* have consistent encryption, use the
+:mc:`mc mv` command with :mc-cmd:`~mc mv --enc-kms`, :mc-cmd:`~mc mv --enc-s3`, or :mc-cmd:`~mc mv --enc-c` to specify the type of encryption to use for the moved contents.
+This manually modifies the encryption settings or encrypted state of the bucket contents *before* changing the bucket default. 


### PR DESCRIPTION
- Adds new `--output` flag to `mc admin cluster iam export`
- Corrects encryption flags for `mc mv` command noted during build

Does not track a docs issue.

Staged:

- [mc admin cluster iam export](http://192.241.195.202:9000/staging/mc-2024-09-16/linux/reference/minio-mc-admin/mc-admin-cluster-iam-export.html#mc.admin.cluster.iam.export.-output)
- [mc encrypt set](http://192.241.195.202:9000/staging/mc-2024-09-16/linux/reference/minio-mc/mc-encrypt-set.html#behavior)