### PR TITLE
Missing part of command in Object Versioning documentation

### DIFF
--- a/source/administration/object-management/object-versioning.rst
+++ b/source/administration/object-management/object-versioning.rst
@@ -277,7 +277,7 @@ using an S3-compatible SDK.
       .. code-block:: shell
          :class: copyable
 
-         mc version ALIAS/BUCKET
+         mc version enable ALIAS/BUCKET
 
       - Replace ``ALIAS`` with the :mc:`alias <mc alias>` of a configured 
         MinIO deployment.


### PR DESCRIPTION
Now there is standing: `mc version ALIAS/BUCKET` but it should be `mc version enable ALIAS/BUCKET`

the `enable` part in the command example is missing