### PR TITLE
Install page quickstarts generated multiple H1s

### DIFF
--- a/source/includes/container/quickstart.rst
+++ b/source/includes/container/quickstart.rst
@@ -1,19 +1,5 @@
 .. _quickstart-container:
 
-=========================
-Quickstart for Containers
-=========================
-
-.. default-domain:: minio
-
-.. container:: extlinks-video
-
-   - `Installing and Running MinIO on Docker: Overview <https://youtu.be/mg9NRR6Js1s?ref=docs>`__
-   - `Installing and Running MinIO on Docker: Installation Lab <https://youtu.be/Z0FtabDUPtU?ref=docs>`__
-   - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
-   
-   - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
-
 .. |OS| replace:: Docker or Podman
 
 This procedure deploys a :ref:`Single-Node Single-Drive <minio-installation-comparison>` MinIO server onto |OS| for early development and evaluation of MinIO Object Storage and its S3-compatible API layer. 

--- a/source/includes/k8s/quickstart.rst
+++ b/source/includes/k8s/quickstart.rst
@@ -1,17 +1,5 @@
 .. _quickstart-kubernetes:
 
-================================
-Quickstart: MinIO for Kubernetes
-================================
-
-.. default-domain:: minio
-
-.. container:: extlinks-video
-
-   - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
-   
-   - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
-
 .. |OS| replace:: Kubernetes
 
 This procedure deploys a Single-Node Single-Drive MinIO server onto |OS| for early development and evaluation of MinIO Object Storage and its S3-compatible API layer. 

--- a/source/includes/linux/quickstart.rst
+++ b/source/includes/linux/quickstart.rst
@@ -1,19 +1,5 @@
 .. _quickstart-linux:
 
-===========================
-Quickstart: MinIO for Linux
-===========================
-
-.. default-domain:: minio
-
-.. container:: extlinks-video
-
-   - `Installing and Running MinIO on Linux <https://www.youtube.com/watch?v=74usXkZpNt8&list=PLFOIsHSSYIK1BnzVY66pCL-iJ30Ht9t1o>`__
-
-   - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
-   
-   - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
-
 .. |OS| replace:: Linux
 
 This procedure deploys a :ref:`Standalone <minio-installation-comparison>` MinIO server onto |OS| for early development and evaluation of MinIO Object Storage and its S3-compatible API layer. 

--- a/source/includes/macos/quickstart.rst
+++ b/source/includes/macos/quickstart.rst
@@ -1,17 +1,5 @@
 .. _quickstart-macos:
 
-=============================
-Quickstart: MinIO for Mac OSX
-=============================
-
-.. default-domain:: minio
-
-.. container:: extlinks-video
-
-   - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
-   
-   - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
-
 .. |OS| replace:: MacOS
 
 This procedure deploys a :ref:`Single-Node Single-Drive <minio-installation-comparison>` MinIO server onto |OS| for early development and evaluation of MinIO Object Storage and its S3-compatible API layer.

--- a/source/includes/windows/common-minio-kes.rst
+++ b/source/includes/windows/common-minio-kes.rst
@@ -115,7 +115,7 @@ This command assumes the ``minio-kes.cert``, ``minio-kes.key``, and ``kes-server
    - The documentation on this site uses API keys.
 
    .. code-block:: shell
-      :substitions:
+      :substitutions:
 
       MINIO_KMS_KES_CERT_FILE=|miniocertpath|\minio-kes.cert
       MINIO_KMS_KES_KEY_FILE=|miniocertpath|\minio-kes.key

--- a/source/includes/windows/quickstart.rst
+++ b/source/includes/windows/quickstart.rst
@@ -1,18 +1,5 @@
 .. _quickstart-windows:
 
-=============================
-Quickstart: MinIO for Windows
-=============================
-
-.. default-domain:: minio
-
-.. container:: extlinks-video
-
-   - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
-   
-   - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
-
-
 .. |OS| replace:: Windows
 
 This procedure deploys a :ref:`Single-Node Single-Drive <minio-installation-comparison>` MinIO server onto |OS| for early development and evaluation of MinIO Object Storage and its S3-compatible API layer. 

--- a/source/index.rst
+++ b/source/index.rst
@@ -4,6 +4,50 @@ MinIO Object Storage for |platform|
 
 .. default-domain:: minio
 
+.. cond:: container
+
+   .. container:: extlinks-video
+
+      - `Installing and Running MinIO on Docker: Overview <https://youtu.be/mg9NRR6Js1s?ref=docs>`__
+      - `Installing and Running MinIO on Docker: Installation Lab <https://youtu.be/Z0FtabDUPtU?ref=docs>`__
+      - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
+      
+      - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
+
+.. cond:: k8s
+
+   .. container:: extlinks-video
+
+      - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
+
+      - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
+
+.. cond:: linux
+
+   .. container:: extlinks-video
+   
+      - `Installing and Running MinIO on Linux <https://www.youtube.com/watch?v=74usXkZpNt8&list=PLFOIsHSSYIK1BnzVY66pCL-iJ30Ht9t1o>`__
+   
+      - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
+      
+      - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
+
+.. cond:: macos
+
+   .. container:: extlinks-video
+   
+      - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
+      
+      - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
+
+.. cond:: windows
+
+   .. container:: extlinks-video
+
+      - `Object Storage Essentials <https://www.youtube.com/playlist?list=PLFOIsHSSYIK3WitnqhqfpeZ6fRFKHxIr7>`__
+      
+      - `How to Connect to MinIO with JavaScript <https://www.youtube.com/watch?v=yUR4Fvx0D3E&list=PLFOIsHSSYIK3Dd3Y_x7itJT1NUKT5SxDh&index=5>`__
+
 .. contents:: Table of Contents
    :local:
    :depth: 2


### PR DESCRIPTION
Include files for quickstarts had a page title that resulted in a duplicate H1. This removes the duplicate and moves the links for video to the index.rst page.

Closes #1408

Staging examples:
- [linux](http://192.241.195.202:9000/staging/marketing-seo/linux/index.html)
- [containers](http://192.241.195.202:9000/staging/marketing-seo/container/index.html)

I didn't stage the others, because it's the same work on those pages. But you can check that the pages render with only one H1, the video links change with the platform, etc.