### PR TITLE
[documentation][keycloak] Invalid procedure for "Validate Admin API Access"

### DIFF
--- a/source/operations/external-iam/configure-keycloak-identity-management.rst
+++ b/source/operations/external-iam/configure-keycloak-identity-management.rst
@@ -172,15 +172,15 @@ You can validate the functionality by using the Admin REST API with the MinIO cl
 
       curl -d "client_id=minio" \
            -d "client_secret=secretvalue" \
-           -d "grant_type=password" \
-           http://keycloak-url:port/admin/realms/REALM/protocol/openid-connect/token
+           -d "grant_type=client_credentials" \
+           http://keycloak-url:port/realms/REALM/protocol/openid-connect/token
 
 2. Use the value returned as the ``access_token`` to access the Admin API:
 
    .. code-block:: shell
       :class: copyable
 
-      curl -H "Authentication: Bearer ACCESS_TOKEN_VALUE" \
+      curl -H "Authorization: Bearer ACCESS_TOKEN_VALUE" \
            http://keycloak-url:port/admin/realms/REALM/users/UUID
 
    Replace ``UUID`` with the unique ID for the user which you want to retrieve.


### PR DESCRIPTION
I've been following the guide on configuring MinIO for Authenticating using keycloak.
I think that section _2) Validate Admin API Access_ of [Enable the Keycloak Admin REST API](https://min.io/docs/minio/container/operations/external-iam/configure-keycloak-identity-management.html#id4) doesn't work as it's supposed to.


## Expected Behavior
Retrieve the bearer token:
```sh
curl -d "client_id=minio" \
     -d "client_secret=secretvalue" \
     -d "grant_type=client_credentials" \
     http://keycloak-url:port/realms/REALM/protocol/openid-connect/token
```

Use the value returned as the access_token to access the Admin API:
```sh
curl -H "Authorization: Bearer ACCESS_TOKEN_VALUE" \
     http://keycloak-url:port/admin/realms/REALM/users/UUID
```

## Current Behavior
Retrieve the bearer token:
```sh
curl -d "client_id=minio" \
     -d "client_secret=secretvalue" \
     -d "grant_type=password" \
     http://keycloak-url:port/admin/realms/REALM/protocol/openid-connect/token
```

Use the value returned as the access_token to access the Admin API:
```sh
curl -H "Authentication: Bearer ACCESS_TOKEN_VALUE" \
     http://keycloak-url:port/admin/realms/REALM/users/UUID
```

## Possible Solution
Replacing snippets from _Current Behavior_ to _Expected Behavior_ i mentioned seems to work.

## Steps to Reproduce (for bugs)
Follow the guide under https://min.io/docs/minio/container/operations/external-iam/configure-keycloak-identity-management.html