### PR TITLE
Updates for the 2024-09-09 releases of the server and mc

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-cluster-iam-import.rst
+++ b/source/reference/minio-mc-admin/mc-admin-cluster-iam-import.rst
@@ -21,6 +21,28 @@ The :mc:`mc admin cluster iam import` command imports :ref:`IAM <minio-authentic
 
 You can use this command to manually restore IAM metadata settings for a MinIO deployment.
 
+.. versionadded:: mc RELEASE.2024-09-09T07-53-10Z
+
+   The command outputs the results of the import, including the following:
+
+   - number of indidividual entities imported:
+     - policies
+     - users
+     - groups
+     - service accounts
+   - policies imported to a:
+     - user
+     - group
+     - service account
+   - entities that failed to import:
+     - policies
+     - users
+     - groups
+     - service accounts
+     - policies to a user
+     - policies to a group
+     - policies to a service account
+
 .. tab-set::
 
    .. tab-item:: EXAMPLE

--- a/source/reference/minio-mc-admin/mc-admin-cluster-iam-import.rst
+++ b/source/reference/minio-mc-admin/mc-admin-cluster-iam-import.rst
@@ -25,28 +25,11 @@ You can use this command to manually restore IAM metadata settings for a MinIO d
 
    The command outputs the results of the import, including the following:
 
-   - number of indidividual entities imported:
-    
-     - policies
-     - users
-     - groups
-     - service accounts
+   - count of individual entities imported by entity type
 
-   - policies imported to a:
+   - list of policies imported by entity type they imported to
 
-     - user
-     - group
-     - service account
-
-   - entities that failed to import:
-
-     - policies
-     - users
-     - groups
-     - service accounts
-     - policies to a user
-     - policies to a group
-     - policies to a service account
+   - list of entities that failed to import
 
 .. tab-set::
 

--- a/source/reference/minio-mc-admin/mc-admin-cluster-iam-import.rst
+++ b/source/reference/minio-mc-admin/mc-admin-cluster-iam-import.rst
@@ -26,15 +26,20 @@ You can use this command to manually restore IAM metadata settings for a MinIO d
    The command outputs the results of the import, including the following:
 
    - number of indidividual entities imported:
+    
      - policies
      - users
      - groups
      - service accounts
+
    - policies imported to a:
+
      - user
      - group
      - service account
+
    - entities that failed to import:
+
      - policies
      - users
      - groups

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-disable.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-disable.rst
@@ -19,7 +19,7 @@ Description
 
 .. start-mc-idp-ldap-accesskey-disable-desc
 
-:mc:`mc idp ldap accesskey disable` disables the specified access key on the local server.
+:mc:`mc idp ldap accesskey disable` disables the specified :ref:`access key <minio-id-access-keys>` on the MinIO deployment.
 
 .. end-mc-idp-ldap-accesskey-disable-desc
 
@@ -27,7 +27,7 @@ Description
 
    .. tab-item:: EXAMPLE
 
-         The following example disables the access key ``mykey`` from the ``minio`` deployment:
+         The following example disables the access key ``mykey`` on the ``minio`` deployment:
 
       .. code-block:: shell
          :class: copyable

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-disable.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-disable.rst
@@ -1,0 +1,102 @@
+.. _minio-mc-idp-ldap-accesskey-disable:
+
+=================================
+``mc idp ldap accesskey disable``
+=================================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+.. mc:: mc idp ldap accesskey disable
+
+
+Description
+-----------
+
+.. start-mc-idp-ldap-accesskey-disable-desc
+
+:mc:`mc idp ldap accesskey disable` disables the specified access key on the local server.
+
+.. end-mc-idp-ldap-accesskey-disable-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+         The following example disables the access key ``mykey`` from the ``minio`` deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc idp ldap accesskey disable minio mykey
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] idp ldap accesskey disable  \
+                                          ALIAS       \
+                                          KEY
+
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment configured for AD/LDAP integration.
+      - Replace ``KEY`` with the access key to disable.
+        
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment configured for AD/LDAP.
+
+   For example:
+
+   .. code-block:: none
+
+         mc idp ldap accesskey disable minio
+
+.. mc-cmd:: KEY
+   :required:
+
+   The configured access key to disable.
+
+Example
+~~~~~~~
+
+Disable the access key ``mykey`` from the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey disable minio/ mykey
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-edit.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-edit.rst
@@ -19,7 +19,7 @@ Description
 
 .. start-mc-idp-ldap-accesskey-edit-desc
 
-:mc:`mc idp ldap accesskey edit` modifies the specified access key on the local server.
+:mc:`mc idp ldap accesskey edit` modifies the specified :ref:`access key <minio-id-access-keys>` on the local server.
 
 .. end-mc-idp-ldap-accesskey-rm-desc
 

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-edit.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-edit.rst
@@ -1,0 +1,165 @@
+.. _minio-mc-idp-ldap-accesskey-edit:
+
+==============================
+``mc idp ldap accesskey edit``
+==============================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+.. mc:: mc idp ldap accesskey edit
+
+
+Description
+-----------
+
+.. start-mc-idp-ldap-accesskey-edit-desc
+
+:mc:`mc idp ldap accesskey edit` modifies the specified access key on the local server.
+
+.. end-mc-idp-ldap-accesskey-rm-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+         The following example modifies the secret for the access key ``mykey`` on the ``minio`` deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc idp ldap accesskey edit myminio/ mykey --secret-key 'xxxxxxx' 
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] idp ldap accesskey rm                        \
+                                          ALIAS                        \
+                                          KEY                          \
+                                          [--secret-key <string>]      \
+                                          [--policy <string>]          \
+                                          [--name <string>]            \
+                                          [--description <string>]     \
+                                          [--expiry-duration <string>] \
+                                          [--expiry <string>]
+
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment configured for AD/LDAP integration.
+      - Replace ``KEY`` with the access key to delete.
+        
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment configured for AD/LDAP.
+
+   For example:
+
+   .. code-block:: none
+
+         mc idp ldap accesskey ls minio
+
+.. mc-cmd:: KEY
+   :required:
+
+   The configured access key to delete.
+
+.. mc-cmd:: --description
+   :optional:
+
+   Add a description for the service account.
+   For example, you might specify the reason the access key exists.
+
+.. mc-cmd:: --expiry
+   :optional:
+
+   The date after which the access key expires.
+   Enter the date in YYYY-MM-DD format.
+
+   For example, to expire the credentials after December 31, 2024, enter ``2024-12-31``.
+
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey edit --expiry-duration`.
+
+.. mc-cmd:: --expiry-duration
+   :optional:
+
+   Length of time the access key pair should remain valid for use in ``#d#h#s`` format.
+       
+   For example, ``7d``, ``24h``, ``5d12h30s`` are valid strings.
+
+   Mutually exclusive with :mc-cmd:`~mc idp ldap accesskey edit --expiry`.
+
+.. mc-cmd:: --name
+   :optional:
+
+   A human-readable name to use for the account.
+
+.. mc-cmd:: --policy
+   :optional:
+
+   File path to the JSON-formatted policy to use for the account.
+
+   If not specified, the account uses the same policy as the authenticated user.
+
+.. mc-cmd:: --secret-key
+   :optional:
+
+   A secret to use for the account.
+
+
+Example
+~~~~~~~
+
+Modify a secret for an access key
++++++++++++++++++++++++++++++++++
+
+Modify the secret for the access key ``mykey`` on the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey edit myminio/ mykey --secret-key 'xxxxxxx' 
+
+Modify the expiration duration for an accesskey
++++++++++++++++++++++++++++++++++++++++++++++++
+
+Modify the expiration duration for the access key ``mykey`` on the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey edit myminio/ mykey ---expiry-duration 24h 
+
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-enable.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-enable.rst
@@ -19,7 +19,7 @@ Description
 
 .. start-mc-idp-ldap-accesskey-enable-desc
 
-The :mc:`mc idp ldap accesskey enable` enables the specified access key on the local server.
+The :mc:`mc idp ldap accesskey enable` enables the specified :ref:`access key <minio-id-access-keys>` on the local server.
 
 .. end-mc-idp-ldap-accesskey-enable-desc
 

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-enable.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-enable.rst
@@ -1,0 +1,102 @@
+.. _minio-mc-idp-ldap-accesskey-enable:
+
+================================
+``mc idp ldap accesskey enable``
+================================
+
+.. default-domain:: minio
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+.. mc:: mc idp ldap accesskey enable
+
+
+Description
+-----------
+
+.. start-mc-idp-ldap-accesskey-enable-desc
+
+The :mc:`mc idp ldap accesskey enable` enables the specified access key on the local server.
+
+.. end-mc-idp-ldap-accesskey-enable-desc
+
+.. tab-set::
+
+   .. tab-item:: EXAMPLE
+
+         The following example enables the access key ``mykey`` from the ``minio`` deployment:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc idp ldap accesskey enable minio/ mykey
+
+   .. tab-item:: SYNTAX
+
+      The command has the following syntax:
+
+      .. code-block:: shell
+         :class: copyable
+
+         mc [GLOBALFLAGS] idp ldap accesskey enable  \
+                                          ALIAS      \
+                                          KEY
+
+
+      - Replace ``ALIAS`` with the :ref:`alias <alias>` of a MinIO deployment configured for AD/LDAP integration.
+      - Replace ``KEY`` with the access key to enable.
+        
+      .. include:: /includes/common-minio-mc.rst
+         :start-after: start-minio-syntax
+         :end-before: end-minio-syntax
+
+
+Parameters
+~~~~~~~~~~
+
+.. mc-cmd:: ALIAS
+   :required:
+
+   The :ref:`alias <alias>` of the MinIO deployment configured for AD/LDAP.
+
+   For example:
+
+   .. code-block:: none
+
+         mc idp ldap accesskey enable minio mykey
+
+.. mc-cmd:: KEY
+   :required:
+
+   The configured access key to enable.
+
+Example
+~~~~~~~
+
+Enable the access key ``mykey`` from the ``minio`` deployment.
+
+.. code-block:: shell
+   :class: copyable
+
+   mc idp ldap accesskey enable minio/ mykey
+
+Global Flags
+~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-globals
+   :end-before: end-minio-mc-globals
+
+
+Behavior
+--------
+
+S3 Compatibility
+~~~~~~~~~~~~~~~~
+
+.. include:: /includes/common-minio-mc.rst
+   :start-after: start-minio-mc-s3-compatibility
+   :end-before: end-minio-mc-s3-compatibility

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey.rst
@@ -43,6 +43,26 @@ The :mc-cmd:`mc idp ldap accesskey` command has the following subcommands:
           :start-after: start-mc-idp-ldap-accesskey-create-desc
           :end-before: end-mc-idp-ldap-accesskey-create-desc
 
+   * - :mc-cmd:`mc idp ldap accesskey disable`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-disable.rst
+          :start-after: start-mc-idp-ldap-accesskey-disable-desc
+          :end-before: end-mc-idp-ldap-accesskey-disable-desc
+
+   * - :mc-cmd:`mc idp ldap accesskey edit`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-edit.rst
+          :start-after: start-mc-idp-ldap-accesskey-edit-desc
+          :end-before: end-mc-idp-ldap-accesskey-edit-desc
+
+   * - :mc-cmd:`mc idp ldap accesskey enable`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-enable.rst
+          :start-after: start-mc-idp-ldap-accesskey-enable-desc
+          :end-before: end-mc-idp-ldap-accesskey-enable-desc
+
+   * - :mc-cmd:`mc idp ldap accesskey info`
+     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-info.rst
+          :start-after: start-mc-idp-ldap-accesskey-info-desc
+          :end-before: end-mc-idp-ldap-accesskey-info-desc
+
    * - :mc-cmd:`mc idp ldap accesskey ls`
      - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-ls.rst
           :start-after: start-mc-idp-ldap-accesskey-ls-desc
@@ -53,15 +73,13 @@ The :mc-cmd:`mc idp ldap accesskey` command has the following subcommands:
           :start-after: start-mc-idp-ldap-accesskey-rm-desc
           :end-before: end-mc-idp-ldap-accesskey-rm-desc
 
-   * - :mc-cmd:`mc idp ldap accesskey info`
-     - .. include:: /reference/minio-mc/mc-idp-ldap-accesskey-info.rst
-          :start-after: start-mc-idp-ldap-accesskey-info-desc
-          :end-before: end-mc-idp-ldap-accesskey-info-desc
-
 .. toctree::
    :titlesonly:
    :hidden:
 
+   /reference/minio-mc/mc-idp-ldap-accesskey-disable
+   /reference/minio-mc/mc-idp-ldap-accesskey-edit
+   /reference/minio-mc/mc-idp-ldap-accesskey-enable
+   /reference/minio-mc/mc-idp-ldap-accesskey-info
    /reference/minio-mc/mc-idp-ldap-accesskey-ls
    /reference/minio-mc/mc-idp-ldap-accesskey-rm
-   /reference/minio-mc/mc-idp-ldap-accesskey-info

--- a/source/reference/minio-server/settings/notifications/webhook-service.rst
+++ b/source/reference/minio-server/settings/notifications/webhook-service.rst
@@ -272,6 +272,47 @@ Client Key
 
 Specify the path to the client private key to use for performing mTLS authentication to the webhook service.
 
+MaxRetry
+~~~~~~~~
+
+*Optional*
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_NOTIFY_WEBHOOK_MAX_RETRY
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: notify_webhook max_retry
+         :delimiter: " "
+
+Maximum number of attempts to retry an event send.
+
+RetryInterval
+~~~~~~~~~~~~~
+
+*Optional*
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_NOTIFY_WEBHOOK_RETRY_INTERVAL
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: notify_webhook retry_interval
+         :delimiter: " "
+
+Length of time to wait between retry attempts.
+The default value is ``3s``.
+
 Comment
 ~~~~~~~
 

--- a/source/reference/minio-server/settings/notifications/webhook-service.rst
+++ b/source/reference/minio-server/settings/notifications/webhook-service.rst
@@ -291,6 +291,7 @@ MaxRetry
          :delimiter: " "
 
 Maximum number of attempts to retry an event send.
+By default, the max number of retries is set to ``0``.
 
 RetryInterval
 ~~~~~~~~~~~~~


### PR DESCRIPTION
- adds new config options for webhook events
- adds new subcommands to mc idp ldap accesskey
- adds info about new output during iam import

Closes #1316

Staged:
- [Webhook configs](http://192.241.195.202:9000/staging/2024-09-09/linux/reference/minio-server/settings/notifications/webhook-service.html#maxretry)
- [mc idp ldap accesskey](http://192.241.195.202:9000/staging/2024-09-09/linux/reference/minio-mc/mc-idp-ldap-accesskey.html)
- [mc admin cluster iam import](http://192.241.195.202:9000/staging/2024-09-09/linux/reference/minio-mc-admin/mc-admin-cluster-iam-import.html)