### PR TITLE
Update common-installation.rst

### DIFF
--- a/source/includes/common-installation.rst
+++ b/source/includes/common-installation.rst
@@ -234,7 +234,7 @@ Use Consistent Type of Drive
    This can result in performance issues, as some drives have differing or worse read/write characteristics and cannot respond at the same rate as the NVMe drives.
 
 Use Consistent Size of Drive
-   MinIO limits the size used per drive to the smallest drive in the deployment.
+   MinIO limits the size used per drive to the smallest drive in the pool.
 
    For example, deploy a pool consisting of the same number of NVMe drives with identical capacity of ``7.68TiB``.
    If you deploy one drive with ``3.84TiB``, MinIO treats all drives in the pool as having that smaller capacity.


### PR DESCRIPTION
See https://miniohq.slack.com/archives/C03VDE2R9ED/p1734487467518789

The admonition in https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#storage-requirements should read:
`MinIO limits the size used per drive to the smallest drive in the pool.`
instead of
`MinIO limits the size used per drive to the smallest drive in the deployment.`