### PR TITLE
correct parent flag for mkdir in installation content

### DIFF
--- a/source/includes/container/steps-configure-minio-kes-hashicorp.rst
+++ b/source/includes/container/steps-configure-minio-kes-hashicorp.rst
@@ -7,9 +7,9 @@ Prior to starting these steps, create the following folders:
    :class: copyable
    :substitutions:
 
-   mkdir -P |kescertpath|
-   mkdir -P |kesconfigpath|
-   mkdir -P |miniodatapath|
+   mkdir -p |kescertpath|
+   mkdir -p |kesconfigpath|
+   mkdir -p |miniodatapath|
 
 For Windows hosts, substitute the paths with Windows-style paths, e.g. ``C:\minio-kes-vault\``.
 

--- a/source/includes/macos/steps-configure-minio-kes-hashicorp.rst
+++ b/source/includes/macos/steps-configure-minio-kes-hashicorp.rst
@@ -7,9 +7,9 @@ Prior to starting these steps, create the following folders:
    :class: copyable
    :substitutions:
 
-   mkdir -P |kescertpath|
-   mkdir -P |kesconfigpath|
-   mkdir -P |miniodatapath|
+   mkdir -p |kescertpath|
+   mkdir -p |kesconfigpath|
+   mkdir -p |miniodatapath|
 
 Prerequisite
 ~~~~~~~~~~~~


### PR DESCRIPTION
Flag is lower case, not upper case.

Caught while testing

Not (manually) staged.