### PR TITLE
fix example commands to export envvars for linux

### DIFF
--- a/source/administration/monitoring/publish-events-to-amqp.rst
+++ b/source/administration/monitoring/publish-events-to-amqp.rst
@@ -73,23 +73,46 @@ You can configure a new AMQP service endpoint using either environment variables
       *required* variables are
       :envvar:`MINIO_NOTIFY_AMQP_ENABLE` and :envvar:`MINIO_NOTIFY_AMQP_URL`:
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_AMQP_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_AMQP_URL_<IDENTIFIER>="<ENDPOINT>"
+               set MINIO_NOTIFY_AMQP_EXCHANGE_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_EXCHANGE_TYPE_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_ROUTING_KEY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_MANDATORY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_DURABLE_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_NO_WAIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_INTERNAL_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_AUTO_DELETED_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_DELIVERY_MODE_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_QUEUE_DIR_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_AMQP_COMMENT_<IDENTIFIER>="<string>"
 
-         set MINIO_NOTIFY_AMQP_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_AMQP_URL_<IDENTIFIER>="<ENDPOINT>"
-         set MINIO_NOTIFY_AMQP_EXCHANGE_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_EXCHANGE_TYPE_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_ROUTING_KEY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_MANDATORY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_DURABLE_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_NO_WAIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_INTERNAL_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_AUTO_DELETED_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_DELIVERY_MODE_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_QUEUE_DIR_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_QUEUE_LIMIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_AMQP_COMMENT_<IDENTIFIER>="<string>"
+      .. cond:: not windows
+
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_AMQP_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_AMQP_URL_<IDENTIFIER>="<ENDPOINT>"
+               export MINIO_NOTIFY_AMQP_EXCHANGE_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_EXCHANGE_TYPE_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_ROUTING_KEY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_MANDATORY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_DURABLE_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_NO_WAIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_INTERNAL_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_AUTO_DELETED_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_DELIVERY_MODE_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_QUEUE_DIR_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_AMQP_COMMENT_<IDENTIFIER>="<string>"
+         
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         AMQP service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -160,7 +183,7 @@ You can configure a new AMQP service endpoint using either environment variables
       <minio-server-config-bucket-notification-amqp>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/administration/monitoring/publish-events-to-elasticsearch.rst
+++ b/source/administration/monitoring/publish-events-to-elasticsearch.rst
@@ -68,19 +68,35 @@ You can configure a new Elasticsearch service endpoint using either environment 
       - :envvar:`MINIO_NOTIFY_ELASTICSEARCH_INDEX`
       - :envvar:`MINIO_NOTIFY_ELASTICSEARCH_FORMAT`
 
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_ELASTICSEARCH_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_ELASTICSEARCH_URL_<IDENTIFIER>="<ENDPOINT>"
+               set MINIO_NOTIFY_ELASTICSEARCH_INDEX_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_ELASTICSEARCH_FORMAT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_ELASTICSEARCH_USERNAME_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_ELASTICSEARCH_PASSWORD_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_ELASTICSEARCH_QUEUE_DIR_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_ELASTICSEARCH_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_ELASTICSEARCH_COMMENT_<IDENTIFIER>="<string>"
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: not windows
 
-         set MINIO_NOTIFY_ELASTICSEARCH_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_ELASTICSEARCH_URL_<IDENTIFIER>="<ENDPOINT>"
-         set MINIO_NOTIFY_ELASTICSEARCH_INDEX_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_ELASTICSEARCH_FORMAT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_ELASTICSEARCH_USERNAME_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_ELASTICSEARCH_PASSWORD_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_ELASTICSEARCH_QUEUE_DIR_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_ELASTICSEARCH_QUEUE_LIMIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_ELASTICSEARCH_COMMENT_<IDENTIFIER>="<string>"
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_ELASTICSEARCH_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_ELASTICSEARCH_URL_<IDENTIFIER>="<ENDPOINT>"
+               export MINIO_NOTIFY_ELASTICSEARCH_INDEX_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_ELASTICSEARCH_FORMAT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_ELASTICSEARCH_USERNAME_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_ELASTICSEARCH_PASSWORD_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_ELASTICSEARCH_QUEUE_DIR_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_ELASTICSEARCH_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_ELASTICSEARCH_COMMENT_<IDENTIFIER>="<string>"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         TARGET service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -150,7 +166,7 @@ You can configure a new Elasticsearch service endpoint using either environment 
       <minio-server-config-bucket-notification-elasticsearch>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/administration/monitoring/publish-events-to-kafka.rst
+++ b/source/administration/monitoring/publish-events-to-kafka.rst
@@ -68,25 +68,49 @@ You can configure a new Kafka service endpoint using either environment variable
       :envvar:`MINIO_NOTIFY_KAFKA_ENABLE` and 
       :envvar:`MINIO_NOTIFY_KAFKA_BROKERS`:
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_KAFKA_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_KAFKA_BROKERS_<IDENTIFIER>="<ENDPOINT>"
+               set MINIO_NOTIFY_KAFKA_TOPIC_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_SASL_USERNAME_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_SASL_PASSWORD_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_SASL_MECHANISM_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_TLS_CLIENT_AUTH_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_SASL_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_TLS_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_CLIENT_TLS_CERT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_CLIENT_TLS_KEY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_QUEUE_DIR_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_VERSION_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_KAFKA_COMMENT_<IDENTIFIER>="<string>"
 
-         set MINIO_NOTIFY_KAFKA_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_KAFKA_BROKERS_<IDENTIFIER>="<ENDPOINT>"
-         set MINIO_NOTIFY_KAFKA_TOPIC_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_SASL_USERNAME_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_SASL_PASSWORD_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_SASL_MECHANISM_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_TLS_CLIENT_AUTH_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_SASL_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_TLS_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_CLIENT_TLS_CERT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_CLIENT_TLS_KEY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_QUEUE_DIR_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_QUEUE_LIMIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_VERSION_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_KAFKA_COMMENT_<IDENTIFIER>="<string>"
+      .. cond:: not windows
+
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_KAFKA_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_KAFKA_BROKERS_<IDENTIFIER>="<ENDPOINT>"
+               export MINIO_NOTIFY_KAFKA_TOPIC_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_SASL_USERNAME_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_SASL_PASSWORD_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_SASL_MECHANISM_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_TLS_CLIENT_AUTH_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_SASL_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_TLS_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_CLIENT_TLS_CERT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_CLIENT_TLS_KEY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_QUEUE_DIR_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_VERSION_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_KAFKA_COMMENT_<IDENTIFIER>="<string>"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         Kafka service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -158,7 +182,7 @@ You can configure a new Kafka service endpoint using either environment variable
       <minio-server-config-bucket-notification-kafka>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/administration/monitoring/publish-events-to-mqtt.rst
+++ b/source/administration/monitoring/publish-events-to-mqtt.rst
@@ -71,20 +71,39 @@ You can configure a new MQTT service endpoint using either environment variables
       - :envvar:`MINIO_NOTIFY_MQTT_USERNAME` *Required if the MQTT server/broker enforces authentication/authorization*
       - :envvar:`MINIO_NOTIFY_MQTT_PASSWORD` *Required if the MQTT server/broker enforces authentication/authorization*
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_MQTT_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_MQTT_BROKER_<IDENTIFIER>="ENDPOINT"
+               set MINIO_NOTIFY_MQTT_TOPIC_<IDENTIFIER>="TOPIC"
+               set MINIO_NOTIFY_MQTT_USERNAME_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_MQTT_PASSWORD_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_MQTT_QOS_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_MQTT_KEEP_ALIVE_INTERVAL_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_MQTT_RECONNECT_INTERVAL_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_MQTT_QUEUE_DIR_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_MQTT_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_MQTT_COMMENT_<IDENTIFIER>="<string>"
 
-         set MINIO_NOTIFY_MQTT_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_MQTT_BROKER_<IDENTIFIER>="ENDPOINT"
-         set MINIO_NOTIFY_MQTT_TOPIC_<IDENTIFIER>="TOPIC"
-         set MINIO_NOTIFY_MQTT_USERNAME_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_MQTT_PASSWORD_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_MQTT_QOS_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_MQTT_KEEP_ALIVE_INTERVAL_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_MQTT_RECONNECT_INTERVAL_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_MQTT_QUEUE_DIR_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_MQTT_QUEUE_LIMIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_MQTT_COMMENT_<IDENTIFIER>="<string>"
+      .. cond:: not windows
+
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_MQTT_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_MQTT_BROKER_<IDENTIFIER>="ENDPOINT"
+               export MINIO_NOTIFY_MQTT_TOPIC_<IDENTIFIER>="TOPIC"
+               export MINIO_NOTIFY_MQTT_USERNAME_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_MQTT_PASSWORD_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_MQTT_QOS_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_MQTT_KEEP_ALIVE_INTERVAL_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_MQTT_RECONNECT_INTERVAL_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_MQTT_QUEUE_DIR_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_MQTT_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_MQTT_COMMENT_<IDENTIFIER>="<string>"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         MQTT service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -163,7 +182,7 @@ You can configure a new MQTT service endpoint using either environment variables
       <minio-server-config-bucket-notification-mqtt>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/administration/monitoring/publish-events-to-mysql.rst
+++ b/source/administration/monitoring/publish-events-to-mysql.rst
@@ -62,18 +62,34 @@ You can configure a new MySQL service endpoint using either environment variable
       - :envvar:`MINIO_NOTIFY_MYSQL_DSN_STRING` 
       - :envvar:`MINIO_NOTIFY_MYSQL_TABLE`
       - :envvar:`MINIO_NOTIFY_MYSQL_FORMAT`
-      
-      .. code-block:: shell
-         :class: copyable
 
-         set MINIO_NOTIFY_MYSQL_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_MYSQL_DSN_STRING_<IDENTIFIER>="user:password@tcp(hostname:port)/database"
-         set MINIO_NOTIFY_MYSQL_TABLE_<IDENTIFIER>="minio-events"
-         set MINIO_NOTIFY_MYSQL_FORMAT_<IDENTIFIER>="namespace|access"
-         set MINIO_NOTIFY_MYSQL_MAX_OPEN_CONNECTIONS_<IDENTIFIER>="2"
-         set MINIO_NOTIFY_MYSQL_QUEUE_DIR_<IDENTIFIER>="/opt/minio/events"
-         set MINIO_NOTIFY_MYSQL_QUEUE_LIMIT_<IDENTIFIER>="100000"
-         set MINIO_NOTIFY_MYSQL_COMMENT_<IDENTIFIER>="MySQL Event Notification Logging for MinIO"
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_MYSQL_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_MYSQL_DSN_STRING_<IDENTIFIER>="user:password@tcp(hostname:port)/database"
+               set MINIO_NOTIFY_MYSQL_TABLE_<IDENTIFIER>="minio-events"
+               set MINIO_NOTIFY_MYSQL_FORMAT_<IDENTIFIER>="namespace|access"
+               set MINIO_NOTIFY_MYSQL_MAX_OPEN_CONNECTIONS_<IDENTIFIER>="2"
+               set MINIO_NOTIFY_MYSQL_QUEUE_DIR_<IDENTIFIER>="/opt/minio/events"
+               set MINIO_NOTIFY_MYSQL_QUEUE_LIMIT_<IDENTIFIER>="100000"
+               set MINIO_NOTIFY_MYSQL_COMMENT_<IDENTIFIER>="MySQL Event Notification Logging for MinIO"
+
+      .. cond:: not windows
+
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_MYSQL_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_MYSQL_DSN_STRING_<IDENTIFIER>="user:password@tcp(hostname:port)/database"
+               export MINIO_NOTIFY_MYSQL_TABLE_<IDENTIFIER>="minio-events"
+               export MINIO_NOTIFY_MYSQL_FORMAT_<IDENTIFIER>="namespace|access"
+               export MINIO_NOTIFY_MYSQL_MAX_OPEN_CONNECTIONS_<IDENTIFIER>="2"
+               export MINIO_NOTIFY_MYSQL_QUEUE_DIR_<IDENTIFIER>="/opt/minio/events"
+               export MINIO_NOTIFY_MYSQL_QUEUE_LIMIT_<IDENTIFIER>="100000"
+               export MINIO_NOTIFY_MYSQL_COMMENT_<IDENTIFIER>="MySQL Event Notification Logging for MinIO"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         MySQL service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -151,7 +167,7 @@ You can configure a new MySQL service endpoint using either environment variable
       <minio-server-config-bucket-notification-mysql>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/administration/monitoring/publish-events-to-nats.rst
+++ b/source/administration/monitoring/publish-events-to-nats.rst
@@ -52,25 +52,49 @@ You can configure a new NATS service endpoint using either environment variables
       The following example code sets *all*  environment variables related to configuring an NATS service endpoint. 
       The minimum *required* variables are :envvar:`MINIO_NOTIFY_NATS_ADDRESS` and :envvar:`MINIO_NOTIFY_NATS_SUBJECT`:
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_NATS_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_NATS_ADDRESS_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_SUBJECT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_USERNAME_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_PASSWORD_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_TOKEN_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_TLS_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_PING_INTERVAL_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_QUEUE_DIR_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_CERT_AUTHORITY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_CLIENT_CERT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_CLIENT_KEY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_COMMENT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NATS_JETSTREAM_<IDENTIFIER>="<string>"
 
-         set MINIO_NOTIFY_NATS_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_NATS_ADDRESS_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_SUBJECT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_USERNAME_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_PASSWORD_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_TOKEN_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_TLS_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_PING_INTERVAL_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_QUEUE_DIR_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_QUEUE_LIMIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_CERT_AUTHORITY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_CLIENT_CERT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_CLIENT_KEY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_COMMENT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NATS_JETSTREAM_<IDENTIFIER>="<string>"
+      .. cond:: not windows
+
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_NATS_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_NATS_ADDRESS_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_SUBJECT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_USERNAME_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_PASSWORD_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_TOKEN_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_TLS_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_PING_INTERVAL_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_QUEUE_DIR_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_CERT_AUTHORITY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_CLIENT_CERT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_CLIENT_KEY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_COMMENT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NATS_JETSTREAM_<IDENTIFIER>="<string>"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the NATS service endpoint. 
         Use the same ``<IDENTIFIER>`` value for all environment variables related to the new target service endpoint.

--- a/source/administration/monitoring/publish-events-to-nsq.rst
+++ b/source/administration/monitoring/publish-events-to-nsq.rst
@@ -55,18 +55,33 @@ You can configure a new NSQ service endpoint using either environment variables
       :envvar:`MINIO_NOTIFY_NSQ_NSQD_ADDRESS` and 
       :envvar:`MINIO_NOTIFY_NSQ_TOPIC`:
 
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_NSQ_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_NSQ_NSQD_ADDRESS_<IDENTIFIER>="<ENDPOINT>"
+               set MINIO_NOTIFY_NSQ_TOPIC_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NSQ_TLS_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NSQ_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NSQ_QUEUE_DIR_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NSQ_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_NSQ_COMMENT_<IDENTIFIER>="<string>"
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: not windows
 
-         set MINIO_NOTIFY_NSQ_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_NSQ_NSQD_ADDRESS_<IDENTIFIER>="<ENDPOINT>"
-         set MINIO_NOTIFY_NSQ_TOPIC_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NSQ_TLS_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NSQ_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NSQ_QUEUE_DIR_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NSQ_QUEUE_LIMIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_NSQ_COMMENT_<IDENTIFIER>="<string>"
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_NSQ_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_NSQ_NSQD_ADDRESS_<IDENTIFIER>="<ENDPOINT>"
+               export MINIO_NOTIFY_NSQ_TOPIC_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NSQ_TLS_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NSQ_TLS_SKIP_VERIFY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NSQ_QUEUE_DIR_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NSQ_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_NSQ_COMMENT_<IDENTIFIER>="<string>"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         TARGET service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -131,7 +146,7 @@ You can configure a new NSQ service endpoint using either environment variables
       <minio-server-config-bucket-notification-nsq>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/administration/monitoring/publish-events-to-postgresql.rst
+++ b/source/administration/monitoring/publish-events-to-postgresql.rst
@@ -65,18 +65,33 @@ variables *or* by setting runtime configuration settings.
       - :envvar:`MINIO_NOTIFY_POSTGRES_TABLE`
       - :envvar:`MINIO_NOTIFY_POSTGRES_FORMAT`
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_POSTGRES_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_<IDENTIFIER>="host=postgresql-endpoint.example.net port=4222"
+               set MINIO_NOTIFY_POSTGRES_TABLE_<IDENTIFIER>="minioevents"
+               set MINIO_NOTIFY_POSTGRES_FORMAT_<IDENTIFIER>="namespace|access"
+               set MINIO_NOTIFY_POSTGRES_MAX_OPEN_CONNECTIONS_<IDENTIFIER>="2"
+               set MINIO_NOTIFY_POSTGRES_QUEUE_DIR_<IDENTIFIER>="/opt/minio/events"
+               set MINIO_NOTIFY_POSTGRES_QUEUE_LIMIT_<IDENTIFIER>="100000"
+               set MINIO_NOTIFY_POSTGRES_COMMENT_<IDENTIFIER>="PostgreSQL Notification Event Logging for MinIO"
 
-         set MINIO_NOTIFY_POSTGRES_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_<IDENTIFIER>="host=postgresql-endpoint.example.net port=4222"
-         set MINIO_NOTIFY_POSTGRES_TABLE_<IDENTIFIER>="minioevents"
-         set MINIO_NOTIFY_POSTGRES_FORMAT_<IDENTIFIER>="namespace|access"
-         set MINIO_NOTIFY_POSTGRES_MAX_OPEN_CONNECTIONS_<IDENTIFIER>="2"
-         set MINIO_NOTIFY_POSTGRES_QUEUE_DIR_<IDENTIFIER>="/opt/minio/events"
-         set MINIO_NOTIFY_POSTGRES_QUEUE_LIMIT_<IDENTIFIER>="100000"
-         set MINIO_NOTIFY_POSTGRES_COMMENT_<IDENTIFIER>="PostgreSQL Notification Event Logging for MinIO"
+      .. cond:: not windows
 
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_POSTGRES_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_<IDENTIFIER>="host=postgresql-endpoint.example.net port=4222"
+               export MINIO_NOTIFY_POSTGRES_TABLE_<IDENTIFIER>="minioevents"
+               export MINIO_NOTIFY_POSTGRES_FORMAT_<IDENTIFIER>="namespace|access"
+               export MINIO_NOTIFY_POSTGRES_MAX_OPEN_CONNECTIONS_<IDENTIFIER>="2"
+               export MINIO_NOTIFY_POSTGRES_QUEUE_DIR_<IDENTIFIER>="/opt/minio/events"
+               export MINIO_NOTIFY_POSTGRES_QUEUE_LIMIT_<IDENTIFIER>="100000"
+               export MINIO_NOTIFY_POSTGRES_COMMENT_<IDENTIFIER>="PostgreSQL Notification Event Logging for MinIO"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         PostgreSQL service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -154,7 +169,7 @@ variables *or* by setting runtime configuration settings.
       <minio-server-config-bucket-notification-postgresql>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/administration/monitoring/publish-events-to-redis.rst
+++ b/source/administration/monitoring/publish-events-to-redis.rst
@@ -58,17 +58,33 @@ You can configure a new Redis service endpoint using either environment variable
       - :envvar:`MINIO_NOTIFY_REDIS_KEY` 
       - :envvar:`MINIO_NOTIFY_REDIS_FORMAT`
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_REDIS_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_REDIS_ADDRESS_<IDENTIFIER>="<ENDPOINT>"
+               set MINIO_NOTIFY_REDIS_KEY_<IDENTIFIER>="<STRING>"
+               set MINIO_NOTIFY_REDIS_FORMAT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_REDIS_PASSWORD_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_REDIS_QUEUE_DIR_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_REDIS_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_REDIS_COMMENT_<IDENTIFIER>="<string>"
 
-         set MINIO_NOTIFY_REDIS_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_REDIS_ADDRESS_<IDENTIFIER>="<ENDPOINT>"
-         set MINIO_NOTIFY_REDIS_KEY_<IDENTIFIER>="<STRING>"
-         set MINIO_NOTIFY_REDIS_FORMAT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_REDIS_PASSWORD_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_REDIS_QUEUE_DIR_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_REDIS_QUEUE_LIMIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_REDIS_COMMENT_<IDENTIFIER>="<string>"
+      .. cond:: not windows
+
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_REDIS_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_REDIS_ADDRESS_<IDENTIFIER>="<ENDPOINT>"
+               export MINIO_NOTIFY_REDIS_KEY_<IDENTIFIER>="<STRING>"
+               export MINIO_NOTIFY_REDIS_FORMAT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_REDIS_PASSWORD_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_REDIS_QUEUE_DIR_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_REDIS_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_REDIS_COMMENT_<IDENTIFIER>="<string>"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         TARGET service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -133,7 +149,7 @@ You can configure a new Redis service endpoint using either environment variable
       <minio-server-config-bucket-notification-redis>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/administration/monitoring/publish-events-to-webhook.rst
+++ b/source/administration/monitoring/publish-events-to-webhook.rst
@@ -55,18 +55,33 @@ variables *or* by setting runtime configuration settings.
       :envvar:`MINIO_NOTIFY_WEBHOOK_ENABLE` and 
       :envvar:`MINIO_NOTIFY_WEBHOOK_ENDPOINT`:
 
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_NOTIFY_WEBHOOK_ENABLE_<IDENTIFIER>="on"
+               set MINIO_NOTIFY_WEBHOOK_ENDPOINT_<IDENTIFIER>="ENDPOINT"
+               set MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_WEBHOOK_QUEUE_DIR_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_WEBHOOK_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_WEBHOOK_CLIENT_CERT_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_WEBHOOK_CLIENT_KEY_<IDENTIFIER>="<string>"
+               set MINIO_NOTIFY_WEBHOOK_COMMENT_<IDENTIFIER>="<string>"
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: not windows
 
-         set MINIO_NOTIFY_WEBHOOK_ENABLE_<IDENTIFIER>="on"
-         set MINIO_NOTIFY_WEBHOOK_ENDPOINT_<IDENTIFIER>="ENDPOINT"
-         set MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_WEBHOOK_QUEUE_DIR_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_WEBHOOK_QUEUE_LIMIT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_WEBHOOK_CLIENT_CERT_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_WEBHOOK_CLIENT_KEY_<IDENTIFIER>="<string>"
-         set MINIO_NOTIFY_WEBHOOK_COMMENT_<IDENTIFIER>="<string>"
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_NOTIFY_WEBHOOK_ENABLE_<IDENTIFIER>="on"
+               export MINIO_NOTIFY_WEBHOOK_ENDPOINT_<IDENTIFIER>="ENDPOINT"
+               export MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_WEBHOOK_QUEUE_DIR_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_WEBHOOK_QUEUE_LIMIT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_WEBHOOK_CLIENT_CERT_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_WEBHOOK_CLIENT_KEY_<IDENTIFIER>="<string>"
+               export MINIO_NOTIFY_WEBHOOK_COMMENT_<IDENTIFIER>="<string>"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the
         Webhook service endpoint. Use the same ``<IDENTIFIER>`` value for all 
@@ -131,7 +146,7 @@ variables *or* by setting runtime configuration settings.
       <minio-server-config-bucket-notification-webhook>` for complete 
       documentation on each setting.
 
-2) Restart the MinIO Deployment
+1) Restart the MinIO Deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You must restart the MinIO deployment to apply the configuration changes. 

--- a/source/operations/monitoring/minio-logging.rst
+++ b/source/operations/monitoring/minio-logging.rst
@@ -56,12 +56,23 @@ runtime configuration settings.
       - :envvar:`MINIO_LOGGER_WEBHOOK_ENABLE`
       - :envvar:`MINIO_LOGGER_WEBHOOK_ENDPOINT`
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
+         
+               set MINIO_LOGGER_WEBHOOK_ENABLE_<IDENTIFIER>="on"
+               set MINIO_LOGGER_WEBHOOK_ENDPOINT_<IDENTIFIER>="https://webhook-1.example.net"
+               set MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="TOKEN"
 
-         set MINIO_LOGGER_WEBHOOK_ENABLE_<IDENTIFIER>="on"
-         set MINIO_LOGGER_WEBHOOK_ENDPOINT_<IDENTIFIER>="https://webhook-1.example.net"
-         set MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="TOKEN"
+      .. cond:: not windows
+
+         .. code-block:: shell
+            :class: copyable
+
+               export MINIO_LOGGER_WEBHOOK_ENABLE_<IDENTIFIER>="on"
+               export MINIO_LOGGER_WEBHOOK_ENDPOINT_<IDENTIFIER>="https://webhook-1.example.net"
+               export MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="TOKEN"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the 
         HTTP webhook endpoint. Use the same ``<IDENTIFIER>`` for all environment
@@ -83,16 +94,32 @@ runtime configuration settings.
 
         For example: for a Bearer token, prepend ``Bearer``:
 
-        .. code-block:: shell
+        .. cond:: windows
+        
+           .. code-block:: shell
 
-           set MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
+              set MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
+
+        .. cond:: not windows
+        
+           .. code-block:: shell
+
+              export MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
 
         Modify the value according to the endpoint requirements.
         A custom authentication format could resemble the following:
 
-        .. code-block:: shell
+        .. cond:: windows
+        
+           .. code-block:: shell
 
-           set MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
+              set MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
+        
+        .. cond:: not windows
+        
+           .. code-block:: shell
+
+              export MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
 
         Consult the documenation for the desired service for more details.
 
@@ -181,14 +208,27 @@ settings:
       - :envvar:`MINIO_AUDIT_WEBHOOK_ENABLE`
       - :envvar:`MINIO_AUDIT_WEBHOOK_ENDPOINT`
 
-      .. code-block:: shell
-         :class: copyable
+      .. cond:: windows
+      
+         .. code-block:: shell
+            :class: copyable
 
-         set MINIO_AUDIT_WEBHOOK_ENABLE_<IDENTIFIER>="on"
-         set MINIO_AUDIT_WEBHOOK_ENDPOINT_<IDENTIFIER>="https://webhook-1.example.net"
-         set MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="TOKEN"
-         set MINIO_AUDIT_WEBHOOK_CLIENT_CERT_<IDENTIFIER>="cert.pem"
-         set MINIO_AUDIT_WEBHOOK_CLIENT_KEY_<IDENTIFIER>="cert.key"
+            set MINIO_AUDIT_WEBHOOK_ENABLE_<IDENTIFIER>="on"
+            set MINIO_AUDIT_WEBHOOK_ENDPOINT_<IDENTIFIER>="https://webhook-1.example.net"
+            set MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="TOKEN"
+            set MINIO_AUDIT_WEBHOOK_CLIENT_CERT_<IDENTIFIER>="cert.pem"
+            set MINIO_AUDIT_WEBHOOK_CLIENT_KEY_<IDENTIFIER>="cert.key"
+
+      .. cond:: not windows
+      
+         .. code-block:: shell
+            :class: copyable
+
+            export MINIO_AUDIT_WEBHOOK_ENABLE_<IDENTIFIER>="on"
+            export MINIO_AUDIT_WEBHOOK_ENDPOINT_<IDENTIFIER>="https://webhook-1.example.net"
+            export MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_<IDENTIFIER>="TOKEN"
+            export MINIO_AUDIT_WEBHOOK_CLIENT_CERT_<IDENTIFIER>="cert.pem"
+            export MINIO_AUDIT_WEBHOOK_CLIENT_KEY_<IDENTIFIER>="cert.key"
 
       - Replace ``<IDENTIFIER>`` with a unique descriptive string for the 
         HTTP webhook endpoint. Use the same ``<IDENTIFIER>`` for all environment
@@ -210,16 +250,32 @@ settings:
 
         For example: for a Bearer token, prepend ``Bearer``:
 
-        .. code-block:: shell
+        .. cond:: windows
+        
+           .. code-block:: shell
 
-           set MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
+              set MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
+
+        .. cond:: not windows
+        
+           .. code-block:: shell
+
+              export MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
 
         Modify the value according to the endpoint requirements.
         A custom authentication format could resemble the following:
 
-        .. code-block:: shell
+        .. cond:: windows
+        
+           .. code-block:: shell
 
-           set MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
+              set MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
+
+        .. cond:: not windows
+        
+           .. code-block:: shell
+
+              export MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
 
         Consult the documenation for the desired service for more details.
 

--- a/source/reference/minio-server/settings/console.rst
+++ b/source/reference/minio-server/settings/console.rst
@@ -175,8 +175,9 @@ Defaults to ``default-src 'self' 'unsafe-eval' 'unsafe-inline';``
          .. code-block:: shell
             :class: copyable
 
-            set MINIO_BROWSER_CONTENT_SECURITY_POLICY="default-src 'self' 'unsafe-eval' 'unsafe-inline';"
+            export MINIO_BROWSER_CONTENT_SECURITY_POLICY="default-src 'self' 'unsafe-eval' 'unsafe-inline';"
 
+            
    .. tab-item:: Configuration Setting
       :sync: config
 
@@ -215,7 +216,7 @@ Other HSTS settings are optional.
          .. code-block:: shell
             :class: copyable
 
-            set MINIO_BROWSER_HSTS_SECONDS=31536000
+            export MINIO_BROWSER_HSTS_SECONDS=31536000            
 
       .. envvar:: MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS
 
@@ -225,7 +226,7 @@ Other HSTS settings are optional.
          .. code-block:: shell
             :class: copyable
 
-            set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
+            export MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
 
       .. envvar:: MINIO_BROWSER_HSTS_PRELOAD
 
@@ -235,7 +236,7 @@ Other HSTS settings are optional.
          .. code-block:: shell
             :class: copyable
 
-            set MINIO_BROWSER_HSTS_INCLUDE_SUB_DOMAINS="on"
+            export MINIO_BROWSER_HSTS_PRELOAD="on"
 
    .. tab-item:: Configuration Settings
       :sync: config
@@ -348,7 +349,7 @@ Defaults to ``strict-origin-when-cross-origin``.
          .. code-block:: shell
             :class: copyable
 
-            set MINIO_BROWSER_REFERRER_POLICY="strict-origin-when-cross-origin"
+            export MINIO_BROWSER_REFERRER_POLICY="strict-origin-when-cross-origin"
 
    .. tab-item:: Configuration Setting
       :sync: config

--- a/source/reference/minio-server/settings/metrics-and-logging.rst
+++ b/source/reference/minio-server/settings/metrics-and-logging.rst
@@ -163,7 +163,7 @@ Auth Token
       .. code-block:: shell
          :class: copyable
    
-         set MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
+         export MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
    
       Modify the value according to the endpoint requirements.
       A custom authentication format could resemble the following:
@@ -171,7 +171,7 @@ Auth Token
       .. code-block:: shell
          :class: copyable
    
-         set MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
+         export MINIO_LOGGER_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
    
       Consult the documentation for the desired service for more details.
    
@@ -489,7 +489,7 @@ Depending on the endpoint, you may need to include additional information.
       .. code-block:: shell
          :class: copyable
 
-         set MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
+         export MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
 
       Modify the value according to the endpoint requirements.
       
@@ -498,7 +498,7 @@ Depending on the endpoint, you may need to include additional information.
       .. code-block:: shell
          :class: copyable
 
-         set MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
+         export MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
 
    .. tab-item:: Configuration Setting
       :sync: config

--- a/source/reference/minio-server/settings/notifications/amqp.rst
+++ b/source/reference/minio-server/settings/notifications/amqp.rst
@@ -40,11 +40,11 @@ For example, the following commands set two distinct AMQP service endpoints as `
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_AMQP_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_AMQP_URL_PRIMARY="amqp://user:password@amqp-endpoint.example.net:5672"
+         export MINIO_NOTIFY_AMQP_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_AMQP_URL_PRIMARY="amqp://user:password@amqp-endpoint.example.net:5672"
       
-         set MINIO_NOTIFY_AMQP_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_AMQP_URL_SECONDARY="amqp://user:password@amqp-endpoint.example.net:5672"
+         export MINIO_NOTIFY_AMQP_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_AMQP_URL_SECONDARY="amqp://user:password@amqp-endpoint.example.net:5672"
    
       For example, :envvar:`MINIO_NOTIFY_AMQP_ENABLE_PRIMARY <MINIO_NOTIFY_AMQP_ENABLE>` indicates the environment variable is associated to an AMQP service endpoint with ID of ``PRIMARY``.
    

--- a/source/reference/minio-server/settings/notifications/elasticsearch.rst
+++ b/source/reference/minio-server/settings/notifications/elasticsearch.rst
@@ -39,15 +39,15 @@ Examples
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_ELASTICSEARCH_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_ELASTICSEARCH_URL_PRIMARY="https://user:password@elasticsearch-endpoint.example.net:9200"
-         set MINIO_NOTIFY_ELASTICSEARCH_INDEX_PRIMARY="bucketevents"
-         set MINIO_NOTIFY_ELASTICSEARCH_FORMAT_PRIMARY="namespace"
+         export MINIO_NOTIFY_ELASTICSEARCH_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_ELASTICSEARCH_URL_PRIMARY="https://user:password@elasticsearch-endpoint.example.net:9200"
+         export MINIO_NOTIFY_ELASTICSEARCH_INDEX_PRIMARY="bucketevents"
+         export MINIO_NOTIFY_ELASTICSEARCH_FORMAT_PRIMARY="namespace"
       
-         set MINIO_NOTIFY_ELASTICSEARCH_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_ELASTICSEARCH_URL_SECONDARY="https://user:password@elasticsearch-endpoint.example.net:9200"
-         set MINIO_NOTIFY_ELASTICSEARCH_INDEX_SECONDARY="bucketevents"
-         set MINIO_NOTIFY_ELASTICSEARCH_FORMAT_SECONDARY="namespace"
+         export MINIO_NOTIFY_ELASTICSEARCH_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_ELASTICSEARCH_URL_SECONDARY="https://user:password@elasticsearch-endpoint.example.net:9200"
+         export MINIO_NOTIFY_ELASTICSEARCH_INDEX_SECONDARY="bucketevents"
+         export MINIO_NOTIFY_ELASTICSEARCH_FORMAT_SECONDARY="namespace"
 
    .. tab-item:: Configuration Settings
       :sync: config

--- a/source/reference/minio-server/settings/notifications/kafka.rst
+++ b/source/reference/minio-server/settings/notifications/kafka.rst
@@ -40,11 +40,11 @@ For example, the following commands set two distinct Kafka service endpoints as 
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_KAFKA_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_KAFKA_BROKERS_PRIMARY="https://kafka1.example.net:9200, https://kafka2.example.net:9200"
+         export MINIO_NOTIFY_KAFKA_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_KAFKA_BROKERS_PRIMARY="https://kafka1.example.net:9200, https://kafka2.example.net:9200"
       
-         set MINIO_NOTIFY_KAFKA_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_KAFKA_BROKERS_SECONDARY="https://kafka1.example.net:9200, https://kafka2.example.net:9200"
+         export MINIO_NOTIFY_KAFKA_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_KAFKA_BROKERS_SECONDARY="https://kafka1.example.net:9200, https://kafka2.example.net:9200"
 
    .. tab-item:: Configuration Setting
       :sync: config

--- a/source/reference/minio-server/settings/notifications/mqtt.rst
+++ b/source/reference/minio-server/settings/notifications/mqtt.rst
@@ -36,11 +36,11 @@ For example, the following commands set two distinct MQTT service endpoints as `
       .. code-block:: shell
          :class: copyable
    
-         set MINIO_NOTIFY_MQTT_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_MQTT_BROKER_PRIMARY="tcp://user:password@mqtt-endpoint.example.net:1883"
+         export MINIO_NOTIFY_MQTT_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_MQTT_BROKER_PRIMARY="tcp://user:password@mqtt-endpoint.example.net:1883"
    
-         set MINIO_NOTIFY_MQTT_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_MQTT_BROKER_SECONDARY="tcp://user:password@mqtt-endpoint.example.net:1883"
+         export MINIO_NOTIFY_MQTT_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_MQTT_BROKER_SECONDARY="tcp://user:password@mqtt-endpoint.example.net:1883"
 
    .. tab-item:: Configuration Setting
       :sync: config

--- a/source/reference/minio-server/settings/notifications/mysql.rst
+++ b/source/reference/minio-server/settings/notifications/mysql.rst
@@ -40,15 +40,15 @@ The following commands set two distinct MySQL service endpoints as ``PRIMARY`` a
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_MYSQL_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_MYSQL_DSN_STRING_PRIMARY="username:password@tcp(mysql.example.com:3306)/miniodb"
-         set MINIO_NOTIFY_MYSQL_TABLE_PRIMARY="minioevents"
-         set MINIO_NOTIFY_MYSQL_FORMAT_PRIMARY="namespace"
+         export MINIO_NOTIFY_MYSQL_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_MYSQL_DSN_STRING_PRIMARY="username:password@tcp(mysql.example.com:3306)/miniodb"
+         export MINIO_NOTIFY_MYSQL_TABLE_PRIMARY="minioevents"
+         export MINIO_NOTIFY_MYSQL_FORMAT_PRIMARY="namespace"
       
-         set MINIO_NOTIFY_MYSQL_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_MYSQL_DSN_STRING_SECONDARY="username:password@tcp(mysql.example.com:3306)/miniodb"
-         set MINIO_NOTIFY_MYSQL_TABLE_SECONDARY="minioevents"
-         set MINIO_NOTIFY_MYSQL_FORMAT_SECONDARY="namespace"
+         export MINIO_NOTIFY_MYSQL_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_MYSQL_DSN_STRING_SECONDARY="username:password@tcp(mysql.example.com:3306)/miniodb"
+         export MINIO_NOTIFY_MYSQL_TABLE_SECONDARY="minioevents"
+         export MINIO_NOTIFY_MYSQL_FORMAT_SECONDARY="namespace"
 
       With these settings, :envvar:`MINIO_NOTIFY_MYSQL_ENABLE_PRIMARY <MINIO_NOTIFY_MYSQL_ENABLE>` indicates the environment variable is associated to a MySQL service endpoint with ID of ``PRIMARY``.
 

--- a/source/reference/minio-server/settings/notifications/nats.rst
+++ b/source/reference/minio-server/settings/notifications/nats.rst
@@ -48,11 +48,11 @@ For example, the following commands set two distinct NATS service endpoints as `
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_NATS_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_NATS_ADDRESS_PRIMARY="nats-endpoint.example.net:4222"
+         export MINIO_NOTIFY_NATS_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_NATS_ADDRESS_PRIMARY="nats-endpoint.example.net:4222"
 
-         set MINIO_NOTIFY_NATS_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_NATS_ADDRESS_SECONDARY="nats-endpoint.example.net:4222"
+         export MINIO_NOTIFY_NATS_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_NATS_ADDRESS_SECONDARY="nats-endpoint.example.net:4222"
 
       With these settings, :envvar:`MINIO_NOTIFY_NATS_ENABLE_PRIMARY <MINIO_NOTIFY_NATS_ENABLE>` indicates the environment variable is associated to an NATS service endpoint with ID of ``PRIMARY``.
 

--- a/source/reference/minio-server/settings/notifications/nsq.rst
+++ b/source/reference/minio-server/settings/notifications/nsq.rst
@@ -36,13 +36,13 @@ For example, the following commands set two distinct NSQ service endpoints as ``
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_NSQ_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_NSQ_NSQD_ADDRESS_PRIMARY="https://user:password@nsq-endpoint.example.net:9200"
-         set MINIO_NOTIFY_NSQ_TOPIC_PRIMARY="bucketevents"
+         export MINIO_NOTIFY_NSQ_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_NSQ_NSQD_ADDRESS_PRIMARY="https://user:password@nsq-endpoint.example.net:9200"
+         export MINIO_NOTIFY_NSQ_TOPIC_PRIMARY="bucketevents"
       
-         set MINIO_NOTIFY_NSQ_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_NSQ_NSQD_ADDRESS_SECONDARY="https://user:password@nsq-endpoint.example.net:9200"
-         set MINIO_NOTIFY_NSQ_TOPIC_SECONDARY="bucketevents"
+         export MINIO_NOTIFY_NSQ_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_NSQ_NSQD_ADDRESS_SECONDARY="https://user:password@nsq-endpoint.example.net:9200"
+         export MINIO_NOTIFY_NSQ_TOPIC_SECONDARY="bucketevents"
 
    .. tab-item:: Configuration Settings
       :sync: config

--- a/source/reference/minio-server/settings/notifications/postgresql.rst
+++ b/source/reference/minio-server/settings/notifications/postgresql.rst
@@ -36,15 +36,15 @@ For example, the following commands set two distinct PostgreSQL service endpoint
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_POSTGRES_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_PRIMARY="host=postgresql-endpoint.example.net port=4222..."
-         set MINIO_NOTIFY_POSTGRES_TABLE_PRIMARY="minioevents"
-         set MINIO_NOTIFY_POSTGRES_FORMAT_PRIMARY="namespace"
+         export MINIO_NOTIFY_POSTGRES_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_PRIMARY="host=postgresql-endpoint.example.net port=4222..."
+         export MINIO_NOTIFY_POSTGRES_TABLE_PRIMARY="minioevents"
+         export MINIO_NOTIFY_POSTGRES_FORMAT_PRIMARY="namespace"
       
-         set MINIO_NOTIFY_POSTGRES_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_SECONDARY="host=postgresql-endpoint.example.net port=4222..."
-         set MINIO_NOTIFY_POSTGRES_TABLE_SECONDARY="minioevents"
-         set MINIO_NOTIFY_POSTGRES_FORMAT_SECONDARY="namespace"
+         export MINIO_NOTIFY_POSTGRES_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_POSTGRES_CONNECTION_STRING_SECONDARY="host=postgresql-endpoint.example.net port=4222..."
+         export MINIO_NOTIFY_POSTGRES_TABLE_SECONDARY="minioevents"
+         export MINIO_NOTIFY_POSTGRES_FORMAT_SECONDARY="namespace"
 
    .. tab-item:: Configuration Settings
       :sync: config

--- a/source/reference/minio-server/settings/notifications/redis.rst
+++ b/source/reference/minio-server/settings/notifications/redis.rst
@@ -36,16 +36,16 @@ For example, the following commands set two distinct Redis service endpoints as 
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_REDIS_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_REDIS_ADDRESS_PRIMARY="redis-endpoint.example.net:9200"
-         set MINIO_NOTIFY_REDIS_KEY_PRIMARY="bucketevents"
-         set MINIO_NOTIFY_REDIS_FORMAT_PRIMARY="namespace"
+         export MINIO_NOTIFY_REDIS_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_REDIS_ADDRESS_PRIMARY="redis-endpoint.example.net:9200"
+         export MINIO_NOTIFY_REDIS_KEY_PRIMARY="bucketevents"
+         export MINIO_NOTIFY_REDIS_FORMAT_PRIMARY="namespace"
       
       
-         set MINIO_NOTIFY_REDIS_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_REDIS_REDIS_ADDRESS_SECONDARY="redis-endpoint2.example.net:9200"
-         set MINIO_NOTIFY_REDIS_KEY_SECONDARY="bucketevents"
-         set MINIO_NOTIFY_REDIS_FORMAT_SECONDARY="namespace"
+         export MINIO_NOTIFY_REDIS_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_REDIS_REDIS_ADDRESS_SECONDARY="redis-endpoint2.example.net:9200"
+         export MINIO_NOTIFY_REDIS_KEY_SECONDARY="bucketevents"
+         export MINIO_NOTIFY_REDIS_FORMAT_SECONDARY="namespace"
 
    .. tab-item:: Configuration Settings
       :sync: config

--- a/source/reference/minio-server/settings/notifications/webhook-service.rst
+++ b/source/reference/minio-server/settings/notifications/webhook-service.rst
@@ -37,11 +37,11 @@ For example, the following commands set two distinct Webhook service endpoints a
       .. code-block:: shell
          :class: copyable
       
-         set MINIO_NOTIFY_WEBHOOK_ENABLE_PRIMARY="on"
-         set MINIO_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY="https://webhook1.example.net"
+         export MINIO_NOTIFY_WEBHOOK_ENABLE_PRIMARY="on"
+         export MINIO_NOTIFY_WEBHOOK_ENDPOINT_PRIMARY="https://webhook1.example.net"
       
-         set MINIO_NOTIFY_WEBHOOK_ENABLE_SECONDARY="on"
-         set MINIO_NOTIFY_WEBHOOK_ENDPOINT_SECONDARY="https://webhook1.example.net"
+         export MINIO_NOTIFY_WEBHOOK_ENABLE_SECONDARY="on"
+         export MINIO_NOTIFY_WEBHOOK_ENDPOINT_SECONDARY="https://webhook1.example.net"
 
    .. tab-item:: Configuration Settings
       :sync: config
@@ -140,7 +140,7 @@ Auth Token
       .. code-block:: shell
          :class: copyable
    
-         set MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
+         export MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_myendpoint="Bearer 1a2b3c4f5e"
    
       Modify the value according to the endpoint requirements.
       A custom authentication format could resemble the following:
@@ -148,7 +148,7 @@ Auth Token
       .. code-block:: shell
          :class: copyable
    
-         set MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
+         export MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN_xyz="ServiceXYZ 1a2b3c4f5e"
    
       Consult the documentation for the desired service for more details.
 


### PR DESCRIPTION
Fixes #1404 

Two sets of fixes:

- add conditionals for windows and linux where shared
- search/replace for linux only (MinIO Server reference pages)

Staging server not available, tested/checked locally
