### PR TITLE
Updates mc event rm for mismatched event error

### DIFF
--- a/source/reference/minio-mc/mc-event-add.rst
+++ b/source/reference/minio-mc/mc-event-add.rst
@@ -65,8 +65,9 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The MinIO :ref:`alias <alias>` and bucket to
+   The MinIO :ref:`alias <alias>` and bucket to
    which the command adds the new event notification. For example:
 
    .. code-block:: shell
@@ -74,19 +75,17 @@ Parameters
       mc event add play/mybucket
 
 .. mc-cmd:: ARN
+   :required:
 
-   *Required* The :aws-docs:`Amazon Resource Name (ARN)
-   <IAM/latest/UserGuide/reference-arns>` of the notification target.
+   The :aws-docs:`Amazon Resource Name (ARN) <IAM/latest/UserGuide/reference-arns>` of the notification target.
 
-   The MinIO server outputs an ARN for each configured
-   notification target at server startup. See
-   :ref:`Bucket Notifications <minio-bucket-notifications>` for more
-   information.
+   The MinIO server outputs an ARN for each configured notification target at server startup. 
+   See :ref:`Bucket Notifications <minio-bucket-notifications>` for more information.
 
 .. mc-cmd:: --event
+   :optional:
 
-
-   *Optional* The event(s) for which MinIO generates bucket notifications.
+   The event(s) for which MinIO generates bucket notifications.
 
    Supports the following values:
 
@@ -96,38 +95,30 @@ Parameters
 
    Specify multiple value using a comma ``,`` delimiter.
 
-   Defaults to ``put,delete,get``.
+   If note specified, defaults to ``put,delete,get``.
 
-   See :ref:`mc-event-supported-events` for a detailed list of S3 events
-   associated to each of the supported values.
+   See :ref:`mc-event-supported-events` for a detailed list of S3 events associated to each of the supported values.
 
 .. mc-cmd:: ignore-existing, p
+   :optional:
 
-
-   *Optional* Directs MinIO to ignore applying the specified event
-   triggers if an existing matching trigger exists.
+   Directs MinIO to ignore applying the specified event triggers if an existing matching trigger exists.
 
 .. mc-cmd:: --prefix
+   :optional:
 
+   The bucket prefix in which the specified :mc-cmd:`~mc event add --event` can trigger a bucket notification.
 
-   *Optional* The bucket prefix in which the specified
-   :mc-cmd:`~mc event add --event` can trigger a bucket notification.
-
-   For example, given a :mc-cmd:`~mc event add ALIAS` of ``play/mybucket``
-   and a :mc-cmd:`~mc event add --prefix` of ``photos``, only events in
-   ``play/mybucket/photos`` trigger bucket notifications.
+   For example, given a :mc-cmd:`~mc event add ALIAS` of ``play/mybucket`` and a :mc-cmd:`~mc event add --prefix` of ``photos``, only events in ``play/mybucket/photos`` trigger bucket notifications.
 
    Omit to trigger the event for all prefixes and objects in the bucket.
 
 .. mc-cmd:: --suffix
+   :optional:
 
+   The bucket suffix in which the specified :mc-cmd:`~mc event add --event` can trigger a bucket notification.
 
-   *Optional* The bucket suffix in which the specified
-   :mc-cmd:`~mc event add --event` can trigger a bucket notification.
-
-   For example, given a :mc-cmd:`~mc event add ALIAS` of ``play/mybucket``
-   and a :mc-cmd:`~mc event add --suffix` of ``.jpg``, only events in
-   ``play/mybucket/*.jpg`` trigger bucket notifications.
+   For example, given a :mc-cmd:`~mc event add ALIAS` of ``play/mybucket`` and a :mc-cmd:`~mc event add --suffix` of ``.jpg``, only events in ``play/mybucket/*.jpg`` trigger bucket notifications.
 
    Omit to trigger the event for all objects regardless of suffix.
 

--- a/source/reference/minio-mc/mc-event-add.rst
+++ b/source/reference/minio-mc/mc-event-add.rst
@@ -67,8 +67,8 @@ Parameters
 .. mc-cmd:: ALIAS
    :required:
 
-   The MinIO :ref:`alias <alias>` and bucket to
-   which the command adds the new event notification. For example:
+   The MinIO :ref:`alias <alias>` and bucket to which the command adds the new event notification. 
+   For example:
 
    .. code-block:: shell
 
@@ -94,15 +94,16 @@ Parameters
    - ``delete``
 
    Specify multiple value using a comma ``,`` delimiter.
+   Do not add any whitespace between values.
 
-   If note specified, defaults to ``put,delete,get``.
+   If not specified, defaults to ``put,delete,get``.
 
    See :ref:`mc-event-supported-events` for a detailed list of S3 events associated to each of the supported values.
 
 .. mc-cmd:: ignore-existing, p
    :optional:
 
-   Directs MinIO to ignore applying the specified event triggers if an existing matching trigger exists.
+   Directs MinIO to ignore the specified event triggers if a matching trigger already exists.
 
 .. mc-cmd:: --prefix
    :optional:

--- a/source/reference/minio-mc/mc-event-list.rst
+++ b/source/reference/minio-mc/mc-event-list.rst
@@ -67,14 +67,14 @@ Parameters
 
    .. code-block:: shell
 
-      mc event add play/mybucket
+      mc event ls play/mybucket ARN...
 
 .. mc-cmd:: ARN
    :required:
 
    The :aws-docs:`Amazon Resource Name (ARN) <IAM/latest/UserGuide/reference-arns>` of the bucket resource.
 
-   The MinIO server outputs an ARN for each configured notification target at server startup. 
+   The MinIO server outputs an ARN at startup for each configured notification target. 
    See :ref:`Bucket Notifications <minio-bucket-notifications>` for more information.
 
 

--- a/source/reference/minio-mc/mc-event-list.rst
+++ b/source/reference/minio-mc/mc-event-list.rst
@@ -60,25 +60,22 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The S3 service :ref:`alias <alias>` and bucket to
-   which the command lists event notification. For example:
+   The S3 service :ref:`alias <alias>` and bucket to which the command lists event notification. 
+   For example:
 
    .. code-block:: shell
 
       mc event add play/mybucket
 
 .. mc-cmd:: ARN
+   :required:
 
-   *Required* The :aws-docs:`Amazon Resource Name (ARN)
-   <IAM/latest/UserGuide/reference-arns>` of the bucket resource.
+   The :aws-docs:`Amazon Resource Name (ARN) <IAM/latest/UserGuide/reference-arns>` of the bucket resource.
 
-   The MinIO server outputs an ARN for each configured notification target at
-   server startup. See
-   :ref:`Bucket Notifications <minio-bucket-notifications>` for more
-   information.
-
-
+   The MinIO server outputs an ARN for each configured notification target at server startup. 
+   See :ref:`Bucket Notifications <minio-bucket-notifications>` for more information.
 
 
 Global Flags

--- a/source/reference/minio-mc/mc-event-remove.rst
+++ b/source/reference/minio-mc/mc-event-remove.rst
@@ -79,7 +79,7 @@ Parameters
 
    The :aws-docs:`Amazon Resource Name (ARN) <IAM/latest/UserGuide/reference-arns>` of the notification target.
 
-   The MinIO server outputs an ARN for each configured notification target at server startup. 
+   The MinIO server outputs an ARN at startup for each configured notification target. 
    See :ref:`minio-bucket-notifications` for more information.
 
    Retrieve the ARN by running :mc:`mc event ls` on the bucket.
@@ -87,7 +87,7 @@ Parameters
 .. mc-cmd:: --event
    :optional:
 
-   The event type(s) specified when adding the event. 
+   The event type(s) specified when the event was added. 
    The entries **must** match the values used when adding the event.
    If no event matches the list of event types, the command returns a ``no notification configuration matched`` error.
 

--- a/source/reference/minio-mc/mc-event-remove.rst
+++ b/source/reference/minio-mc/mc-event-remove.rst
@@ -89,9 +89,10 @@ Parameters
 
    The event type(s) specified when adding the event. 
    The entries **must** match the values used when adding the event.
+   If no event matches the list of event types, the command returns a ``no notification configuration matched`` error.
 
    Specify multiple events using a comma ``,`` delimiter. 
-   See :ref:`mc-event-supported-events` for supported events.
+   See :ref:`mc-event-supported-events` for supported event types.
 
    Defaults to removing an event that triggers for all event types on the :mc-cmd:`~mc event rm ALIAS` bucket with the :mc-cmd:`~mc event rm ARN` notification target.
 

--- a/source/reference/minio-mc/mc-event-remove.rst
+++ b/source/reference/minio-mc/mc-event-remove.rst
@@ -18,8 +18,7 @@ Syntax
 
 .. start-mc-event-remove-desc
 
-The :mc:`mc event rm` command removes event notification triggers on a
-bucket.
+The :mc:`mc event rm` command removes an event notification trigger from a bucket.
 
 .. end-mc-event-remove-desc
 
@@ -46,12 +45,12 @@ The :mc:`mc event remove` command has equivalent functionality to :mc:`mc event 
          :class: copyable
 
          mc [GLOBALFLAGS] event remove        \
+                          ALIAS               \
+                          [ARN]               \
                           [--event "string"]  \
                           [--force]           \
                           [--prefix "string"] \
-                          [--suffix "string"] \
-                          ALIAS               \
-                          [ARN]
+                          [--suffix "string"]
 
       .. include:: /includes/common-minio-mc.rst
          :start-after: start-minio-syntax
@@ -66,44 +65,80 @@ Parameters
 ~~~~~~~~~~
 
 .. mc-cmd:: ALIAS
+   :required:
 
-   *Required* The S3 service :ref:`alias <alias>` and bucket from
-   which the command removes the event notification. For example:
+   The S3 service :ref:`alias <alias>` and bucket from which the command removes the event notification. 
+   For example:
 
    .. code-block:: shell
 
       mc event add play/mybucket
 
 .. mc-cmd:: ARN
+   :required:
 
-   *Required* The :aws-docs:`Amazon Resource Name (ARN)
-   <IAM/latest/UserGuide/reference-arns>` of the notification target.
+   The :aws-docs:`Amazon Resource Name (ARN) <IAM/latest/UserGuide/reference-arns>` of the notification target.
 
-   The MinIO server outputs an ARN for each configured
-   notification target at server startup. See
-   :ref:`minio-bucket-notifications` for more
-   information.
+   The MinIO server outputs an ARN for each configured notification target at server startup. 
+   See :ref:`minio-bucket-notifications` for more information.
+
+   Retrieve the ARN by running :mc:`mc event ls` on the bucket.
 
 .. mc-cmd:: --event
+   :optional:
 
+   The event type(s) specified when adding the event. 
+   The entries **must** match the values used when adding the event.
 
-   *Optional* The event(s) to remove. Specify multiple events using a comma
-   ``,`` delimiter. See :ref:`mc-event-supported-events` for supported events.
+   Specify multiple events using a comma ``,`` delimiter. 
+   See :ref:`mc-event-supported-events` for supported events.
 
-   Defaults to removing all events on the :mc-cmd:`~mc event rm ALIAS`
-   bucket with the :mc-cmd:`~mc event rm ARN` notification target.
+   Defaults to removing an event that triggers for all event types on the :mc-cmd:`~mc event rm ALIAS` bucket with the :mc-cmd:`~mc event rm ARN` notification target.
+
+   Retrieve the event types used by running :mc:`mc event ls` on the bucket.
+   Use the following table to convert event types in the command's output to the entry required for the :mc:`mc event rm` command:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 50 50
+      :width: 100%
+   
+      * - Output of ``mv event ls``
+        - Event type to use
+   
+      * - ``s3:objectAccessed``
+        - ``get``
+   
+      * - ``s3:objectCreated``
+        - ``put``
+   
+      * - ``s3:objectRemoved``
+        - ``delete``
+   
+   For example, if the ``mc event ls`` returns the following:
+
+   .. code-block:: shell
+
+      arn:minio:sqs::mytest:webhook   s3:ObjectAccessed:*,s3:ObjectCreated:*   Filter: 
+      
+   Use the following command to remove the event:
+
+   .. code-block:: shell
+
+      mc event rm alias/bucket arn:minio:sqs::mytest:webhook --event get,put
+
+   The order of event types does not matter, only that you include the same ones that exist for the event.
+
 
 .. mc-cmd:: --force
+   :optional:
 
-
-   *Optional* Removes all events on the :mc-cmd:`~mc event rm ALIAS` bucket
-   with the :mc-cmd:`~mc event rm ARN` notification target.
+   Removes all events on the :mc-cmd:`~mc event rm ALIAS` bucket with the :mc-cmd:`~mc event rm ARN` notification target.
 
 .. mc-cmd:: --prefix
+   :optional:
 
-
-   *Optional* The bucket prefix in which the command removes bucket
-   notifications.
+   The bucket prefix in which the command removes bucket notifications.
 
    For example, given a :mc-cmd:`~mc event rm ALIAS` of
    ``play/mybucket`` and a :mc-cmd:`~mc event rm --prefix` of
@@ -111,10 +146,9 @@ Parameters
    ``play/mybucket/photos``.
 
 .. mc-cmd:: --suffix
+   :optional:
 
-
-   *Optional* The bucket suffix in which the command removes bucket
-   notifications.
+   The bucket suffix in which the command removes bucket notifications.
 
    For example, given a :mc-cmd:`~mc event rm ALIAS` of
    ``play/mybucket`` and a :mc-cmd:`~mc event rm --suffix` of

--- a/source/reference/minio-mc/mc-idp-ldap-accesskey-edit.rst
+++ b/source/reference/minio-mc/mc-idp-ldap-accesskey-edit.rst
@@ -21,7 +21,7 @@ Description
 
 :mc:`mc idp ldap accesskey edit` modifies the specified :ref:`access key <minio-id-access-keys>` on the local server.
 
-.. end-mc-idp-ldap-accesskey-rm-desc
+.. end-mc-idp-ldap-accesskey-edit-desc
 
 .. tab-set::
 


### PR DESCRIPTION
- Cleans up `mc event` command flags with optional/required labels. 
- Drive by fix for an `mc idp` command with an `end-before` include error.

Closes #1263

Staged:

- [mc event remove](http://192.241.195.202:9000/staging/events-1263/linux/reference/minio-mc/mc-event-remove.html)