### PR TITLE
Removes lingering references to DelMarkerObjectExpiration

### DIFF
--- a/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
+++ b/source/administration/object-management/create-lifecycle-management-expiration-rule.rst
@@ -118,22 +118,3 @@ delete markers:
   <mc ilm rule add --noncurrent-expire-days>` with the number of days after
   which to expire noncurrent object versions. For example, specify ``30d`` to
   expire a version after it has been noncurrent for at least 30 days.
-
-Expire All Versions of a Deleted Object
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Starting with :mc-release:`MinIO Server RELEASE.2024-05-01T01-11-10Z`, MinIO supports deleting all versions of an object that has a delete marker as its latest version.
-MinIO supports such deletes with ``JSON``, not through the command line.
-
-To add this capability to a rule, first export the rule to modify with :mc:`mc ilm rule export`.
-Modify the exported rule with additional ``JSON`` that resembles the following:
-
-.. code-block:: text
-   :class: copyable
-
-   <DelMarkerObjectExpiration>
-       <Days> 10 </Days>
-   </DelMarkerObjectExpiration>   
-
-This example ``JSON`` expires all versions of the deleted object after 10 days.
-Modify the value in the ``<Days>`` element to the number of days you want to wait after deleting the object before expiring it and removing it from MinIO.

--- a/source/administration/object-management/object-lifecycle-management.rst
+++ b/source/administration/object-management/object-lifecycle-management.rst
@@ -120,20 +120,6 @@ MinIO has several default behaviors for versioned buckets:
 
   To expire delete markers when there are no remaining versions for that object, specify the :mc-cmd:`~mc ilm rule add --expire-delete-marker` option when creating the expiration rule.
 
-  .. versionchanged:: MinIO RELEASE.2024-05-01T01-11-10Z
-
-     MinIO supports expiring all versions of an object where the latest version is a delete marker, *including expiring the delete marker*, but only with JSON.
-     Add a JSON rule with :mc:`mc ilm rule import`.
-
-     For example, to expire all versions of a deleted object 10 days after the object deletion, use the following JSON:
-
-     .. code-block:: text
-        :class: copyable
-
-        <DelMarkerObjectExpiration>
-            <Days> 10 </Days>
-        </DelMarkerObjectExpiration>
-
 - To expire *all* versions of an object that does *not* have a delete marker after a specified period of days, use the :mc-cmd:`~mc ilm rule add --expire-all-object-versions` flag with the :mc-cmd:`~mc ilm rule add --expire-days` flag. 
   This permits the permanent deletion of the object after the specified number of days pass.
 


### PR DESCRIPTION
Some references were removed in #1388 in the `mc ilm` docs, but these references remained.