### PR TITLE
mention that tiny files are not compressed, also other typos

### DIFF
--- a/source/administration/object-management/data-compression.rst
+++ b/source/administration/object-management/data-compression.rst
@@ -48,7 +48,7 @@ You can control which objects are compressed by specifying the desired file exte
 Excluded File Types
 ~~~~~~~~~~~~~~~~~~~
 
-Some data cannot be effectively compressed, such as video or already compressed data.
+Some data cannot be effectively compressed, such as video, already compressed data, or very small files.
 MinIO does not compress common incompressible file types, even if they are specified in the compression configuration.
 
 Objects of these types are never compressed:

--- a/source/administration/object-management/data-compression.rst
+++ b/source/administration/object-management/data-compression.rst
@@ -48,7 +48,8 @@ You can control which objects are compressed by specifying the desired file exte
 Excluded File Types
 ~~~~~~~~~~~~~~~~~~~
 
-Some data cannot be effectively compressed, such as video, already compressed data, or very small files.
+Some data cannot be effectively compressed.
+For example: video, already compressed data, or very small files.
 MinIO does not compress common incompressible file types, even if they are specified in the compression configuration.
 
 Objects of these types are never compressed:

--- a/source/administration/object-management/data-compression.rst
+++ b/source/administration/object-management/data-compression.rst
@@ -49,7 +49,7 @@ Excluded File Types
 ~~~~~~~~~~~~~~~~~~~
 
 Some data cannot be effectively compressed.
-For example: video, already compressed data, or very small files.
+For example: video, already compressed data, or files less than 4KiB.
 MinIO does not compress common incompressible file types, even if they are specified in the compression configuration.
 
 Objects of these types are never compressed:

--- a/source/includes/common-mc-admin-config.rst
+++ b/source/includes/common-mc-admin-config.rst
@@ -54,6 +54,10 @@
      - | ``application/zip``
        | ``application-x-zip-compressed``
 
+   * - Smaller than 4 KiB
+     -
+     -
+
 .. end-minio-data-compression-default-excluded-desc
 
 .. start-minio-data-compression-default-desc

--- a/source/reference/minio-mc/mc-anonymous-get-json.rst
+++ b/source/reference/minio-mc/mc-anonymous-get-json.rst
@@ -65,7 +65,7 @@ Parameters
 
    .. code-block:: shell
             
-      mc get-json public play/mybucket
+      mc anonymous get-json public play/mybucket
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-anonymous-get.rst
+++ b/source/reference/minio-mc/mc-anonymous-get.rst
@@ -69,7 +69,7 @@ Parameters
 
    .. code-block:: shell
             
-      mc get public play/mybucket
+      mc anonymous get public play/mybucket
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-anonymous-links.rst
+++ b/source/reference/minio-mc/mc-anonymous-links.rst
@@ -67,7 +67,7 @@ Parameters
 
    .. code-block:: shell
             
-      mc links public [FLAGS] play/mybucket
+      mc anonymous links public [FLAGS] play/mybucket
 
 .. mc-cmd:: --recursive
    

--- a/source/reference/minio-mc/mc-anonymous-list.rst
+++ b/source/reference/minio-mc/mc-anonymous-list.rst
@@ -66,7 +66,7 @@ Parameters
 
    .. code-block:: shell
             
-      mc list public play/mybucket
+      mc anonymous list public play/mybucket
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-anonymous-set-json.rst
+++ b/source/reference/minio-mc/mc-anonymous-set-json.rst
@@ -72,7 +72,7 @@ Parameters
 
    .. code-block:: shell
             
-      mc set-json public play/mybucket
+      mc anonymous set-json public play/mybucket
 
 Global Flags
 ~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-anonymous-set.rst
+++ b/source/reference/minio-mc/mc-anonymous-set.rst
@@ -87,8 +87,8 @@ Parameters
    prefix. For example:
 
    .. code-block:: shell
-            
-      mc set public play/mybucket
+
+      mc anonymous set public play/mybucket
 
    Specify a bucket prefix to set the policy on only that prefix. For example,
    this command sets distinct anonymous bucket policies on the 
@@ -96,8 +96,8 @@ Parameters
 
    .. code-block:: shell
 
-      mc set download play/mybucket/downloads
-      mc set upload play/mybucket/uploads
+      mc anonymous set download play/mybucket/downloads
+      mc anonymous set upload play/mybucket/uploads
 
 Global Flags
 ~~~~~~~~~~~~


### PR DESCRIPTION
Came up in a customer issue. Specifically the threshold is 4 kb and there is no configuration option. (Nor does Klaus want one.)

Worth adding? With how much detail? The threshold choice is because of typical block size on disk. You will use at least that much anyway so why bother compressing.

Staged:

http://192.241.195.202:9000/staging/dont-compress-small-objects/linux/administration/object-management/data-compression.html#excluded-file-types

Drive-by fix tacked onto this PR: correct typos in some `mc anonymous` examples.

Staged:
http://192.241.195.202:9000/staging/dont-compress-small-objects/linux/reference/minio-mc/mc-anonymous.html