### PR TITLE
Adds note about setting transition-days flag to 0

### DIFF
--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -173,6 +173,7 @@ Parameters
    The number of calendar days from object creation after which MinIO marks an object as eligible for transition. 
    MinIO transitions the object to the configured remote tier specified to the :mc-cmd:`~mc ilm rule add --transition-tier`. 
    Specify the number of days as an integer, e.g. ``30`` for 30 days.
+   If the remote tier is another MinIO deployment, transition days can be set to ``0`` to mark new objects for the quickest move to the remote tier.
 
    For versioned buckets, the transition rule applies only to the *current* object version. 
    Use the :mc-cmd:`~mc ilm rule add --noncurrent-transition-days` option to apply transition behavior to noncurrent object versions.

--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -173,7 +173,7 @@ Parameters
    The number of calendar days from object creation after which MinIO marks an object as eligible for transition. 
    MinIO transitions the object to the configured remote tier specified to the :mc-cmd:`~mc ilm rule add --transition-tier`. 
    Specify the number of days as an integer, e.g. ``30`` for 30 days.
-   If the remote tier is another MinIO deployment, transition days can be set to ``0`` to mark new objects for the quickest move to the remote tier.
+   If the remote tier is another MinIO deployment, you can set the value to ``0`` to mark new objects as immediately eligible for transition to the remote tier.
 
    For versioned buckets, the transition rule applies only to the *current* object version. 
    Use the :mc-cmd:`~mc ilm rule add --noncurrent-transition-days` option to apply transition behavior to noncurrent object versions.

--- a/source/reference/minio-mc/mc-ilm-rule-edit.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-edit.rst
@@ -256,7 +256,7 @@ Parameters
    the configured remote storage tier specified to the 
    :mc-cmd:`~mc ilm rule edit --transition-tier`. 
    Specify the number of days as an integer, e.g. ``30`` for 30 days.
-   If the remote tier is another MinIO deployment, transition days can be set to ``0`` to mark new objects for the quickest move to the remote tier.
+   If the remote tier is another MinIO deployment, you can set the value to ``0`` to mark new objects as immediately eligible for transition to the remote tier.
 
    For versioned buckets, the transition rule applies only to the *current*
    object version. Use the 

--- a/source/reference/minio-mc/mc-ilm-rule-edit.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-edit.rst
@@ -255,6 +255,8 @@ Parameters
    marks an object as eligible for transition. MinIO transitions the object to
    the configured remote storage tier specified to the 
    :mc-cmd:`~mc ilm rule edit --transition-tier`. 
+   Specify the number of days as an integer, e.g. ``30`` for 30 days.
+   If the remote tier is another MinIO deployment, transition days can be set to ``0`` to mark new objects for the quickest move to the remote tier.
 
    For versioned buckets, the transition rule applies only to the *current*
    object version. Use the 


### PR DESCRIPTION
Only applicable for remote tiers that are also MinIO deployments. 
Per internal discussion.

Need to verify if this applies to the `edit` command and the `noncurrent-transition-days` flags.

Not currently staged.