### PR TITLE
Add batch replication specific actions to source user policy

### DIFF
--- a/source/extra/examples/ReplicationAdminPolicy.json
+++ b/source/extra/examples/ReplicationAdminPolicy.json
@@ -4,7 +4,11 @@
         {
             "Action": [
                 "admin:SetBucketTarget",
-                "admin:GetBucketTarget"
+                "admin:GetBucketTarget",
+                "admin:ListBatchJobs",
+                "admin:DescribeBatchJob",
+                "admin:StartBatchJob",
+                "admin:CancelBatchJob"
             ],
             "Effect": "Allow",
             "Sid": "EnableRemoteBucketConfiguration"


### PR DESCRIPTION
#### Issue
Batch replication requires specific actions to be performable by the source user, including:
```
  "admin:ListBatchJobs",
  "admin:DescribeBatchJob",
  "admin:StartBatchJob",
  "admin:CancelBatchJob"
```
This PR suggests them in the batch replication example provided in the docs.

@poornas Please correct me if needed. This allowed the documentation to be followed smoothly, with a resultant successful batch replication job being spawned.