### PR TITLE
Adds information about changes to ILM deletes

### DIFF
--- a/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
+++ b/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
@@ -99,7 +99,8 @@ delete markers:
       --noncurrent-expire-days NONCURRENT_DAYS \
       --expire-delete-marker
 
-- To expire all versions of an object with no delete marker, include :mc-cmd:`~mc ilm rule add --expire-all-object-versions`.
+- To expire all versions of an object, include :mc-cmd:`~mc ilm rule add --expire-all-object-versions`.
+  This expiration only applies to objects without a ``DeleteMarker`` as the latest or current version.
 
   .. code-block:: shell
      :class: copyable
@@ -122,9 +123,9 @@ Expire All Versions of a Deleted Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting with :mc-release:`MinIO Server RELEASE.2024-05-01T01-11-10Z`, MinIO supports deleting all versions of an object that has a delete marker as its latest version.
-MinIO only supports this function with JSON.
+MinIO supports such deletes with ``JSON``, not through the command line.
 
-To add this function, first export the rule to modify with :mc:`mc ilm rule export`.
+To add this capability to a rule, first export the rule to modify with :mc:`mc ilm rule export`.
 Modify the exported rule with additional ``JSON`` that resembles the following:
 
 .. code-block:: text
@@ -135,4 +136,4 @@ Modify the exported rule with additional ``JSON`` that resembles the following:
    </DelMarkerObjectExpiration>   
 
 This example ``JSON`` expires all versions of the deleted object after 10 days.
-Modify the value in the ``<Days>`` element to the number of days you want to wait after deleting or expiring the object.
+Modify the value in the ``<Days>`` element to the number of days you want to wait after deleting the object before expiring it and removing it from MinIO.

--- a/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
+++ b/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
@@ -99,6 +99,14 @@ delete markers:
       --noncurrent-expire-days NONCURRENT_DAYS \
       --expire-delete-marker
 
+- To expire all versions of an object with no delete marker, include :mc-cmd:`~mc ilm rule add --expire-all-object-versions`.
+
+  .. code-block:: shell
+     :class: copyable
+  
+     mc ilm rule add ALIAS/PATH \ 
+        --expire-all-object-versions
+
 - Replace :mc-cmd:`ALIAS <mc ilm rule add ALIAS>` with the 
   :mc:`alias <mc alias>` of the S3-compatible host.
 
@@ -110,3 +118,21 @@ delete markers:
   which to expire noncurrent object versions. For example, specify ``30d`` to
   expire a version after it has been noncurrent for at least 30 days.
 
+Expire All Versions of a Deleted Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with :mc-release:`MinIO Server RELEASE.2024-05-01T01-11-10Z`, MinIO supports deleting all versions of an object that has a delete marker as its latest version.
+MinIO only supports this function with JSON.
+
+To add this function, first export the rule to modify with :mc:`mc ilm rule export`.
+Modify the exported rule with additional ``JSON`` that resembles the following:
+
+.. code-block:: text
+   :class: copyable
+
+   <DelMarkerObjectExpiration>
+       <Days> 10 </Days>
+   </DelMarkerObjectExpiration>   
+
+This example ``JSON`` expires all versions of the deleted object after 10 days.
+Modify the value in the ``<Days>`` element to the number of days you want to wait after deleting or expiring the object.

--- a/source/administration/object-management/object-delete.rst
+++ b/source/administration/object-management/object-delete.rst
@@ -98,6 +98,10 @@ See the :ref:`scanner <minio-concepts-scanner>` page for more details on how the
 ``DeleteMarkers`` are their own objects.
 Lifecycle rules can remove ``DeleteMarkers`` that are the only remaining versions of their objects.
 
+.. versionchanged:: MinIO RELEASE.2024-05-01T01-11-10Z
+
+With ``JSON``, lifecycle rules can remove all versions of a deleted object after a specified number of days.
+
 Retained Objects
 ----------------
 

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -110,7 +110,7 @@ Versioned Buckets
 ~~~~~~~~~~~~~~~~~
 
 MinIO adopts :s3-docs:`S3 behavior <intro-lifecycle-rules.html#intro-lifecycle-rules-actions>` for expiration rules on :ref:`versioned buckets <minio-bucket-versioning>`. 
-MinIO has two specific default behaviors for versioned buckets:
+MinIO has several default behaviors for versioned buckets:
 
 - MinIO applies the expiration option to only the *current* object version by creating a ``DeleteMarker`` as is normal with versioned delete.
 
@@ -120,8 +120,26 @@ MinIO has two specific default behaviors for versioned buckets:
 
   To expire delete markers when there are no remaining versions for that object, specify the :mc-cmd:`~mc ilm rule add --expire-delete-marker` option when creating the expiration rule.
 
-- To expire *all* versions of an object after a specified period of days, use the :mc-cmd:`~mc ilm rule add --expire-all-object-versions` flag with the :mc-cmd:`~mc ilm rule add --expire-days` flag. 
+  .. versionchanged:: MinIO RELEASE.2024-05-01T01-11-10Z
+
+     MinIO supports expiring all versions of an object where the latest version is a delete marker, *including expiring the delete marker*, but only with JSON.
+     Add a JSON rule with :mc:`mc ilm rule import`.
+
+     For example, to expire all versions of a deleted object 10 days after the object deletion, use the following JSON:
+
+     .. code-block:: text
+        :class: copyable
+
+        <DelMarkerObjectExpiration>
+            <Days> 10 </Days>
+        </DelMarkerObjectExpiration>
+
+- To expire *all* versions of an object that does *not* have a delete marker after a specified period of days, use the :mc-cmd:`~mc ilm rule add --expire-all-object-versions` flag with the :mc-cmd:`~mc ilm rule add --expire-days` flag. 
   This permits the permanent deletion of the object after the specified number of days pass.
+
+  .. versionchanged:: MinIO RELEASE.2024-05-01T01-11-10Z
+
+     This flag applies only to objects that do **not** have a delete marker.
 
 .. _minio-lifecycle-management-scanner:
 

--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -126,6 +126,10 @@ Parameters
 
    After the :ref:`scanner <minio-concepts-scanner>` processes this command, no versions of the object remain on the deployment.
 
+   .. versionchanged:: MinIO RELEASE.2024-05-01T01-11-10Z
+
+   This flag *only* applies to objects that do **not** have a delete marker as the latest version.
+
 .. mc-cmd:: --expire-days
    :optional:   
 
@@ -465,6 +469,25 @@ regardless of its transition status. Use
 :mc:`mc ilm rule ls` to review the currently configured object lifecycle
 management rules for any potential interactions between expiry and transition
 rules.
+
+Expire All Versions of a Deleted Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with :mc-release:`MinIO Server RELEASE.2024-05-01T01-11-10Z`, MinIO supports deleting all versions of an object that has a delete marker as its latest version.
+MinIO only supports this function with JSON.
+
+To add this function, first export the rule to modify with :mc:`mc ilm rule export`.
+Modify the file you exported the rule to with additional JSON that resembles the following:
+
+.. code-block:: text
+   :class: copyable
+
+   <DelMarkerObjectExpiration>
+       <Days> 10 </Days>
+   </DelMarkerObjectExpiration>   
+
+This example ``JSON`` expires all versions of the deleted object after 10 days.
+Modify the value in the ``<Days>`` element to the number of days you want to wait after deleting or expiring the object.
 
 S3 Compatibility
 ~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-ilm-rule-edit.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-edit.rst
@@ -60,6 +60,7 @@ rule on a MinIO bucket.
                           [--prefix "string"]                                 \
                           [--enable]                                          \
                           [--disable]                                         \
+                          [--expire-all-object-versions]                      \
                           [--expire-days "string"]                            \ 
                           [--expire-delete-marker]                            \
                           [--transition-days "string"]                        \
@@ -118,6 +119,22 @@ Parameters
       mc ilm rule edit --prefix "meetingnotes/" myminio/mydata --expire-days "90"
 
    The command modifies a rule that expires objects in the ``mydata`` bucket of the ``myminio`` ALIAS after 90 days for any object with the ``meetingnotes/`` prefix.
+
+
+.. mc-cmd:: --expire-all-object-versions
+   :optional:   
+
+   .. versionadded:: mc RELEASE.2024-02-24T01-33-20Z
+
+   Expire all current **and** noncurrent versions of an object.
+   Use with the :mc-cmd:`~mc ilm rule add --expire-days` option to specify the number of days after which all versions of an object should be deleted by the scanner process.
+
+   After the :ref:`scanner <minio-concepts-scanner>` processes this command, no versions of the object remain on the deployment.
+
+   .. versionadded:: MinIO RELEASE.2024-05-01T01-11-10Z
+
+   This flag *only* applies to objects that do **not** have a delete marker as the latest version.
+
 
 .. mc-cmd:: --expire-days
    :optional:
@@ -322,6 +339,25 @@ For permissions required to edit a rule, refer to the :ref:`required permissions
 
 Behavior
 --------
+
+Expire All Versions of a Deleted Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with :mc-release:`MinIO Server RELEASE.2024-05-01T01-11-10Z`, MinIO supports deleting all versions of an object that has a delete marker as its latest version.
+MinIO only supports this function with JSON.
+
+To add this function, first export the rule to modify with :mc:`mc ilm rule export`.
+Modify the file you exported the rule to with additional JSON that resembles the following:
+
+.. code-block:: text
+   :class: copyable
+
+   <DelMarkerObjectExpiration>
+       <Days> 10 </Days>
+   </DelMarkerObjectExpiration>   
+
+This example ``JSON`` expires all versions of the deleted object after 10 days.
+Modify the value in the ``<Days>`` element to the number of days you want to wait after deleting or expiring the object.
 
 S3 Compatibility
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- New option with JSON to expire all versions of an object with a delete marker.
- Changes `mc ilm rule` subcommand flags `--expire-all-object-versions` to note that only applies to objects without a delete marker.

Closes #1201

Staged:

- [Object Delete](http://192.241.195.202:9000/staging/del-marker-1201/linux/administration/object-management/object-delete.html#lifecycle-management-expiration)
- [Object lifecycle management](http://192.241.195.202:9000/staging/del-marker-1201/linux/administration/object-management/object-lifecycle-management.html#id1)
- [mc ilm rule add](http://192.241.195.202:9000/staging/del-marker-1201/linux/reference/minio-mc/mc-ilm-rule-add.html)
- [mc ilm rule edit](http://192.241.195.202:9000/staging/del-marker-1201/linux/reference/minio-mc/mc-ilm-rule-edit.html)