### PR TITLE
noncurrent-trasition-days can accept 0

### DIFF
--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -202,6 +202,8 @@ Parameters
 
    This option has the same behavior as the S3 ``NoncurrentVersionExpiration`` action.
 
+   If the remote tier is another MinIO deployment, you can set the value to ``0`` to mark new objects as immediately eligible for transition to the remote tier.
+
    MinIO uses a :ref:`scanner process <minio-concepts-scanner>` to check objects against all configured lifecycle management rules. 
    Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
    See :ref:`minio-lifecycle-management-scanner` for more information.

--- a/source/reference/minio-mc/mc-ilm-rule-edit.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-edit.rst
@@ -221,6 +221,8 @@ Parameters
    This option has the same behavior as the 
    S3 ``NoncurrentVersionTransition`` action.
 
+   If the remote tier is another MinIO deployment, you can set the value to ``0`` to mark new objects as immediately eligible for transition to the remote tier.
+
    MinIO uses a :ref:`scanner process <minio-concepts-scanner>` to check objects against all configured
    lifecycle management rules. Slow scanning due to high IO workloads or
    limited system resources may delay application of lifecycle management


### PR DESCRIPTION
If the target transition tier is another MinIO deployment, the days value can be `0`.

Not staged.