### PR TITLE
Minor fixes for several smaller issues

### DIFF
--- a/source/administration/batch-framework-job-keyrotate.rst
+++ b/source/administration/batch-framework-job-keyrotate.rst
@@ -42,10 +42,6 @@ Required Fields
      * - ``key:`` 
        - Only for use with the ``sse-kms`` type. 
          The key to use to unseal the key vault.
-     * - ``context:``
-       - Only for use with the ``sse-kms`` type.
-         The context within which to perform actions. 
-
    
 Optional Fields
 ~~~~~~~~~~~~~~~
@@ -73,6 +69,9 @@ For **flag based filters**
      - A date in ``YYYY-MM-DD`` format.
        
        Keys rotate only for objects created prior to the date.
+   * - ``context:``
+     - Only for use with the ``sse-kms`` type.
+       The context within which to perform actions. 
    * - ``tags:``
      - Rotate keys only for objects with tags that match the specified ``key:`` and ``value:``.  
    * - ``metadata:``

--- a/source/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.rst
+++ b/source/administration/bucket-replication/enable-server-side-multi-site-bucket-replication.rst
@@ -110,8 +110,8 @@ Procedure
 
 This procedure requires repeating steps for each MinIO deployment participating in the multi-site replication configuration. Depending on the number of deployments, this procedure may require significant time and care in implementation. MinIO recommends reading through the procedure *before* attempting to implement the documented steps.
 
-- :ref:`Configure Multi-Site Bucket Replication Using the Command Line <minio-bucket-replication-multi-site-minio-cli-procedure>`
-   - :ref:`Create Replication Remote Targets <minio-bucket-replication-multi-site-minio-cli-create-remote-targets>`
+- Configure Multi-Site Bucket Replication Using the Command Line
+   
    - :ref:`Create New Bucket Replication Rules <minio-bucket-replication-multi-site-minio-cli-create-replication-rules>`
    - :ref:`Validate the Replication Configuration <minio-bucket-replication-multi-site-minio-cli-verify-replication-config>` 
 
@@ -128,8 +128,6 @@ This procedure assumes each alias corresponds to a user with the :ref:`necessary
 
    :mc:`mc replicate add` automatically creates the necessary replication targets, removing the need for using the deprecated ``mc admin remote bucket add`` command.
    This procedure only documents the procedure as of that release.
-
-.. _minio-bucket-replication-multi-site-minio-cli-create-remote-targets:
 
 .. _minio-bucket-replication-multi-site-minio-cli-create-replication-rules:
 

--- a/source/administration/minio-console.rst
+++ b/source/administration/minio-console.rst
@@ -151,7 +151,6 @@ Once logged in to the MinIO Console, users can perform many kinds of tasks.
 - :ref:`Manage objects <minio-console-managing-objects>` by browsing existing objects, uploading objects, or modifying bucket settings.
 - :ref:`Review or modify identity and security <minio-console-security-access>` with access keys, policies, and Identity Provider settings.
 - :ref:`Monitor the health and activities <minio-console-managing-deployment>` with metrics and notifications.
-- :ref:`Manage your deployment's license <minio-console-subscription>`
 
 .. toctree::
    :titlesonly:

--- a/source/includes/linux/file-transfer-protocol-not-k8s.rst
+++ b/source/includes/linux/file-transfer-protocol-not-k8s.rst
@@ -273,6 +273,52 @@ Once the MinIO Server verifies the client's certificate, the user can connect to
    
    sftp -P <SFTP port> <server IP>
 
+
+Procedure
++++++++++
+
+The following procedure generates two key-value pairs, signs one with the other, then uses the resulting signed key to log in to the SFTP server.
+
+1. Generate a key-value pair for the MinIO Server
+   
+   .. code-block:: bash
+      :class: copyable
+
+      ssh-keygen -f ./ca_user_key
+
+2. Generate a key-value pair for the user
+
+   .. code-block:: bash
+      :class: copyable
+
+      ssh-keygen -f ./minioadmin
+
+   Replace ``minioadmin`` with the user accessing the MinIO Server by SFTP.
+
+3. Sign the user key-value pair key with the MinIO Server key-value pair key
+
+   .. code-block:: bash
+      :class: copyable
+
+      ssh-keygen -s ca_user_key -I minioadmin -n minioadmin -V +30d -z 1 minioadmin.pub
+
+   Move the ``minioadmin.pub`` key to the same directory as ``minioadmin`` key-value pair, such as ``~/.ssh/meaningful-directory``.
+
+4. Start or restart the MinIO Server passing the generated public keys
+
+   .. code-block:: bash
+      :class: copyable
+
+      minio server --sftp="address=:8022" --sftp="ssh-private-key=/path/to/ca_user_key" --sftp="trusted-user-ca-key=/path/to/ca_user_key.pub"
+
+5. Connect to the MinIO Server by sftp
+
+   .. code-block:: bash
+      :class: copyable
+
+      sftp -i ./minioadmin -oPort=8022 minioadmin@localhost
+
+
 Require service account or LDAP for authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/operations/network-encryption.rst
+++ b/source/operations/network-encryption.rst
@@ -585,7 +585,13 @@ Self-signed, Internal, Private Certificates, and Public CAs with Intermediate Ce
 
             mv myCA.crt /opt/minio/certs/CAs/
 
-   For a self-signed certificate, the Certificate Authority is typically the private key used to sign the cert.
+   .. important::
+   
+      Do not use or share the private key of the self-signed certificate. 
+      Only the public certificate should be shared or distributed for trust purposes.
+   
+   For certificates signed by an internal, private, or other non-global Certificate Authority, use the same CA that signed the cert.
+   A non-global CA must include the full chain of trust from the intermediate certificate to the root.
 
    For certificates signed by an internal, private, or other non-global Certificate Authority, use the same CA that signed the cert.
    A non-global CA must include the full chain of trust from the intermediate certificate to the root.
@@ -621,7 +627,3 @@ Self-signed, Internal, Private Certificates, and Public CAs with Intermediate Ce
          :class: copyable
 
          kubectl rollout restart deployments.apps/minio-operator -n minio-operator
-
-
-
-   

--- a/source/reference/minio-server/settings/storage-class.rst
+++ b/source/reference/minio-server/settings/storage-class.rst
@@ -44,9 +44,8 @@ Standard Storage Class
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. include:: /includes/common-mc-admin-config.rst
-         :start-after: start-minio-settings-no-config-option
-         :end-before: end-minio-settings-no-config-option
+      .. mc-conf:: storage_class standard
+         :delimiter: " "
 
 The :ref:`parity level <minio-ec-parity>` for the deployment.
 MinIO shards objects written with the default ``STANDARD`` storage class using this parity value.
@@ -113,9 +112,8 @@ Reduced Redundancy Storage Class
    .. tab-item:: Configuration Setting
       :sync: config
 
-      .. include:: /includes/common-mc-admin-config.rst
-         :start-after: start-minio-settings-no-config-option
-         :end-before: end-minio-settings-no-config-option
+      .. mc-conf:: storage_class rrs
+         :delimiter: " "
 
 The :ref:`parity level <minio-ec-parity>` for objects written with the ``REDUCED`` storage class.
 
@@ -132,7 +130,6 @@ Defaults to ``EC:0`` for deployments of erasure set size of 1.
 
 Parity Retention Optimization
 -----------------------------
-
 
 .. tab-set::
 


### PR DESCRIPTION
- Adds missing config settings throughout storage class page.
    
  Closes #1349
    
- Adds instructions for adding certificates for connecting by sftp.
    
  Closes #1354
    
- Corrects information about which key to use for self-signed CAs.
    
  Closes #1358
    
- Moves `context` to optional for batch key rotate jobs.
    
  Closes #1356

- clean up missing ref links causing build warnings.

### Staging info:

- [storage-class](http://192.241.195.202:9000/staging/djw-minor-fixes/linux/reference/minio-server/settings/storage-class.html#standard-storage-class) (select the Config Setting tab)
- [sftp certificate procedure](http://192.241.195.202:9000/staging/djw-minor-fixes/linux/developers/file-transfer-protocol.html#id1)
- [network encryption](http://192.241.195.202:9000/staging/djw-minor-fixes/linux/operations/network-encryption.html#self-signed-internal-private-certificates-and-public-cas-with-intermediate-certificates) (select the "custom certificate path" tab)
- [batch replication key rotation](http://192.241.195.202:9000/staging/djw-minor-fixes/linux/administration/batch-framework-job-keyrotate.html)