### PR TITLE
Updates for mc RELEASE.2024-10-02T08-27-28Z

### DIFF
--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -19,9 +19,13 @@ The :mc-cmd:`mc admin heal` command scans for objects that are damaged or corrup
 
 .. end-mc-admin-heal-desc
 
-:mc-cmd:`mc admin heal` is resource intensive and typically not required even after drive failures or corruption events. 
-Instead, MinIO automatically heals objects damaged by silent bit rot corruption, drive failure, or other issues on ``POST`` or ``GET``. 
-MinIO also performs periodic background object healing using the :ref:`scanner <minio-concepts-scanner>`.
+:mc-cmd:`mc admin heal` is resource intensive and typically not required as a manual process, even after drive failures or corruption events. 
+
+As a part of normal operations, MinIO:
+
+- automatically heals objects damaged by silent bit rot corruption, drive failure, or other issues on each ``POST`` or ``GET`` operation. 
+- performs periodic background object healing using the :ref:`scanner <minio-concepts-scanner>`.
+- aggressively heals objects after drive replacement.
 
 Refer to :ref:`minio-concepts-healing` for more details on how MinIO heals objects.
 

--- a/source/reference/minio-mc-admin/mc-admin-heal.rst
+++ b/source/reference/minio-mc-admin/mc-admin-heal.rst
@@ -15,15 +15,13 @@ Description
 
 .. start-mc-admin-heal-desc
 
-The :mc-cmd:`mc admin heal` command scans for objects that are damaged or
-corrupted and heals those objects.  
+The :mc-cmd:`mc admin heal` command scans for objects that are damaged or corrupted and heals those objects.  
 
 .. end-mc-admin-heal-desc
 
-:mc-cmd:`mc admin heal` is resource intensive and typically not required even
-after drive failures or corruption events. Instead, MinIO automatically heals
-objects damaged by silent bit rot corruption, drive failure, or other issues on
-``POST`` or ``GET``. MinIO also performs periodic background object healing using the :ref:`scanner <minio-concepts-scanner>`.
+:mc-cmd:`mc admin heal` is resource intensive and typically not required even after drive failures or corruption events. 
+Instead, MinIO automatically heals objects damaged by silent bit rot corruption, drive failure, or other issues on ``POST`` or ``GET``. 
+MinIO also performs periodic background object healing using the :ref:`scanner <minio-concepts-scanner>`.
 
 Refer to :ref:`minio-concepts-healing` for more details on how MinIO heals objects.
 
@@ -42,25 +40,41 @@ Syntax
 .. code-block:: shell
    :class: copyable
 
-   mc admin heal [FLAGS] TARGET
+   mc admin heal [FLAGS] TARGET             \
+                         [--all-drives, -a] \
+                         [--force]          \
+                         [--verbose, -v]
 
-:mc-cmd:`mc admin heal` supports the following argument:
+:mc-cmd:`mc admin heal` supports the following arguments:
 
 .. mc-cmd:: TARGET
+   :required:
 
-   *Required*
-
-   The full path to the bucket or bucket prefix on which the command should
-   perform object healing. Specify the :mc-cmd:`alias <mc alias>` of a
-   configured MinIO deployment as the prefix for the path. For example:
+   The full path to the bucket or bucket prefix on which the command should perform object healing. 
+   Specify the :mc-cmd:`alias <mc alias>` of a configured MinIO deployment as the prefix for the path. 
+   For example:
 
    .. code-block:: shell
       :class: copyable
 
       mc admin heal play/mybucket/myprefix
 
-   If the ``TARGET`` bucket or bucket prefix has an active healing scan,
-   the command returns the status of that scan.
+   If the ``TARGET`` bucket or bucket prefix has an active healing scan, the command returns the status of that scan.
+
+.. mc-cmd:: --all-drives, -a
+   :optional:
+
+   Select all drives and show verbose information.
+
+.. mc-cmd:: --force
+   :optional:
+
+   Disables warning prompts.
+
+.. mc-cmd:: --verbose, -v
+   :optional:
+
+   Show information about offline and faulty healing drives.
 
 
 Healing Colors

--- a/source/reference/minio-mc/mc-cp.rst
+++ b/source/reference/minio-mc/mc-cp.rst
@@ -142,6 +142,22 @@ Parameters
    Specify key-value pairs as ``KEY=VALUE\;``. 
    For example, ``--attr key1=value1\;key2=value2\;key3=value3``.
 
+.. mc-cmd:: --checksum
+   :optional:
+
+   .. versionadded:: RELEASE.2024-10-02T08-27-28Z
+
+   Add a checksum to an uploaded object. 
+   
+   Valid values are: 
+   - ``MD5``
+   - ``CRC32``
+   - ``CRC32C``
+   - ``SHA1``
+   - ``SHA256``
+
+   The flag requires server trailing headers and works with AWS or MinIO targets.
+
 .. mc-cmd:: --disable-multipart
    :optional:
 
@@ -166,6 +182,10 @@ Parameters
 
 .. mc-cmd:: --md5
    :optional:
+
+   .. versionchanged:: RELEASE.2024-10-02T08-27-28Z
+
+      Replaced by the :mc-cmd:`~mc cp --checksum` flag.
 
    Forces all uploads to calculate MD5 checksums. 
 

--- a/source/reference/minio-mc/mc-mirror.rst
+++ b/source/reference/minio-mc/mc-mirror.rst
@@ -52,6 +52,7 @@ The :mc:`mc mirror` command synchronizes content to MinIO deployment, similar to
          mc [GLOBALFLAGS] mirror                            \
                           [--active-active]                 \
                           [--attr "string"]                 \
+                          [--checksum "value"]              \
                           [--disable-multipart]             \
                           [--dry-run]                       \
                           [--enc-kms "string"]              \
@@ -150,6 +151,22 @@ Parameters
 
    Add custom metadata for mirrored objects. Specify key-value pairs as ``KEY=VALUE\;``. 
    For example, ``--attr key1=value1\;key2=value2\;key3=value3``.
+
+.. mc-cmd:: --checksum
+   :optional:
+
+   .. versionadded:: RELEASE.2024-10-02T08-27-28Z
+
+   Add a checksum to an uploaded object. 
+   
+   Valid values are: 
+   - ``MD5``
+   - ``CRC32``
+   - ``CRC32C``
+   - ``SHA1``
+   - ``SHA256``
+
+   The flag requires server trailing headers and works with AWS or MinIO targets.
 
 .. mc-cmd:: --disable-multipart
    :optional:

--- a/source/reference/minio-mc/mc-pipe.rst
+++ b/source/reference/minio-mc/mc-pipe.rst
@@ -39,12 +39,13 @@ The :mc:`mc pipe` command streams content from `STDIN <https://www.gnu.org/softw
 
          mc [GLOBALFLAGS] pipe                              \
                           TARGET                            \
+                          [--attr "string"]                 \
+                          [--checksum "string"]             \
                           [--enc-kms "string"]              \
                           [--enc-s3 "string"]               \
                           [--enc-c "string"]                \
                           [--storage-class, --sc "string"]  \
-                          [--attr "string"]                 \
-                          [--tags "string"]                 \
+                          [--tags "string"] 
 
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
@@ -69,6 +70,22 @@ Parameters
 
    Specify key-value pairs as ``KEY=VALUE\;``, separating each pair with a back slash and semicolon (``\;``). 
    For example, ``--attr key1=value1\;key2=value2\;key3=value3``.
+
+.. mc-cmd:: --checksum
+   :optional:
+
+   .. versionadded:: RELEASE.2024-10-02T08-27-28Z
+
+   Add a checksum to an uploaded object. 
+   
+   Valid values are: 
+   - ``MD5``
+   - ``CRC32``
+   - ``CRC32C``
+   - ``SHA1``
+   - ``SHA256``
+
+   The flag requires server trailing headers and works with AWS or MinIO targets.
 
 .. block include of enc-c , enc-s3, and enc-kms
 

--- a/source/reference/minio-mc/mc-put.rst
+++ b/source/reference/minio-mc/mc-put.rst
@@ -99,7 +99,7 @@ Parameters
 
    .. versionadded:: RELEASE.2024-10-02T08-27-28Z
    
-   Disables uploading using the multipart feature, instead putting the object in a single operation.
+   Disables multipart uploads and directs ``mc`` to send the object in a single ``PUT`` operation.
 
 .. block include of enc-c , enc-s3, and enc-kms
 

--- a/source/reference/minio-mc/mc-put.rst
+++ b/source/reference/minio-mc/mc-put.rst
@@ -46,6 +46,8 @@ The :mc:`mc put` uploads an object from the local file system to a bucket on a t
 
          mc [GLOBALFLAGS] put                      \
                           TARGET                   \
+                          [--checksum value]       \
+                          [--disable-multipart]    \
                           [--enc-kms value]        \
                           [--enc-s3 value]         \
                           [--enc-c value]          \
@@ -75,6 +77,29 @@ Parameters
    - ``ALIAS/BUCKET/PREFIX``
    - ``ALIAS/BUCKET/OBJECT-NAME``
    - ``ALIAS/BUCKET/PREFIX/OBJECT-NAME``
+
+.. mc-cmd:: --checksum
+   :optional:
+
+   .. versionadded:: RELEASE.2024-10-02T08-27-28Z
+
+   Add a checksum to an uploaded object. 
+   
+   Valid values are: 
+   - ``MD5``
+   - ``CRC32``
+   - ``CRC32C``
+   - ``SHA1``
+   - ``SHA256``
+
+   The flag requires server trailing headers and works with AWS or MinIO targets.
+
+.. mc-cmd:: --disable-multipart
+   :optional:
+
+   .. versionadded:: RELEASE.2024-10-02T08-27-28Z
+   
+   Disables uploading using the multipart feature, instead putting the object in a single operation.
 
 .. block include of enc-c , enc-s3, and enc-kms
 

--- a/source/reference/minio-mc/mc-ready.rst
+++ b/source/reference/minio-mc/mc-ready.rst
@@ -23,27 +23,27 @@ The :mc:`mc ready` command checks the status of a cluster and whether the cluste
 
    .. tab-item:: EXAMPLE
 
-      The following sends a ``GET`` request to the cluster and returns its status.
+      The following sends a ``GET`` request to the cluster at alias ``myminio`` and returns its status.
 
       .. code-block:: shell
          :class: copyable
 
-         mc ready play
+         mc ready myminio
 
-      The command sends a ``GET`` request to the deployment at the :mc:`~mc alias` ``play``.'
+      The command sends a ``GET`` request to the deployment at the :mc:`~mc alias` ``myminio``.'
       The command repeats the request until it is successful.
 
-      The output before a cluster is ready resembles the following:
+      The output before the cluster at alias ``myminio`` is ready resembles the following:
 
-      .. code-block:: shell
+      .. code-block:: text
 
-         The cluster is unreachable: Get "http://play.min.io:9000/minio/health/cluster": dial tcp 127.0.0.1:9000: connect: connection refused
+         The cluster is `myminio` is unreachable: Get "http://myminio.example.com:9000/minio/health/cluster": dial tcp 198.51.100.0:9000: connect: connection refused
 
-      Once the request succeeds, the output resembles the following:
+      Once the request succeeds in connecting to the ``myminio`` deployment, the output resembles the following:
      
-      .. code-block:: shell
+      .. code-block:: text
 
-         The cluster is ready
+         The cluster `myminio` is ready
 
    .. tab-item:: SYNTAX
 

--- a/source/reference/minio-mc/mc-ready.rst
+++ b/source/reference/minio-mc/mc-ready.rst
@@ -37,7 +37,7 @@ The :mc:`mc ready` command checks the status of a cluster and whether the cluste
 
       .. code-block:: text
 
-         The cluster is `myminio` is unreachable: Get "http://myminio.example.com:9000/minio/health/cluster": dial tcp 198.51.100.0:9000: connect: connection refused
+         The cluster `myminio` is unreachable: Get "http://myminio.example.com:9000/minio/health/cluster": dial tcp 198.51.100.0:9000: connect: connection refused
 
       Once the request succeeds in connecting to the ``myminio`` deployment, the output resembles the following:
      

--- a/source/reference/minio-mc/mc-stat.rst
+++ b/source/reference/minio-mc/mc-stat.rst
@@ -26,7 +26,7 @@ You can also use it to retrieve bucket metadata.
 
 .. end-mc-stat-desc
 
-You can also use :mc:`mc stat` against the local filesystem to produce similar results to the ``stat`` commandline tool.
+You can use :mc:`mc stat` against the local filesystem to produce similar results to the ``stat`` commandline tool.
 
 .. tab-set::
 


### PR DESCRIPTION
- Adds a `--checksum` flag to `mc cp`, `mc mirror`, `mc pipe`, and `mc put`
- Adds `--disable-multipart` to `mc put`
- Adds alias name to outputs of `mc ready`
- Adds flags to `mc admin heal`

Closes #1334

Staged:

- [mc cp](http://192.241.195.202:9000/staging/docs-1334/linux/reference/minio-mc/mc-cp.html#mc.cp.-checksum)
- [mc mirror](http://192.241.195.202:9000/staging/docs-1334/linux/reference/minio-mc/mc-mirror.html#mc.mirror.-checksum)
- [mc pipe](http://192.241.195.202:9000/staging/docs-1334/linux/reference/minio-mc/mc-pipe.html#mc.pipe.-checksum)
- [mc put](http://192.241.195.202:9000/staging/docs-1334/linux/reference/minio-mc/mc-put.html#mc.put.-checksum)
- [mc ready](http://192.241.195.202:9000/staging/docs-1334/linux/reference/minio-mc/mc-ready.html)
- [mc admin heal](http://192.241.195.202:9000/staging/docs-1334/linux/reference/minio-mc-admin/mc-admin-heal.html#mc.admin.heal.-all-drives)