### PR TITLE
Minor fixes to address multiple small issues

### DIFF
--- a/source/administration/batch-framework.rst
+++ b/source/administration/batch-framework.rst
@@ -76,6 +76,10 @@ The :mc:`mc batch` commands include
      - .. include:: /reference/minio-mc/mc-batch-describe.rst
           :start-after: start-mc-batch-describe-desc
           :end-before: end-mc-batch-describe-desc
+   * - :mc:`mc batch cancel`
+     - .. include:: /reference/minio-mc/mc-batch-cancel.rst
+          :start-after: start-mc-batch-cancel-desc
+          :end-before: end-mc-batch-cancel-desc
 
 .. _minio-batch-framework-access:
 

--- a/source/reference/minio-mc.rst
+++ b/source/reference/minio-mc.rst
@@ -109,7 +109,7 @@ Each of the following tabs contains a provider-specific example:
       .. code-block:: shell
          :class: copyable
 
-         mc alias set myS3 https://s3.amazon.com/endpoint ACCESS_KEY SECRET_KEY
+         mc alias set myS3 https://s3.{your-region-code}.amazonaws.com/endpoint ACCESS_KEY SECRET_KEY
 
    .. tab-item:: Google Cloud Storage
 

--- a/source/reference/minio-mc/mc-batch-generate.rst
+++ b/source/reference/minio-mc/mc-batch-generate.rst
@@ -169,7 +169,7 @@ See :ref:`minio-batch-framework-keyrotate-job-ref` for more complete documentati
 
 You can use the following example configuration as a starting point for building your own custom expiration batch job:
 
-.. literalinclude:: /includes/code/keyrotate.yaml
+.. literalinclude:: /includes/code/expire.yaml
    :language: yaml
 
 See :ref:`minio-batch-framework-expire-job-ref` for more complete documentation on each key.

--- a/source/reference/minio-mc/mc-license.rst
+++ b/source/reference/minio-mc/mc-license.rst
@@ -17,7 +17,7 @@ Description
 .. start-mc-license-desc
 
 The :mc:`mc license` commands work with cluster registration for |SUBNET|. 
-Use the commands to register a deployment, unregister a deployment, display information about the cluster's current license, or update the license key for a cluster.
+Use the commands to register a deployment, display information about the cluster's current license, or update the license key for a cluster.
 
 .. end-mc-license-desc
 

--- a/source/reference/minio-server/settings/root-credentials.rst
+++ b/source/reference/minio-server/settings/root-credentials.rst
@@ -13,6 +13,8 @@ Root Access Settings
 This page covers settings that control root (superuser) access for the MinIO process. 
 The root user has complete access and permissions to perform operations on the MinIO deployment.
 
+Root User and Root Password are required even if you use the :kes-docs:`MinIO Key Encryption Service <>` or other key management utility.
+
 .. include:: /includes/common-mc-admin-config.rst
    :start-after: start-minio-settings-defined
    :end-before: end-minio-settings-defined
@@ -93,6 +95,10 @@ Root Access
 Specify ``on`` to enable and ``off`` to disable the :ref:`root <minio-users-root>` user account.
 Disabling the root service account also disables all service accounts associated with root, excluding those used by site replication.
 Defaults to ``on``.
+
+.. important::
+
+   If you disable root API access with this setting, you **must** still set a root user and a root password for internal use.
 
 Ensure you have at least one other admin user, such as one with the :userpolicy:`consoleAdmin` policy, before disabling the root account.
 If you do not have another admin user, disabling the root account locks administrative access to the deployment.


### PR DESCRIPTION
A few quick fixes noted in several issues:

- Literal reference in mc batch generate pointed to the wrong include
   Closes #1318 
- Lingering reference to an "unregister" function removed
  Closes #1324
- Adds admonition about root credentials required, even with KES
  Closes #1325 
- Adds mc batch cancel to list of commands on batch framework overview page
   Closes #1310
- Updates mc client page S3 link to avoid possible copy/paste confusion
  Closes #1311

Staged:

- [mc client](http://192.241.195.202:9000/staging/expire/linux/reference/minio-mc.html)
- And other places you can navigate to from the above page as needed