### PR TITLE
Add info for Object Lambda via configuration settings

### DIFF
--- a/source/developers/transforms-with-object-lambda.rst
+++ b/source/developers/transforms-with-object-lambda.rst
@@ -121,6 +121,8 @@ MinIO also supports the following environment variables for authenticated webhoo
 
 Restart MinIO to apply the changes.
 
+You can also configure Object Lambda with the MinIO Client :mc-cmd:`mc` command line tool.
+For more information, see :ref:`minio-server-envvar-object-lambda-webhook`.
 
 Trigger From an Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/developers/transforms-with-object-lambda.rst
+++ b/source/developers/transforms-with-object-lambda.rst
@@ -121,7 +121,7 @@ MinIO also supports the following environment variables for authenticated webhoo
 
 Restart MinIO to apply the changes.
 
-You can also configure Object Lambda with the MinIO Client :mc-cmd:`mc` command line tool.
+Alternatively, configure Object Lambda with the :ref:`MinIO Client <minio-client>` command line tool.
 For more information, see :ref:`minio-server-envvar-object-lambda-webhook`.
 
 Trigger From an Application

--- a/source/reference/minio-server/settings/object-lambda.rst
+++ b/source/reference/minio-server/settings/object-lambda.rst
@@ -1,7 +1,7 @@
 .. _minio-server-envvar-object-lambda-webhook:
 
 ===============================
-Object Lambda Function Settings
+Object Lambda function settings
 ===============================
 
 .. default-domain:: minio
@@ -10,49 +10,193 @@ Object Lambda Function Settings
    :local:
    :depth: 2
 
-This page documents environment variables for configuring MinIO to publish data to an HTTP webhook endpoint and trigger an Object Lambda function.
-See :ref:`developers-object-lambda` for more complete documentation and tutorials on using these environment variables.
+This page documents settings for configuring MinIO to publish data to an HTTP webhook endpoint and trigger an Object Lambda function.
+See :ref:`developers-object-lambda` for more complete documentation and tutorials on using these settings.
 
-You can specify multiple webhook endpoints as Lambda targets by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
-For example, the following command sets two distinct Object Lambda webhook endpoints:
+You can establish or modify settings by defining:
 
-.. code-block:: shell
-   :class: copyable
+- an *environment variable* on the host system prior to starting or restarting the MinIO Server.
+  Refer to your operating system's documentation for how to define an environment variable.
+- a *configuration setting* using :mc:`mc admin config set`.
 
-   export MINIO_LAMBDA_WEBHOOK_ENABLE_myfunction="on"
-   export MINIO_LAMBDA_WEBHOOK_ENDPOINT_myfunction="http://webhook-1.example.net"
-   export MINIO_LAMBDA_WEBHOOK_ENABLE_yourfunction="on"
-   export MINIO_LAMBDA_WEBHOOK_ENDPOINT_yourfunction="http://webhook-2.example.net"
+If you define both an environment variable and the similar configuration setting, MinIO uses the environment variable value.
+
+Some settings have only an environment variable or a configuration setting, but not both.
 
 .. include:: /includes/common-mc-admin-config.rst
    :start-after: start-minio-settings-test-before-prod
    :end-before: end-minio-settings-test-before-prod
 
-Environment Variables
----------------------
 
-.. envvar:: MINIO_LAMBDA_WEBHOOK_ENABLE
+Enable
+------
 
-   Specify ``"on"`` to enable the Object Lambda webhook endpoint for a handler function.
+.. tab-set::
 
-   Requires specifying :envvar:`MINIO_LAMBDA_WEBHOOK_ENDPOINT`.
+   .. tab-item:: Environment Variable
+      :sync: envvar
 
-.. envvar:: MINIO_LAMBDA_WEBHOOK_ENDPOINT
+      .. envvar:: MINIO_LAMBDA_WEBHOOK_ENABLE
 
-   The HTTP endpoint of the lambda webhook for the handler function.
+         Specify ``"on"`` to enable the Object Lambda webhook endpoint for a handler function.
 
-.. envvar:: MINIO_LAMBDA_WEBHOOK_AUTH_TOKEN
+         Requires specifying :envvar:`MINIO_LAMBDA_WEBHOOK_ENDPOINT`.
 
-   Specify the opaque string or JWT authorization token to use for authenticating to the lambda webhook service.
+	 You can specify multiple webhooks as Lambda targets by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         For example, the following command enables two distinct Object Lambda webhook endpoints:
 
-   .. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+         .. code-block:: shell
+            :class: copyable
 
-      MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
+            export MINIO_LAMBDA_WEBHOOK_ENABLE_myfunction="on"
+            export MINIO_LAMBDA_WEBHOOK_ENABLE_yourfunction="on"
 
-.. envvar:: MINIO_LAMBDA_WEBHOOK_CLIENT_CERT
+   .. tab-item:: Configuration Setting
+      :sync: config
 
-   Specify the path to the client certificate to use for performing mTLS authentication to the lambda webhook service.
+      .. mc-conf:: lambda_webhook enable
+         :delimiter: " "
 
-.. envvar:: MINIO_LAMBDA_WEBHOOK_CLIENT_KEY
+         *Optional*
 
-   Specify the path to the private key to use for performing mTLS authentication to the lambda webhook service.
+         Specify ``"on"`` to enable the Object Lambda webhook endpoint for a handler function.
+	 Requires specifying :mc-conf:`~lambda_webhook.endpoint`.
+
+	 Example:
+
+	 .. code-block:: shell
+	    :class: copyable
+
+            mc admin config set myminio lambda_webhook:myfunction endpoint="https://example.com/" enable=on
+
+Endpoint
+--------
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_LAMBDA_WEBHOOK_ENDPOINT
+
+         The HTTP endpoint of the lambda webhook for the handler function.
+
+         You can specify multiple webhook endpoints as Lambda targets by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         For example, the following command sets two distinct Object Lambda webhook endpoints:
+
+         .. code-block:: shell
+            :class: copyable
+
+            export MINIO_LAMBDA_WEBHOOK_ENDPOINT_myfunction="http://webhook-1.example.net"
+            export MINIO_LAMBDA_WEBHOOK_ENDPOINT_yourfunction="http://webhook-2.example.net"
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: lambda_webhook endpoint
+         :delimiter: " "
+
+         *Optional*
+
+         The HTTP endpoint of the lambda webhook for the handler function.
+
+Auth token
+----------
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_LAMBDA_WEBHOOK_AUTH_TOKEN
+
+         Specify the opaque string or JWT authorization token to use for authenticating to the lambda webhook service.
+
+         You can specify the token for multiple Lambda target by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         For example, the following command configures a token for two distinct Object Lambda webhook endpoints:
+
+         .. code-block:: shell
+            :class: copyable
+
+            export MINIO_LAMBDA_WEBHOOK_AUTH_TOKEN_myfunction="1a2b3c4d5e"
+            export MINIO_LAMBDA_WEBHOOK_AUTH_TOKEN_yourfunction="1a2b3c4d5e"
+
+         .. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+            MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: lambda_webhook auth_token
+         :delimiter: " "
+
+         *Optional*
+
+         Specify the opaque string or JWT authorization token to use for authenticating to the lambda webhook service.
+
+         .. versionchanged:: RELEASE.2023-06-23T20-26-00Z
+
+            MinIO redacts this value when returned as part of :mc-cmd:`mc admin config get`.         
+
+Client cert
+-----------
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_LAMBDA_WEBHOOK_CLIENT_CERT
+
+         Specify the path to the client certificate to use for performing mTLS authentication to the lambda webhook service.
+
+         You can specify the client cert for multiple Lambda target by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         For example, the following command configures a cert for two distinct Object Lambda webhook endpoints:
+
+         .. code-block:: shell
+            :class: copyable
+
+            export MINIO_LAMBDA_WEBHOOK_CLIENT_CERT_myfunction="/path/to/cert1"
+            export MINIO_LAMBDA_WEBHOOK_CLIENT_CERT_yourfunction="/path/to/cert2"
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: lambda_webhook client_cert
+         :delimiter: " "
+
+         *Optional*
+     
+         Specify the path to the client certificate to use for performing mTLS authentication to the lambda webhook service.
+
+Client key
+----------
+
+.. tab-set::
+
+   .. tab-item:: Environment Variable
+      :sync: envvar
+
+      .. envvar:: MINIO_LAMBDA_WEBHOOK_CLIENT_KEY
+
+         Specify the path to the private key to use for performing mTLS authentication to the lambda webhook service.
+
+         You can specify the client key for multiple Lambda target by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         For example, the following command configures a key for two distinct Object Lambda webhook endpoints:
+
+         .. code-block:: shell
+            :class: copyable
+
+            export MINIO_LAMBDA_WEBHOOK_CLIENT_KEY_myfunction="/path/to/key1"
+            export MINIO_LAMBDA_WEBHOOK_CLIENT_KEY_yourfunction="/path/to/key2"
+
+   .. tab-item:: Configuration Setting
+      :sync: config
+
+      .. mc-conf:: lambda_webhook client_key
+         :delimiter: " "
+
+         *Optional*
+
+         Specify the path to the private key to use for performing mTLS authentication to the lambda webhook service.

--- a/source/reference/minio-server/settings/object-lambda.rst
+++ b/source/reference/minio-server/settings/object-lambda.rst
@@ -10,7 +10,7 @@ Object Lambda function settings
    :local:
    :depth: 2
 
-This page documents settings for configuring MinIO to publish data to an HTTP webhook endpoint and trigger an Object Lambda function.
+This page describes the settings available to configure MinIO to publish data to an HTTP webhook endpoint and trigger an Object Lambda function.
 See :ref:`developers-object-lambda` for more complete documentation and tutorials on using these settings.
 
 You can establish or modify settings by defining:
@@ -42,7 +42,7 @@ Enable
 
          Requires specifying :envvar:`MINIO_LAMBDA_WEBHOOK_ENDPOINT`.
 
-	 You can specify multiple webhooks as Lambda targets by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+	 You can specify multiple webhooks as Lambda targets by appending a unique identifier for each Object Lambda function.
          For example, the following command enables two distinct Object Lambda webhook endpoints:
 
          .. code-block:: shell
@@ -81,7 +81,7 @@ Endpoint
 
          The HTTP endpoint of the lambda webhook for the handler function.
 
-         You can specify multiple webhook endpoints as Lambda targets by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         You can specify multiple webhook endpoints as Lambda targets by appending a unique identifier for each Object Lambda function.
          For example, the following command sets two distinct Object Lambda webhook endpoints:
 
          .. code-block:: shell
@@ -112,7 +112,7 @@ Auth token
 
          Specify the opaque string or JWT authorization token to use for authenticating to the lambda webhook service.
 
-         You can specify the token for multiple Lambda target by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         You can specify the token for multiple Lambda targets by appending a unique identifier for each Object Lambda function.
          For example, the following command configures a token for two distinct Object Lambda webhook endpoints:
 
          .. code-block:: shell
@@ -151,7 +151,7 @@ Client cert
 
          Specify the path to the client certificate to use for performing mTLS authentication to the lambda webhook service.
 
-         You can specify the client cert for multiple Lambda target by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         You can specify the client cert for multiple Lambda targets by appending a unique identifier for each Object Lambda function.
          For example, the following command configures a cert for two distinct Object Lambda webhook endpoints:
 
          .. code-block:: shell
@@ -182,7 +182,7 @@ Client key
 
          Specify the path to the private key to use for performing mTLS authentication to the lambda webhook service.
 
-         You can specify the client key for multiple Lambda target by appending a unique identifier ``_FUNCTIONNAME`` for each Object Lambda function.
+         You can specify the client key for multiple Lambda targets by appending a unique identifier for each Object Lambda function.
          For example, the following command configures a key for two distinct Object Lambda webhook endpoints:
 
          .. code-block:: shell

--- a/source/reference/minio-server/settings/object-lambda.rst
+++ b/source/reference/minio-server/settings/object-lambda.rst
@@ -87,8 +87,8 @@ Endpoint
          .. code-block:: shell
             :class: copyable
 
-            export MINIO_LAMBDA_WEBHOOK_ENDPOINT_myfunction="http://webhook-1.example.net"
-            export MINIO_LAMBDA_WEBHOOK_ENDPOINT_yourfunction="http://webhook-2.example.net"
+            export MINIO_LAMBDA_WEBHOOK_ENDPOINT_myfunction="http://webhook-1.example.com"
+            export MINIO_LAMBDA_WEBHOOK_ENDPOINT_yourfunction="http://webhook-2.example.com"
 
    .. tab-item:: Configuration Setting
       :sync: config


### PR DESCRIPTION
Thank you to @wdinyes for noticing you can configure Object Lambda this way. New text is not super comprehensive, but hopefully enough to guide someone in the correct direction. My understanding is not too many people are using Object Lambda right now.

Staged:
http://192.241.195.202:9000/staging/DOCS-1400/linux/reference/minio-server/settings/object-lambda.html

Fixes https://github.com/minio/docs/issues/1400