### PR TITLE
Deprecates `logs` for `mc support callhome`

### DIFF
--- a/source/reference/minio-mc/mc-support-callhome.rst
+++ b/source/reference/minio-mc/mc-support-callhome.rst
@@ -19,16 +19,16 @@ Description
 
 .. start-mc-support-callhome-desc
 
-The :mc-cmd:`mc support callhome` command allows the enabling or disabling of reports from a deployment to |SUBNET|.
+The :mc-cmd:`mc support callhome` command allows the enabling or disabling of diagnostic information from a deployment to |SUBNET|.
 
 .. end-mc-support-callhome-desc
 
 All ``mc support`` commands require an active SUBNET subscription.
 
-When enabled, MinIO can send logs to SUBNET in real time, diagnostics every 24 hours, or both.
+When enabled, MinIO sends diagnostic information to SUBNET.
 
 MinIO disables this functionality by default, regardless of registration status.
-You must explicitly enable the ``callhome`` function to begin real time log upload.
+You must explicitly enable the ``callhome`` function to begin information upload.
 
 .. include:: /includes/common-mc-support.rst
    :start-after: start-minio-only
@@ -49,6 +49,10 @@ Syntax
                           [--logs]  \
                           [--diag]
 
+   .. note::
+
+      The ``--logs`` and ``--diag`` flags are no longer supported in SUBNET and will be removed in a future release.
+
 .. mc-cmd:: disable
    :fullpath:
 
@@ -61,6 +65,10 @@ Syntax
                           [--logs] \
                           [--diag]
 
+   .. note::
+
+      The ``--logs`` and ``--diag`` flags are no longer supported in SUBNET and will be removed in a future release.
+
 .. mc-cmd:: status
    :fullpath:
 
@@ -72,6 +80,10 @@ Syntax
                           ALIAS    \
                           [--logs] \
                           [--diag]
+
+   .. note::
+
+      The ``--logs`` and ``--diag`` flags are no longer supported in SUBNET and will be removed in a future release.
             
 Parameters
 ~~~~~~~~~~
@@ -84,10 +96,18 @@ Parameters
 .. mc-cmd:: --logs
    :optional:
 
+   .. note::
+
+      This option is no longer supported in SUBNET and will be removed in a future release.
+
    Send or stop sending log information to SUBNET in real time.
 
 .. mc-cmd:: --diag
    :optional:
+
+   .. note::
+
+      This option is no longer supported in SUBNET and will be removed in a future release.
 
    Send or stop sending deployment diagnostic information to SUBNET every 24 hours.
 
@@ -96,32 +116,20 @@ If you do not pass either ``--logs`` or ``--diag``, the command applies to both 
 Examples
 --------
 
-Enable ``callhome`` Reporting
+Enable ``callhome`` reporting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enable the sending of data for deployment with the alias ``minio1``.
-When enabled for a deployment registered to SUBNET, MinIO sends logs and diagnostics to SUBNET.
+Enable sending diagnostic information to SUBNET for a deployment registered to SUBNET with an :ref:`alias <alias>` of ``minio1``.
 
 .. code-block:: shell
    :class: copyable
  
    mc support callhome enable minio1
 
-Enable ``callhome`` Reporting for Logs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Disable ``callhome`` reporting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enable logs callhome for a deployment with the alias ``minio1``.
-When enabled for a deployment registered to SUBNET, MinIO sends logs to SUBNET in real time.
-
-.. code-block:: shell
-   :class: copyable
- 
-   mc support callhome enable minio1 --logs
-
-Disable ``callhome`` Logs
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Disable sending real time information to SUBNET for a deployment registered to SUBNET with an :ref:`alias <alias>` of ``minio1``.
+Disable sending diagnostic information to SUBNET for a deployment registered to SUBNET with an :ref:`alias <alias>` of ``minio1``.
 
 .. code-block:: shell
    :class: copyable
@@ -129,10 +137,10 @@ Disable sending real time information to SUBNET for a deployment registered to S
    mc support callhome disable minio1
 
 
-Display Current ``callhome`` Settings
+Display Current ``callhome`` settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Display whether a deployment with the alias ``minio1`` sends diagnostics or logs to SUBNET.
+Display whether a deployment with the alias ``minio1`` sends information to SUBNET.
 
 .. code-block:: shell
    :class: copyable

--- a/source/reference/minio-mc/minio-client-settings.rst
+++ b/source/reference/minio-mc/minio-client-settings.rst
@@ -25,7 +25,7 @@ Host Credentials
 Use this setting to add a temporary alias to use for `mc` commands.
 For example, for use with scripting.
 
-The temporary alias uses the :aws-docs:`AWS s3v4 API <AmazonS3/latest/API/sig-v4-authenticating-requests.html>`.
+The temporary alias uses the :aws-docs:`AWS s3v4 signature <AmazonS3/latest/API/sig-v4-authenticating-requests.html>`.
 
 .. tab-set::
 


### PR DESCRIPTION
SUBNET no longer supports the uploading of logs.
The flags still exist in the MinIO Client, but no longer function.

Opportunistic fix to clarify that s3v4 is a signature type, not an API.

No issue to link.