### PR TITLE
fix prom example typo

### DIFF
--- a/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
+++ b/source/operations/monitoring/collect-minio-metrics-using-prometheus.rst
@@ -273,23 +273,23 @@ You can execute queries here to analyze the collected metrics.
       .. code-block:: shell
          :class: copyable
 
-         minio_node_drive_free_bytes{job-"minio-job"}[5m]
-         minio_node_drive_free_inodes{job-"minio-job"}[5m]
+         minio_node_drive_free_bytes{job="minio-job"}[5m]
+         minio_node_drive_free_inodes{job="minio-job"}[5m]
 
-         minio_node_drive_latency_us{job-"minio-job"}[5m]
+         minio_node_drive_latency_us{job="minio-job"}[5m]
 
-         minio_node_drive_offline_total{job-"minio-job"}[5m]
-         minio_node_drive_online_total{job-"minio-job"}[5m]
+         minio_node_drive_offline_total{job="minio-job"}[5m]
+         minio_node_drive_online_total{job="minio-job"}[5m]
 
-         minio_node_drive_total{job-"minio-job"}[5m]
+         minio_node_drive_total{job="minio-job"}[5m]
 
-         minio_node_drive_total_bytes{job-"minio-job"}[5m]
-         minio_node_drive_used_bytes{job-"minio-job"}[5m]
+         minio_node_drive_total_bytes{job="minio-job"}[5m]
+         minio_node_drive_used_bytes{job="minio-job"}[5m]
 
-         minio_node_drive_errors_timeout{job-"minio-job"}[5m]
-         minio_node_drive_errors_availability{job-"minio-job"}[5m]
+         minio_node_drive_errors_timeout{job="minio-job"}[5m]
+         minio_node_drive_errors_availability{job="minio-job"}[5m]
 
-         minio_node_drive_io_waiting{job-"minio-job"}[5m]
+         minio_node_drive_io_waiting{job="minio-job"}[5m]
 
    .. tab-item:: Recommended Metrics
 


### PR DESCRIPTION
The `minio-job` example has `{job-"minio-job"}` where it should be `{job="minio-job"}`

Corresponding changes in other repos/branches:
https://github.com/miniohq/aistor-object-store-docs/pull/70
https://github.com/miniohq/aistor-object-store-docs/pull/71