### PR TITLE
Bug fixes for two issues related to LDAP and site replication

### DIFF
--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -233,12 +233,15 @@ The user can then use the passed SSH Public Key to log in to SFTP servers.
 
 Specify the base Distinguished Name (DN) MinIO uses when querying for 
 user credentials matching those provided by an authenticating client.
+
+Separate multiple DNs with a semicolon (``;``).
+
 For example:
 
 .. code-block:: shell
    :class: copyable
 
-   cn=miniousers,dc=myldapserver,dc=net
+   cn=miniousers;dc=myldapserver;dc=net
 
 Supports :ref:`Lookup-Bind  <minio-external-identity-management-ad-ldap-lookup-bind>` mode.
 
@@ -279,7 +282,7 @@ For example:
 
 .. start-minio-ad-ldap-group-search-base-dn
 
-Specify a comma-separated list of group search base Distinguished Names 
+Specify a semicolon-separated (``;``) list of group search base `Distinguished Names <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ldap/distinguished-names>`__
 MinIO uses when performing group lookups.
  
 For example:
@@ -287,7 +290,7 @@ For example:
 .. code-block:: shell
    :class: copyable
    
-   cn=miniogroups,dc=myldapserver,dc=net"
+   cn=miniogroups,dc=myldapserver,dc=net;ou=swengg,dc=min,dc=io
 
 .. end-minio-ad-ldap-group-search-base-dn
 
@@ -406,7 +409,7 @@ MinIO sends the token using the HTTP `Authorization <https://developer.mozilla.o
 
 .. start-minio-identity-management-role-policy
 
-Specify a comma separated list of MinIO :ref:`policies <minio-policy>` to assign to authenticated users.
+Specify a comma-separated list of MinIO :ref:`policies <minio-policy>` to assign to authenticated users.
 
 .. end-minio-identity-management-role-policy
 

--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -241,7 +241,7 @@ For example:
 .. code-block:: shell
    :class: copyable
 
-   cn=miniousers;dc=myldapserver;dc=net
+   cn=miniousers,dc=myldapserver,dc=net;ou=swengg,dc=min,dc=io
 
 Supports :ref:`Lookup-Bind  <minio-external-identity-management-ad-ldap-lookup-bind>` mode.
 

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -427,7 +427,7 @@ The new site must meet the following requirements:
    .. tab-item:: Command Line
       :sync: cli
 
-      #. Deploy the new MinIO peer site(s) following the stated requirements.
+      #. Deploy the new MinIO peer site(s) following the stated requirements
 
 
       #. Configure an alias for the new site

--- a/source/operations/install-deploy-manage/multi-site-replication.rst
+++ b/source/operations/install-deploy-manage/multi-site-replication.rst
@@ -453,13 +453,17 @@ The new site must meet the following requirements:
       #. Add site replication configuration
 
          Use the :mc-cmd:`mc admin replicate add` command to expand the site replication configuration with the new peer site.
-         Specify the alias of any existing healthy peer site as the first parameter and the alias of the new site as the second parameter.
+         Specify the alias of *all* existing peer sites, then the alias of the new site to add.
 
-         For example, the following command adds the new peer site ``minio4`` to an existing site replication configuration on ``minio1``.
+         For example, the following command adds the new peer site ``minio4`` to an existing site replication configuration that includes the existing sites ``minio1``, ``minio2``, and ``minio3``.
       
          .. code-block:: shell
          
-            mc admin replicate add minio1 minio4
+            mc admin replicate add minio1 minio2 minio3 minio4
+
+         .. note::
+
+            If any of the sites are unreachable or permanently lost, you **must** first remove the unreachable site(s) with :mc-cmd:`mc admin replicate rm` before expanding with the new site.
       
       #. Query the site replication configuration to verify
       

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -138,9 +138,9 @@ Syntax
       Only the first alias can have buckets or objects.
       The first site can also be empty.
 
-      To expand an existing site replication to one more new replication sites, the first :ref:`alias <alias>` must be a peer site in the site replication set to expand.
+      To expand an existing site replication to one more new replication sites, list all existing peer site :ref:`aliases <alias>` in the site replication set to expand.
       Then include one or more additional :ref:`aliases <alias>` to add to the existing site replication.
-      The deployments to add must be empty.
+      The peers being added must be empty.
 
    .. mc-cmd:: --replicate-ilm-expiry
       :optional:

--- a/source/reference/minio-mc-admin/mc-admin-replicate.rst
+++ b/source/reference/minio-mc-admin/mc-admin-replicate.rst
@@ -97,13 +97,17 @@ Syntax
 
             mc admin replicate add minio1 minio2 minio3
 
-         The following command expands an existing site replication that includes peer site ``minio1`` to an additional peer site, ``minio5``.
+         The following command expands an existing site replication that includes peer sites ``minio1``, ``minio2``, ``minio3``, and ``minio4`` to an additional peer site, ``minio5``.
          ``minio5`` contains no data.
+         List *all* existing peer sites first.
+         List the site to expand to last.
+
+         If any existing sites are unreachable, first remove the unreachable sites with :mc-cmd:`mc admin replicate rm`, then proceed with the site replication expansion.
 
          .. code-block:: shell
             :class: copyable
 
-            mc admin replicate add minio1 minio5
+            mc admin replicate add minio1 minio2 minio3 minio4 minio5
 
          The following command creates a new site replication configuration with ILM expiration rule synchronization between peer sites ``minio1``, ``minio2``, and ``minio3``.
          


### PR DESCRIPTION
Corrects docs to state that when expanding a site replication peer set, you must list all existing peers.

Closes #1340 

Adds information that when adding Distinguished Names as search parameters, multiple DNs must be separated with a semi-colon.

Closes #1341 

Staging info:

- [site replication](http://192.241.195.202:9000/staging/ldap-delimiter-1341/linux/operations/install-deploy-manage/multi-site-replication.html#expand-site-replication) NOTE: change is in the `Command Line` tab.
- [mc admin replicate add](http://192.241.195.202:9000/staging/ldap-delimiter-1341/linux/reference/minio-mc-admin/mc-admin-replicate.html#mc.admin.replicate.add)
- [LDAP config settings](http://192.241.195.202:9000/staging/ldap-delimiter-1341/linux/reference/minio-server/settings/iam/ldap.html#user-dn-search-base-dn)