### PR TITLE
Remove documentation references to _MINIO_BATCH_REPLICATION_WORKERS

### DIFF
--- a/source/administration/batch-framework-job-replicate.rst
+++ b/source/administration/batch-framework-job-replicate.rst
@@ -30,7 +30,7 @@ Batch Replication between MinIO deployments have the following advantages over u
 
 .. versionchanged:: MinIO Server RELEASE.2023-02-17T17-52-43Z
 
-   Run batch replication with multiple workers in parallel by specifying the :envvar:`MINIO_BATCH_REPLICATION_WORKERS` environment variable.
+   Run batch replication with multiple workers in parallel by specifying the :envvar:`_MINIO_BATCH_REPLICATION_WORKERS` environment variable.
 
 Starting with the MinIO Server ``RELEASE.2023-05-04T21-44-30Z``, the other deployment can be either another MinIO deployment or any S3-compatible location using a realtime storage class.
 Use filtering options in the replication ``YAML`` file to exclude objects stored in locations that require rehydration or other restoration methods before serving the requested object.

--- a/source/administration/batch-framework-job-replicate.rst
+++ b/source/administration/batch-framework-job-replicate.rst
@@ -28,10 +28,6 @@ Batch Replication between MinIO deployments have the following advantages over u
 - Batch jobs are one-time, curated processes allowing for fine control replication
 - (MinIO to MinIO only) The replication process copies object versions from source to target
 
-.. versionchanged:: MinIO Server RELEASE.2023-02-17T17-52-43Z
-
-   Run batch replication with multiple workers in parallel by specifying the :envvar:`_MINIO_BATCH_REPLICATION_WORKERS` environment variable.
-
 Starting with the MinIO Server ``RELEASE.2023-05-04T21-44-30Z``, the other deployment can be either another MinIO deployment or any S3-compatible location using a realtime storage class.
 Use filtering options in the replication ``YAML`` file to exclude objects stored in locations that require rehydration or other restoration methods before serving the requested object.
 Batch replication to these types of remotes uses ``mc mirror`` behavior.

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -191,7 +191,7 @@ Batch Replication
 
    .. tab-item:: Environment Variable
 
-      .. envvar:: MINIO_BATCH_REPLICATION_WORKERS
+      .. envvar:: _MINIO_BATCH_REPLICATION_WORKERS
 
          *Optional*
 

--- a/source/reference/minio-server/settings/core.rst
+++ b/source/reference/minio-server/settings/core.rst
@@ -189,14 +189,6 @@ Batch Replication
 
 .. tab-set::
 
-   .. tab-item:: Environment Variable
-
-      .. envvar:: _MINIO_BATCH_REPLICATION_WORKERS
-
-         *Optional*
-
-         Specifying the maximum number of parallel processes to use when performing the batch application job.
-
    .. tab-item:: Configuration Setting
 
       .. include:: /includes/common-mc-admin-config.rst


### PR DESCRIPTION
Hidden env var `_MINIO_BATCH_REPLICATION_WORKERS` is being referred to in documentation. It needs to be either:
- removed as a hidden variable
- renamed with a leading `_`
- enabled as a regular variable in ~`minio`~ and `eos`, without a leading `_`

See example the files referred to in the PR and https://github.com/minio/minio/blob/39df134204b17336b133ab22256ac17fe72adcd6/cmd/batch-handlers.go#L398

Pending review and discussion with @harshavardhana and @poornas 

This PR removes documentation references to this variable.