### PR TITLE
Update TypeScript guidance

### DIFF
--- a/source/developers/minio-drivers.rst
+++ b/source/developers/minio-drivers.rst
@@ -165,13 +165,6 @@ Install
        npm install
        npm install -g
 
-  - TypeScript
-
-    .. code-block:: shell
-       :class: copyable
-
-       npm install --save-dev @types/minio
-
 
 .. _haskell-sdk:
 


### PR DESCRIPTION
The JavaScript Install instructions include a TypeScript section. I removed it entirely because types are now provided by `minio-js` and should not be installed separately via `@types/minio`.

Happy to consider alternatives, such as keeping the section with a note like "types are now provided by the `minio-js` package".

