### PR TITLE
DOCS-1386: Undeprecating mc license update

### DIFF
--- a/source/reference/minio-mc-deprecated.rst
+++ b/source/reference/minio-mc-deprecated.rst
@@ -71,10 +71,6 @@ Table of Deprecated Commands
      - :mc-cmd:`mc replicate backlog`
      - mc RELEASE.2023-07-18T21-05-38Z
 
-   * - ``mc license update``
-     - No replacement
-     - mc RELEASE.2024-07-03T20-17-25Z 
-
 
 Table of Deprecated Admin Commands
 ----------------------------------
@@ -234,7 +230,6 @@ Table of Deprecated Admin Commands
    /reference/deprecated/mc-ilm-import
    /reference/deprecated/mc-ilm-ls
    /reference/deprecated/mc-ilm-rm
-   /reference/deprecated/mc-license-update
    /reference/deprecated/mc-quota
    /reference/deprecated/mc-quota-clear
    /reference/deprecated/mc-quota-info

--- a/source/reference/minio-mc/mc-license-update.rst
+++ b/source/reference/minio-mc/mc-license-update.rst
@@ -10,19 +10,6 @@
 
 .. mc:: mc license update
 
-.. important:: 
-
-   This command is no longer maintained in the Open Source MinIO Server or MinIO Client product and has been removed completely as of MinIO Client ``RELEASE.2024-07-03T20-17-25Z``.
-
-   For questions about licensing the MinIO Server, contact sales@min.io.
-
-.. note::
-
-   ``mc license update`` requires :ref:`MinIO Client <minio-client>` version ``RELEASE.2023-11-20T16-30-59Z``.
-   While not strictly required, best practice keeps the :ref:`MinIO Client version <mc-client-versioning>` in alignment with the MinIO Server version.
-   
-   If for any reason you cannot upgrade your MinIO Client to the required version or later for the purpose of registering to SUBNET, register using the :ref:`MinIO Console <minio-docs-subnet>` instead.
-
 Description
 -----------
 
@@ -32,11 +19,7 @@ Use the :mc-cmd:`mc license update` command to replace a license key for a deplo
 
 .. end-mc-license-update-desc
 
-.. versionchanged:: RELEASE.2023-01-18T04-36-38Z
-
-   For deployments registered for |SUBNET|, MinIO automatically checks for and updates the license every month.
-
-If not passed with the command, MinIO checks the license file on SUBNET and automatically updates it.
+For deployments registered for |SUBNET|, MinIO automatically checks for and updates the license every month.
 
 Examples
 --------

--- a/source/reference/minio-mc/mc-license.rst
+++ b/source/reference/minio-mc/mc-license.rst
@@ -44,6 +44,10 @@ Subcommands
           :start-after: start-mc-license-register-desc
           :end-before: end-mc-license-register-desc
 
+   * - :mc:`~mc license update`
+     - .. include:: /reference/minio-mc/mc-license-update.rst
+          :start-after: start-mc-license-update-desc
+          :end-before: end-mc-license-update-desc
 
 .. toctree::
    :titlesonly:
@@ -51,3 +55,4 @@ Subcommands
    
    /reference/minio-mc/mc-license-info
    /reference/minio-mc/mc-license-register
+   /reference/minio-mc/mc-license-update


### PR DESCRIPTION
Closes #1386 

# Summary

`mc license update` was mistakenly marked as deprecated.

This adds it back to the main reference.

Staged: http://192.241.195.202:9000/staging/DOCS-1386/linux/reference/minio-mc/mc-license.html