### PR TITLE
Fixes for missing or bugs in the custom token STS docs

### DIFF
--- a/source/administration/identity-access-management/pluggable-authentication.rst
+++ b/source/administration/identity-access-management/pluggable-authentication.rst
@@ -75,7 +75,7 @@ The login flow for an application is as follows:
       {
          "user": "<string>",
          "maxValiditySeconds": 3600,
-         "claims": "KEY=VALUE,[KEY=VALUE,...]"
+         "claims": {"KEY": "VALUE", ...}
       }
 
    .. list-table::
@@ -90,7 +90,7 @@ The login flow for an application is as follows:
         - The maximum allowed expiry duration for the returned credentials
 
       * - ``claims``
-        - A list of key-value pair claims associated with the requested credentials.
+        - A JSON string of ``"key": "value"`` pair claims associated with the requested credentials.
           MinIO reserves and ignores the ``exp``, ``parent``, and ``sub`` claims objects if present.
 
 4. MinIO returns a response to the STS API request that includes temporary credentials for use with making authenticated requests.

--- a/source/developers/security-token-service/AssumeRoleWithCustomToken.rst
+++ b/source/developers/security-token-service/AssumeRoleWithCustomToken.rst
@@ -67,6 +67,9 @@ This endpoint supports the following query parameters:
 
        See :envvar:`MINIO_IDENTITY_PLUGIN_ROLE_ID` or :mc-conf:`identity_plugin role_id <identity_plugin.role_id>` for more information.
 
+       Note that MinIO automatically prepends ``idmp-`` to a configured ``ROLE_ID`` when generating the RoleArn.
+       Include that string with the ``ROLE_ID`` if required.
+
    * - ``DurationSeconds``
      - integer
      - *Optional*

--- a/source/includes/common-minio-external-auth.rst
+++ b/source/includes/common-minio-external-auth.rst
@@ -422,6 +422,7 @@ Specify a comma-separated list of MinIO :ref:`policies <minio-policy>` to assign
 .. start-minio-identity-management-role-id
 
 Specify a unique ID MinIO uses to generate an ARN for this identity manager.
+MinIO automatically adds an ``idmp-`` prefix to the specified ID when generating the ARN.
 
 If omitted, MinIO automatically generates the ID and prints the full ARN to the server log.
 


### PR DESCRIPTION
- Adds that `idmp-` string is added to `ROLE_ID` when generating an ARN
- Updates claims example in the plugin docs to be JSON instead of basic comma-delimited key-value pairs