### PR TITLE
Add section for supported KMS actions

### DIFF
--- a/source/administration/identity-access-management/policy-based-access-control.rst
+++ b/source/administration/identity-access-management/policy-based-access-control.rst
@@ -709,69 +709,6 @@ MinIO extends the S3 standard condition keys with the following extended key:
          ]
       }
 
-Support kms action keys
------------------------
-
-MinIO supports restricting key management service (KMS) actions by policy.
-
-You can restrict KMS activities in a policy with any of the following KMS actions:
-
-.. policy-action:: kms:Status
-
-   Check the status of KMS.
-
-.. policy-action:: kms:Metrics
-
-   Obtain Prometheus-formatted metrics.
-
-.. policy-action:: kms:API
-
-   List supported API endpoints.
-
-.. policy-action:: kms:Version
-
-   Retrieve the KMS version.
-
-.. policy-action:: kms:CreateKey
-
-   Create a new KMS key.
-
-.. policy-action:: kms:ListKeys
-
-   Retrieve a list of existing KMS keys.
-
-.. policy-action:: kms:KeyStatus
-
-   Retrieve the status of a specified KMS key.
-
-.. versionchanged:: RELEASE.2024-07-16T23-46-41Z
-
-   KMS actions can be restricted by resource or a resource prefix.
-   The wildcard character ``*`` can be used to apply the KMS action policy to all resources that match the prefix.
-
-   For example, the following policy document allows a user to list keys, create new keys, and check the status of keys for any resource that begins with ``keys-abc-`` or ``myuser-``.
-
-   .. codeblock:: shell
-      :class: copyable
-   
-      {
-          "Version": "2012-10-17",
-          "Statement": [
-              {
-                  "Effect": "Allow",
-                  "Action": [
-                      "kms:CreateKey",
-                      "kms:KeyStatus",
-                      "kms:ListKeys"
-                  ],
-                  "Resource": [
-                      "arn:minio:kms:::keys-abc-*",
-                      "arn:minio:kms:::myuser-*"
-                  ]
-              }
-          ]
-      }
-
 .. _minio-policy-mc-admin-actions:
 
 ``mc admin`` Policy Action Keys
@@ -817,10 +754,14 @@ services:
 .. policy-action:: admin:KMSCreateKey
 
    Allows creating a new KMS master key
+   
+   While this option is still supported, :policy-action:`kms:CreateKey` is preferred.
 
 .. policy-action:: admin:KMSKeyStatus
 
    Allows getting KMS key status
+
+   While this option is still supported, :policy-action:`kms:KeyStatus` is preferred.
 
 .. policy-action:: admin:ServerInfo
 
@@ -984,6 +925,71 @@ services:
 .. policy-action:: admin:Rebalance
 
    Allows access to start, query, or stop a rebalancing of objects across pools with varying free storage space.
+
+KMS policy action keys
+----------------------
+
+MinIO supports restricting key management service (KMS) actions by policy.
+
+You can restrict KMS activities in a policy with any of the following KMS actions:
+
+.. policy-action:: kms:Status
+
+   Check the status of KMS.
+
+.. policy-action:: kms:Metrics
+
+   Obtain Prometheus-formatted metrics.
+
+.. policy-action:: kms:API
+
+   List supported API endpoints.
+
+.. policy-action:: kms:Version
+
+   Retrieve the KMS version.
+
+.. policy-action:: kms:CreateKey
+
+   Create a new KMS key.
+
+.. policy-action:: kms:ListKeys
+
+   Retrieve a list of existing KMS keys.
+
+.. policy-action:: kms:KeyStatus
+
+   Retrieve the status of a specified KMS key.
+
+To select all of the available kms policy actions, use ``kms:*``.
+
+.. versionchanged:: RELEASE.2024-07-16T23-46-41Z
+
+   KMS actions can be restricted by resource or a resource prefix.
+   The wildcard character ``*`` can be used to apply the KMS action policy to all resources that match the prefix.
+
+   For example, the following policy document allows a user to list keys, create new keys, and check the status of keys for any resource that begins with ``keys-abc-`` or ``myuser-``.
+
+   .. codeblock:: shell
+      :class: copyable
+   
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Action": [
+                      "kms:CreateKey",
+                      "kms:KeyStatus",
+                      "kms:ListKeys"
+                  ],
+                  "Resource": [
+                      "arn:minio:kms:::keys-abc-*",
+                      "arn:minio:kms:::myuser-*"
+                  ]
+              }
+          ]
+      }
 
 ``mc admin`` Policy Condition Keys
 ----------------------------------

--- a/source/administration/identity-access-management/policy-based-access-control.rst
+++ b/source/administration/identity-access-management/policy-based-access-control.rst
@@ -709,6 +709,69 @@ MinIO extends the S3 standard condition keys with the following extended key:
          ]
       }
 
+Support kms action keys
+-----------------------
+
+MinIO supports restricting key management service (KMS) actions by policy.
+
+You can restrict KMS activities in a policy with any of the following KMS actions:
+
+.. policy-action:: kms:Status
+
+   Check the status of KMS.
+
+.. policy-action:: kms:Metrics
+
+   Obtain Prometheus-formatted metrics.
+
+.. policy-action:: kms:API
+
+   List supported API endpoints.
+
+.. policy-action:: kms:Version
+
+   Retrieve the KMS version.
+
+.. policy-action:: kms:CreateKey
+
+   Create a new KMS key.
+
+.. policy-action:: kms:ListKeys
+
+   Retrieve a list of existing KMS keys.
+
+.. policy-action:: kms:KeyStatus
+
+   Retrieve the status of a specified KMS key.
+
+.. versionchanged:: RELEASE.2024-07-16T23-46-41Z
+
+   KMS actions can be restricted by resource or a resource prefix.
+   The wildcard character ``*`` can be used to apply the KMS action policy to all resources that match the prefix.
+
+   For example, the following policy document allows a user to list keys, create new keys, and check the status of keys for any resource that begins with ``keys-abc-`` or ``myuser-``.
+
+   .. codeblock:: shell
+      :class: copyable
+   
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Action": [
+                      "kms:CreateKey",
+                      "kms:KeyStatus",
+                      "kms:ListKeys"
+                  ],
+                  "Resource": [
+                      "arn:minio:kms:::keys-abc-*",
+                      "arn:minio:kms:::myuser-*"
+                  ]
+              }
+          ]
+      }
+
 .. _minio-policy-mc-admin-actions:
 
 ``mc admin`` Policy Action Keys


### PR DESCRIPTION
Adds section to the policy based access control page for supported KMS action keys.
Refers two existing kms related keys to the preferred `kms:` keys.

Closes #1283