### PR TITLE
Clarify additional MinIO Console options available using mc

### DIFF
--- a/source/administration/minio-console.rst
+++ b/source/administration/minio-console.rst
@@ -19,6 +19,7 @@ Overview
 --------
 
 You can use the MinIO Console for administration tasks like Identity and Access Management, Metrics and Log Monitoring, or Server Configuration.
+It provides access to many common options and complements the more comprehensive command line configurations available using :mc:`mc`.
 
 The MinIO Console is embedded as part of the MinIO Server. 
 You can also deploy a standalone MinIO Console using the instructions in the :minio-git:`github repository <console>`.

--- a/source/administration/minio-console.rst
+++ b/source/administration/minio-console.rst
@@ -19,7 +19,7 @@ Overview
 --------
 
 You can use the MinIO Console for administration tasks like Identity and Access Management, Metrics and Log Monitoring, or Server Configuration.
-It provides access to many common options and complements the more comprehensive command line configurations available using :mc:`mc`.
+For more comprehensive or advanced configuration of MinIO, use the :mc:`mc` command line tool.
 
 The MinIO Console is embedded as part of the MinIO Server. 
 You can also deploy a standalone MinIO Console using the instructions in the :minio-git:`github repository <console>`.


### PR DESCRIPTION
Add a clearer callout to `mc` for features not/no longer available in MinIO Console. 

Given that several things were removed, enumerating specific commands seems impractical? Opinions solicited.

From a community issue: https://github.com/minio/console/issues/3498

Not yet staged.