### PR TITLE
Drop fstrim as a recommended software to remove or disable

### DIFF
--- a/source/operations/checklists/software.rst
+++ b/source/operations/checklists/software.rst
@@ -36,7 +36,6 @@ MinIO Pre-requisites
        - ``mlocate`` or ``plocate``
        - ``updatedb``
        - ``auditd``
-       - ``fstrim``
        - Crowdstrike Falcon
        - Antivirus software (``clamav``)
       


### PR DESCRIPTION
Per internal discussion.
`fstrim` has more benefits than concerns at this point.