### PR TITLE
Fixing links to videos missing a :

### DIFF
--- a/source/administration/object-management.rst
+++ b/source/administration/object-management.rst
@@ -10,8 +10,8 @@ Object Management
 
 .. container:: extlinks-video
 
-   - `Versioning overview <https//youtu.be/XGOiwV6Cbuk?ref=docs>`__
-   - `Object locking and retention overview <https//youtu.be/Hk9Z-sltUu8?ref=docs>`__
+   - `Versioning overview <https://youtu.be/XGOiwV6Cbuk?ref=docs>`__
+   - `Object locking and retention overview <https://youtu.be/Hk9Z-sltUu8?ref=docs>`__
    - `MinIO Object Lifecycle Management Part I <https://youtu.be/Exg2KsfzHzI?ref=docs>`__
    - `MinIO Object Lifecycle Management Part II <https://youtu.be/5fz3rE3wjGg?ref=docs>`__
 

--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -12,8 +12,8 @@ Bucket Versioning
 
 .. container:: extlinks-video
 
-   - `Versioning overview <https//youtu.be/XGOiwV6Cbuk?ref=docs>`__
-   - `Versioning lab <https//youtu.be/nFUI2N5zH34?ref=docs>`__
+   - `Versioning overview <https://youtu.be/XGOiwV6Cbuk?ref=docs>`__
+   - `Versioning lab <https://youtu.be/nFUI2N5zH34?ref=docs>`__
 
 Overview
 --------


### PR DESCRIPTION
Found a few more links for videos missing a `:` after the `http`.
This fixes those.