### PR TITLE
Updates for mc RELEASE.2025-03-12T17-29-24Z

### DIFF
--- a/source/operations/monitoring/metrics-v2.rst
+++ b/source/operations/monitoring/metrics-v2.rst
@@ -72,8 +72,13 @@ The following sections describe the version 2 endpoints and metrics.
 
       .. versionchanged:: RELEASE.2023-08-31T15-31-16Z
 
-      You can scrape :ref:`bucket-level metrics <minio-available-bucket-metrics>` using the following URL endpoint:
+         You can scrape :ref:`bucket-level metrics <minio-available-bucket-metrics>` using the following URL endpoint:
 
+      .. versionchanged:: RELEASE.2025-03-12T17-29-24Z
+
+         v2 metrics have a limit of 100 buckets for performance reasons.
+         For metrics across a higher number of buckets, use :ref:`v3 metrics <minio-metrics-and-alerts-available-metrics>` instead.
+     
       .. code-block:: shell
          :class: copyable
 
@@ -108,6 +113,12 @@ The following sections describe the version 2 endpoints and metrics.
    :parser: myst_parser.sphinx_
 
 .. _minio-available-bucket-metrics:
+
+   .. versionchanged:: RELEASE.2025-03-12T17-29-24Z
+
+      v2 metrics have a limit of 100 buckets for performance reasons.
+      For metrics across a higher number of buckets, use :ref:`v3 metrics <minio-metrics-and-alerts-available-metrics>` instead.
+
 
 .. include:: /includes/common-metrics-bucket.md
    :parser: myst_parser.sphinx_

--- a/source/reference/minio-mc/mc-ilm-rule-add.rst
+++ b/source/reference/minio-mc/mc-ilm-rule-add.rst
@@ -202,8 +202,6 @@ Parameters
 
    This option has the same behavior as the S3 ``NoncurrentVersionExpiration`` action.
 
-   If the remote tier is another MinIO deployment, you can set the value to ``0`` to mark new objects as immediately eligible for transition to the remote tier.
-
    MinIO uses a :ref:`scanner process <minio-concepts-scanner>` to check objects against all configured lifecycle management rules. 
    Slow scanning due to high IO workloads or limited system resources may delay application of lifecycle management rules. 
    See :ref:`minio-lifecycle-management-scanner` for more information.

--- a/source/reference/minio-mc/mc-support-callhome.rst
+++ b/source/reference/minio-mc/mc-support-callhome.rst
@@ -78,12 +78,11 @@ Syntax
                
       mc support callhome status   \
                           ALIAS    \
-                          [--logs] \
                           [--diag]
 
    .. note::
 
-      The ``--logs`` and ``--diag`` flags are no longer supported in SUBNET and will be removed in a future release.
+      The ``--diag`` flag is no longer supported in SUBNET and will be removed in a future release.
             
 Parameters
 ~~~~~~~~~~
@@ -93,15 +92,6 @@ Parameters
 
    The :ref:`alias <alias>` of the MinIO deployment.
 
-.. mc-cmd:: --logs
-   :optional:
-
-   .. note::
-
-      This option is no longer supported in SUBNET and will be removed in a future release.
-
-   Send or stop sending log information to SUBNET in real time.
-
 .. mc-cmd:: --diag
    :optional:
 
@@ -110,8 +100,6 @@ Parameters
       This option is no longer supported in SUBNET and will be removed in a future release.
 
    Send or stop sending deployment diagnostic information to SUBNET every 24 hours.
-
-If you do not pass either ``--logs`` or ``--diag``, the command applies to both logs and diagnostics.
 
 Examples
 --------


### PR DESCRIPTION
- removes `--logs` flag from `mc support callhome`
- enforces 100 bucket limit for v2 metrics

Closes #1439

Opportunistic fix to remove errant copy/paste for `--noncurrent-expire-days` flag in `mc ilm rule add`

Closes #1438