### PR TITLE
docs: fixed the format for --older-than parameter in mc-rm

### DIFF
--- a/source/reference/minio-mc/mc-rm.rst
+++ b/source/reference/minio-mc/mc-rm.rst
@@ -192,7 +192,7 @@ Parameters
    :optional:
 
    Remove object(s) older than the specified time limit. Specify a
-   string in ``#d#hh#mm#ss`` format. For example: ``--older-than 1d2hh3mm4ss``.
+   string in ``#d#h#m#s`` format. For example: ``--older-than 1d2h3m4s``.
       
    Defaults to ``0`` (all objects).
 


### PR DESCRIPTION
The format for--older-than parameter in the docs was #d#hh#mm#ss which cannot be parsed when used, the correct format is #d#h#m#s