### PR TITLE
Explain limitations with multi-part uploads, move other unsupported/limitations content

### DIFF
--- a/source/operations/concepts/thresholds.rst
+++ b/source/operations/concepts/thresholds.rst
@@ -94,19 +94,6 @@ Erasure Code Limits
    * - Write quorum
      - :math:`(N/2)+1`
 
-
-Unsupported S3 Bucket APIs
---------------------------
-
-MinIO does not support the following API calls available in S3.
-These APIs are either redundant or only provide functionality within AWS S3.
-
-- ``BucketACL``, ``ObjectACL`` (use :ref:`Policies <minio-policy>`)
-- ``BucketCORS`` (CORS enabled by default on all buckets for all HTTP verbs)
-- ``BucketWebsite`` (use ``caddy`` or ``nginx``)
-- ``BucketAnalytics``, ``BucketMetrics``, ``BucketLogging`` (use :ref:`Bucket Notifications <minio-bucket-notifications>`)
-- ``BucketRequestPayment``
-
 Object Name Limitations
 -----------------------
 
@@ -116,7 +103,7 @@ Filesystem and Operating System Restrictions
 Object Names in MinIO are restricted primarily by the local operating system and filesystem.
 Windows and some other operating systems restrict file systems with certain special characters, such as ``^``, ``*``, ``|``, ``\``, ``/``, ``&``, ``"``, or ``;``.
 
-The above list is not exhaustive and may not apply to your operating system and filesystem combination.
+This list is not exhaustive and may not apply to your operating system and filesystem combination.
 
 Consult your operating system vendor or filesystem documentation for a comprehensive list for your situation.
 

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -66,8 +66,8 @@ Multipart Uploads
 Differences from S3 APIs for Multipart Uploads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `ListMultipartUploads` requires exact object name as prefix
-- `AbortMultipartUpload` is not supported with `PutBucketLifecycle`
+- ``ListMultipartUploads`` requires exact object name as prefix
+- ``AbortMultipartUpload`` is not supported with ``PutBucketLifecycle``
 
 Bucket APIs
 -----------

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -66,8 +66,8 @@ Multipart Uploads
 Differences from S3 APIs for Multipart Uploads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``ListMultipartUploads`` requires exact object name as prefix
-- ``AbortMultipartUpload`` is not supported with ``PutBucketLifecycle``
+- ``ListMultipartUploads`` requires the exact object name as a prefix
+- The ``AbortIncompleteMultipartUpload`` lifecycle action is not supported with ``PutBucketLifecycle``
 
 Bucket APIs
 -----------

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -44,6 +44,14 @@ Object Locking
 - :s3-api:`GetObjectLockConfiguration <API_GetObjectLockConfiguration.html>`
 - :s3-api:`PutObjectLockConfiguration <API_PutObjectLockConfiguration.html>`
 
+Unsupported API Object Endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   GetObjectAcl
+   PutObjectAcl
+
 Multipart Uploads
 ~~~~~~~~~~~~~~~~~
 
@@ -55,13 +63,11 @@ Multipart Uploads
 - :s3-api:`UploadPart <API_UploadPart.html>`
 - :s3-api:`UploadPartCopy <API_UploadPartCopy.html>`
 
-Unsupported API Object Endpoints
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Differences from S3 APIs for Multipart Uploads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: text
-
-   GetObjectAcl
-   PutObjectAcl
+- `ListMultipartUploads` requires exact object name as prefix
+- `AbortMultipartUpload` is not supported with `PutBucketLifecycle`
 
 Bucket APIs
 -----------
@@ -114,8 +120,8 @@ Bucket Policies
 - :s3-api:`PutBucketPolicy <API_PutBucketPolicy.html>`
 - :s3-api:`DeleteBucketPolicy <API_DeleteBucketPolicy.html>`
 
-Unsupported API Bucket Endpoints
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Unsupported API Bucket Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
@@ -151,3 +157,11 @@ Unsupported API Bucket Endpoints
    ListBucketAnalyticsConfigurations
    DeleteBucketAnalyticsConfiguration
    CreateSession
+
+MinIO alternatives for unsupported Bucket resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- For calls to ``BucketACL`` or ``ObjectACL`` operations, use :ref:`Policies <minio-policy>`.
+- Calls to ``BucketCORS`` operations are not needed because CORS is enabled by default on all buckets for all HTTP verbs.
+- For calls to ``BucketWebsite`` operations, use ``caddy`` or ``nginx``.
+- For calls to ``BucketAnalytics``, ``BucketMetrics``, or ``BucketLogging`` operations, use :ref:`Bucket Notifications <minio-bucket-notifications>`.

--- a/source/reference/s3-api-compatibility.rst
+++ b/source/reference/s3-api-compatibility.rst
@@ -64,10 +64,10 @@ Multipart Uploads
 - :s3-api:`UploadPartCopy <API_UploadPartCopy.html>`
 
 Differences from S3 APIs for Multipart Uploads
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+++++++++++++++++++++++++++++++++++++++++++++++
 
-- ``ListMultipartUploads`` requires the exact object name as a prefix
-- The ``AbortIncompleteMultipartUpload`` lifecycle action is not supported with ``PutBucketLifecycle``
+- ``ListMultipartUploads`` requires the exact object name as a prefix.
+- The ``AbortIncompleteMultipartUpload`` lifecycle action is not supported with ``PutBucketLifecycle``.
 
 Bucket APIs
 -----------


### PR DESCRIPTION
- Explains requirements for `ListMultipartUploads`
- Notes that `AbortIncompleteMultipartUploads` is not supported with `PutBucketLifecycle`

This approach does not provide all the detail in the original ticket, because we don't do so for other operations/actions.

Also moved content about bucket operations limitations from thresholds and limits page to S3 compatibility page. Took some suggestions from discussion in ticket.

Closes #1216 

Staging:

[Differences from S3 APIs for Multipart Uploads](http://192.241.195.202:9000/staging/DOC-1216/linux/reference/s3-api-compatibility.html#id5)
[MinIO alternatives for unsupported Bucket resources](http://192.241.195.202:9000/staging/DOC-1216/linux/reference/s3-api-compatibility.html#id12)
To check that content is moved: [Thresholds and Limits](http://192.241.195.202:9000/staging/DOC-1216/linux/operations/concepts/thresholds.html)