### PR TITLE
Fix non .docutils table styles

### DIFF
--- a/source/_static/scss/includes/_misc.scss
+++ b/source/_static/scss/includes/_misc.scss
@@ -371,16 +371,6 @@ figcaption {
    }
 }
 
-
-// ---------------------------------------
-// Fixing table issues from asciidoc -> md
-// ---------------------------------------
-
-table thead tr.header {
-   background-color: lightgray;
-   box-shadow: none;
-}
-
 // --------------------------------------
 // Improving readability of ordered lists
 // --------------------------------------

--- a/source/_static/scss/includes/_reset.scss
+++ b/source/_static/scss/includes/_reset.scss
@@ -223,9 +223,11 @@ table {
 // ----------------------
 table,
 table.docutils {
+    all: revert;
     box-shadow: none;
     margin: 1rem 0 2rem;
     width: 100%;
+    border-collapse: collapse;
 
     & > thead {
         tr.header {
@@ -236,7 +238,7 @@ table.docutils {
 
     td,
     th {
-        border-color: var(--table-border-color);
+        border: 1px solid var(--table-border-color);
         padding: 0.75rem 1rem;
         line-height: 1.5;
         vertical-align: top;
@@ -248,6 +250,7 @@ table.docutils {
         font-weight: $font-weight-medium;
         color: var(--headings-color);
         font-size: $font-size-sm;
+        background-color: var(--table-th-bg);
     }
 
     caption {
@@ -275,24 +278,26 @@ table.docutils {
 
         tr {
             &:first-child {
-                th {
-                    border-top-color: transparent;
+                th,
+                th.stub ~ td {
+                    border-top-width: 0;
                 }
             }
 
             &:last-child {
+                th,
                 td {
-                    border-bottom-color: transparent;
+                    border-bottom-width: 0;
                 }
             }
 
             td, th {
                 &:first-child {
-                    border-left-color: transparent;
+                    border-left-width: 0;
                 }
 
                 &:last-child {
-                    border-right-color: transparent;
+                    border-right-width: 0;
                 }
             }
         }

--- a/source/_static/scss/includes/_reset.scss
+++ b/source/_static/scss/includes/_reset.scss
@@ -221,10 +221,18 @@ table {
 // ----------------------
 // Table
 // ----------------------
+table,
 table.docutils {
     box-shadow: none;
     margin: 1rem 0 2rem;
     width: 100%;
+
+    & > thead {
+        tr.header {
+            background: transparent;
+            box-shadow: none;
+        }
+    }
 
     td,
     th {
@@ -233,6 +241,7 @@ table.docutils {
         line-height: 1.5;
         vertical-align: top;
         text-align: left;
+        background: transparent;
     }
 
     th {

--- a/source/_static/scss/includes/_theme.scss
+++ b/source/_static/scss/includes/_theme.scss
@@ -60,6 +60,7 @@ $theme-properties: (
 
     // Table
     --table-border-color: $light-300 $dark-200,
+    --table-th-bg: $light-100 darken($dark-200, 5%),
 
     // Code
     --code-bg: $light-200 lighten($dark-500, 17.5%),


### PR DESCRIPTION
As @pavelanni pointed out, some tables, like the ones shown below, had broken styling that didn't align with the [design specs](https://min.io/docs/minio/kubernetes/upstream/design.html#list-table). This PR resolves the issue by applying the correct styles to ensure consistency with the overall design guidelines.

**Issue:** 

https://min.io/docs/minio/kubernetes/upstream/reference/operator-crd.html#customcertificateconfig

<img width="783" alt="Screenshot 2024-10-08 at 14 26 17" src="https://github.com/user-attachments/assets/cdb8ff3e-2ace-4bf4-9b43-6dceccb0d2ae">


**Fix:**
<img width="783" alt="Screenshot 2024-10-08 at 15 19 20" src="https://github.com/user-attachments/assets/6306cdd7-7d19-4452-a109-03328b43128d">

