### PR TITLE
Removes examples to expire all versions with delete marker

### DIFF
--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -443,6 +443,10 @@ The following command removes delete markers for objects where the delete marker
 
 - Replace :mc-cmd:`PATH <mc ilm rule add ALIAS>` with the path to the bucket on the S3-compatible host.
 
+.. note::
+
+   To delete all versions of an object with a delete marker as its latest version, *including the delete marker*, consider using :ref:`batch expiration <minio-mc-batch-generate-expire-job>`.
+
 Required Permissions
 --------------------
 
@@ -469,25 +473,6 @@ regardless of its transition status. Use
 :mc:`mc ilm rule ls` to review the currently configured object lifecycle
 management rules for any potential interactions between expiry and transition
 rules.
-
-Expire All Versions of a Deleted Object
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Starting with :mc-release:`MinIO Server RELEASE.2024-05-01T01-11-10Z`, MinIO supports deleting all versions of an object that has a delete marker as its latest version.
-MinIO only supports this function with JSON.
-
-To add this function, first export the rule to modify with :mc:`mc ilm rule export`.
-Modify the file you exported the rule to with additional JSON that resembles the following:
-
-.. code-block:: text
-   :class: copyable
-
-   <DelMarkerObjectExpiration>
-       <Days> 10 </Days>
-   </DelMarkerObjectExpiration>   
-
-This example ``JSON`` expires all versions of the deleted object after 10 days.
-Modify the value in the ``<Days>`` element to the number of days you want to wait after deleting or expiring the object.
 
 S3 Compatibility
 ~~~~~~~~~~~~~~~~

--- a/source/reference/minio-mc/mc-ilm-rule-edit.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-edit.rst
@@ -340,25 +340,6 @@ For permissions required to edit a rule, refer to the :ref:`required permissions
 Behavior
 --------
 
-Expire All Versions of a Deleted Object
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Starting with :mc-release:`MinIO Server RELEASE.2024-05-01T01-11-10Z`, MinIO supports deleting all versions of an object that has a delete marker as its latest version.
-MinIO only supports this function with JSON.
-
-To add this function, first export the rule to modify with :mc:`mc ilm rule export`.
-Modify the file you exported the rule to with additional JSON that resembles the following:
-
-.. code-block:: text
-   :class: copyable
-
-   <DelMarkerObjectExpiration>
-       <Days> 10 </Days>
-   </DelMarkerObjectExpiration>   
-
-This example ``JSON`` expires all versions of the deleted object after 10 days.
-Modify the value in the ``<Days>`` element to the number of days you want to wait after deleting or expiring the object.
-
 S3 Compatibility
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This functionality was never fully implemented and will not be implemented.

Closes #1383 

Staged: 
- [mc ilm rule add](http://192.241.195.202:9000/staging/delete-marker/linux/reference/minio-mc/mc-ilm-rule-add.html#remove-delete-markers)
- [mc ilm rule edit](http://192.241.195.202:9000/staging/delete-marker/linux/reference/minio-mc/mc-ilm-rule-edit.html#behavior)