### PR TITLE
Fix for bucket event limits

### DIFF
--- a/source/administration/monitoring/bucket-notifications.rst
+++ b/source/administration/monitoring/bucket-notifications.rst
@@ -100,11 +100,15 @@ To enable synchronous bucket notifications for *all configured remote targets*, 
 
 .. note::
 
-   MinIO maintains a per-remote queue of events (``10000`` by default) where it stores unsent and pending events.
+   For synchronous and asynchronous events, MinIO maintains a per-remote queue where it stores unsent and pending events.
+   The queue limit defaults to ``100000``.
 
-   For asynchronous or synchronous bucket notifications, MinIO discards new events if the queue fills.
+   MinIO discards new events if the queue fills with unsent messages.
+
    You can increase the queue size as necessary to better accommodate the rate of event send and processing of the MinIO deployment and remote target.
+   Use the ``QUEUE_LIMIT`` environment variable or configuration setting for your notification method to modify this limit.
 
+   For asynchronous events, MinIO allows a maximum of ``50000`` concurrent ``send`` calls.
 
 .. _minio-bucket-notifications-event-types:
 

--- a/source/administration/monitoring/bucket-notifications.rst
+++ b/source/administration/monitoring/bucket-notifications.rst
@@ -103,7 +103,7 @@ To enable synchronous bucket notifications for *all configured remote targets*, 
    For synchronous and asynchronous events, MinIO maintains a per-remote queue where it stores unsent and pending events.
    The queue limit defaults to ``100000``.
 
-   MinIO discards new events if the queue fills with unsent messages.
+   MinIO discards new events when the queue is full.
 
    You can increase the queue size as necessary to better accommodate the rate of event send and processing of the MinIO deployment and remote target.
    Use the ``QUEUE_LIMIT`` environment variable or configuration setting for your notification method to modify this limit.

--- a/source/url-excludes.yaml
+++ b/source/url-excludes.yaml
@@ -12,7 +12,9 @@ excludes:
 - 'operations/install-deploy-manage/deploy-minio-tenant-helm.rst'
 - 'operations/install-deploy-manage/deploy-operator-kustomize.rst'
 - 'operations/deploy-manage-tenants.rst'
-- `operations/cert-manager.rst`
+- 'operations/cert-manager.rst'
+- 'operations/cert-manager/cert-manager-operator.rst'
+- 'operations/cert-manager/cert-manager-tenants.rst'
 - 'developers/sts-for-operator.rst'
 - 'reference/kubectl-minio-plugin.rst'
 - 'reference/kubectl-minio-plugin/kubectl-minio-delete.rst'
@@ -49,7 +51,9 @@ excludes:
 - 'operations/install-deploy-manage/deploy-minio-tenant-helm.rst'
 - 'operations/install-deploy-manage/deploy-operator-kustomize.rst'
 - 'operations/deploy-manage-tenants.rst'
-- `operations/cert-manager.rst`
+- 'operations/cert-manager.rst'
+- 'operations/cert-manager/cert-manager-operator.rst'
+- 'operations/cert-manager/cert-manager-tenants.rst'
 - 'reference/kubectl-minio-plugin*'
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
@@ -84,7 +88,9 @@ excludes:
 - 'operations/install-deploy-manage/deploy-minio-tenant-helm.rst'
 - 'operations/install-deploy-manage/deploy-operator-kustomize.rst'
 - 'operations/deploy-manage-tenants.rst'
-- `operations/cert-manager.rst`
+- 'operations/cert-manager.rst'
+- 'operations/cert-manager/cert-manager-operator.rst'
+- 'operations/cert-manager/cert-manager-tenants.rst'
 - 'reference/kubectl-minio-plugin*'
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
@@ -113,7 +119,9 @@ excludes:
 - 'operations/install-deploy-manage/decommission-server-pool.rst'
 - 'operations/install-deploy-manage/expand-minio-deployment.rst'
 - 'operations/deploy-manage-tenants.rst'
-- `operations/cert-manager.rst`
+- 'operations/cert-manager.rst'
+- 'operations/cert-manager/cert-manager-operator.rst'
+- 'operations/cert-manager/cert-manager-tenants.rst'
 - 'operations/install-deploy-manage/deploy-minio-tenant-helm.rst'
 - 'operations/install-deploy-manage/deploy-operator-kustomize.rst'
 - 'reference/kubectl-minio-plugin*'

--- a/source/url-excludes.yaml
+++ b/source/url-excludes.yaml
@@ -12,6 +12,7 @@ excludes:
 - 'operations/install-deploy-manage/deploy-minio-tenant-helm.rst'
 - 'operations/install-deploy-manage/deploy-operator-kustomize.rst'
 - 'operations/deploy-manage-tenants.rst'
+- `operations/cert-manager.rst`
 - 'developers/sts-for-operator.rst'
 - 'reference/kubectl-minio-plugin.rst'
 - 'reference/kubectl-minio-plugin/kubectl-minio-delete.rst'
@@ -48,6 +49,7 @@ excludes:
 - 'operations/install-deploy-manage/deploy-minio-tenant-helm.rst'
 - 'operations/install-deploy-manage/deploy-operator-kustomize.rst'
 - 'operations/deploy-manage-tenants.rst'
+- `operations/cert-manager.rst`
 - 'reference/kubectl-minio-plugin*'
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
@@ -82,6 +84,7 @@ excludes:
 - 'operations/install-deploy-manage/deploy-minio-tenant-helm.rst'
 - 'operations/install-deploy-manage/deploy-operator-kustomize.rst'
 - 'operations/deploy-manage-tenants.rst'
+- `operations/cert-manager.rst`
 - 'reference/kubectl-minio-plugin*'
 - 'reference/minio-server*'
 - 'reference/minio-mc*'
@@ -110,6 +113,7 @@ excludes:
 - 'operations/install-deploy-manage/decommission-server-pool.rst'
 - 'operations/install-deploy-manage/expand-minio-deployment.rst'
 - 'operations/deploy-manage-tenants.rst'
+- `operations/cert-manager.rst`
 - 'operations/install-deploy-manage/deploy-minio-tenant-helm.rst'
 - 'operations/install-deploy-manage/deploy-operator-kustomize.rst'
 - 'reference/kubectl-minio-plugin*'


### PR DESCRIPTION
- Updates information on limits related to events.
- Adds cert-manager pages to URL-excludes file for non-k8s builds

Closes #1313

Staged:
- [bucket notifications, see blue note section](http://192.241.195.202:9000/staging/docs-1313/linux/administration/monitoring/bucket-notifications.html#asynchronous-vs-synchronous-bucket-notifications)