### PR TITLE
Recommend kernel 6.6 and greater

### DIFF
--- a/source/operations/checklists/software.rst
+++ b/source/operations/checklists/software.rst
@@ -20,8 +20,8 @@ MinIO Pre-requisites
    :width: 100%
 
    * - :octicon:`circle`
-     - Servers running a Linux operating system with a 5.x+ kernel, such as Red Hat Enterprise Linux (RHEL) 9 or Ubuntu LTS 20.04+.
-       Ensure the chosen OS uses LTS and in-support releases of the Linux Kernel 5.x or 6.x series.
+     - Servers running a Linux operating system with a 6.6+ kernel, such as Red Hat Enterprise Linux (RHEL) 9 or Ubuntu LTS 24.04+.
+       Ensure the chosen OS uses LTS and in-support releases of a 6.6+ Linux kernel.
 
    * - :octicon:`circle`
      - A method to synchronize time servers across nodes, such as with ``ntp``, ``timedatectl`` or ``timesyncd``.

--- a/source/operations/checklists/software.rst
+++ b/source/operations/checklists/software.rst
@@ -20,7 +20,7 @@ MinIO Pre-requisites
    :width: 100%
 
    * - :octicon:`circle`
-     - Servers running a Linux operating system with a 6.6+ kernel, such as Red Hat Enterprise Linux (RHEL) 9 or Ubuntu LTS 24.04+.
+     - Servers running a Linux operating system with a 6.6+ kernel. Red Hat Enterprise Linux (RHEL) 10 or Ubuntu LTS 22.04.01+ ship with these Kernel's by default.
        Ensure the chosen OS uses LTS and in-support releases of a 6.6+ Linux kernel.
 
    * - :octicon:`circle`


### PR DESCRIPTION
Recommend kernel 6.6+ to include fix for fstrim performance

PTAL @klauspost @harshavardhana 

https://lore.kernel.org/all/20230903232923.211003-3-david@fromorbit.com/

https://github.com/torvalds/linux/commit/89cfa899608fc28d018bdf9551a6ff508ea6207e